### PR TITLE
fix PNG exports with html2canvas, some SVG style fixing, add electron / release process CI / CD, style fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,74 +1,136 @@
-name: Build and Deploy Logomaker to GitHub Pages
+# .github/workflows/release.yml
+
+name: Bump Version, Build & Release Electron App
 
 on:
   push:
-    branches: [ "master" ] # CHANGE TO "main" if that's your default branch
-  workflow_dispatch: # Allows manual triggering
+    branches:
+      - master # Or 'main'
+  workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, cancel older runs
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  contents: write # NEEDED for standard-version to commit/tag & electron-builder to release
+  # pages: write    # Add back if deploying pages in same workflow
+  # id-token: write # Add back if deploying pages in same workflow
 
 jobs:
-  # Build job
-  build:
-    runs-on: ubuntu-latest
+  release:
+    # Prevent multiple concurrent release builds for the same ref
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    runs-on: ubuntu-latest # Run versioning/tagging/committing on one OS (Linux is fine)
+
     steps:
-      - name: Checkout repository
+      # 1. Checkout code (fetch all history for standard-version)
+      - name: Check out Git repository
         uses: actions/checkout@v4
-        # Ensure LFS files are fetched during checkout
         with:
+          fetch-depth: 0 # Fetch all history for standard-version to analyze commits
           lfs: true
+          # Use a token with write access if needed for pushing commit/tag
+          # token: ${{ secrets.YOUR_PAT_OR_APP_TOKEN }} # OPTIONAL: Use if default GITHUB_TOKEN lacks push rights
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          # Specify the Node.js version used by your scripts
-          # Check your local version with `node -v`
-          node-version: '20' # Or '18', '22', etc.
-          cache: 'npm' # Optional: cache npm dependencies
-
-      # Git LFS is needed explicitly in some runners/versions
+      # 2. Install Git LFS
       - name: Install Git LFS
         run: |
           git lfs install
           git lfs pull
-        # Add error handling if needed
-        # continue-on-error: true
 
-      # Optional but recommended: Install dependencies if build relies on them (e.g., portapack for bundling check)
-      - name: Install Dependencies
-        run: npm ci # 'ci' is generally preferred in workflows over 'install'
-
-      - name: Build Logomaker Optimized Version
-        run: node scripts/build.js # This runs all necessary steps
-
-      - name: Setup GitHub Pages
-        uses: actions/configure-pages@v4
-        # No base path needed here if deploying to root of GH Pages site for repo
-
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      # 3. Setup Node.js
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          # Upload ONLY the optimized build output directory
-          path: './dist/github-pages'
+          node-version: 20
+          cache: 'npm'
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build # Wait for the build job to complete
+      # 4. Install All Dependencies (including devDeps for standard-version)
+      - name: Install Dependencies
+        run: npm ci
+
+      # --- Configure Git ---
+      # Needed for standard-version to commit the version bump
+      - name: Configure Git User
+        run: |
+          git config user.name "GitHub Action Bot"
+          git config user.email "action-bot@github.com" # Or a no-reply email
+
+      # --- Version Bump & Changelog ---
+      # Run standard-version: bumps version, updates CHANGELOG, commits, tags
+      # It will automatically detect the next version based on conventional commits.
+      # It only runs if there are feat/fix/BREAKING commits since the last tag.
+      - name: Bump version and create changelog
+        run: npx standard-version --commit-all --release-as patch # Use patch | minor | major or let it detect based on commits
+        # OR simply: npx standard-version # To let it auto-detect bump level
+        # Add --skip.changelog=true if you don't want CHANGELOG.md updated
+        env:
+           # Use default token which *should* have push rights for commits/tags
+           # If branch protection prevents this, use a PAT/App token via secrets
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Push Changes & Tag ---
+      # Push the commit created by standard-version and the new tag
+      - name: Push changes and tag
+        run: git push --follow-tags origin ${{ github.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Use token for push rights
+
+      # --- Build & Release Electron App using electron-builder ---
+      # Use a separate job for multi-platform builds, triggered after versioning
+      # OR build directly here if only targeting one platform or using cross-compilation setup
+
+  build_and_publish:
+    needs: release # Run after versioning/tagging/pushing is done
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest] # Build on all platforms
+    runs-on: ${{ matrix.os }}
+
+    permissions: # Permissions might be needed again for checkout/setup? Usually inherited or default is ok.
+        contents: read # Read is usually enough for build job
+
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        # This action automatically uses the artifact uploaded by upload-pages-artifact
+      # Checkout the specific commit/tag created by standard-version (or just the latest)
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          # No need to fetch full depth here usually
+
+      - name: Install Git LFS
+        run: |
+          git lfs install
+          git lfs pull
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      # Build the portable web content needed for Electron
+      - name: Build Portable Web App Content
+        run: npm run build:portable
+
+      # Build and Publish the Electron App for the current matrix OS
+      - name: Build and Publish Electron Application
+        run: npm run release:electron # This runs 'electron-builder --publish always'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed by electron-builder to upload assets
+
+          # Important Note: By default, electron-builder running on multiple OS in parallel
+          # might try to create the *same* GitHub release tag/name multiple times, causing errors.
+          # Solutions:
+          # 1) (Recommended) Use a tool/action like `ncipollo/release-action` AFTER all builds
+          #    to create ONE release and upload all artifacts to it.
+          # 2) Configure electron-builder cleverly (e.g., use draft releases and only publish the final one).
+          # 3) Build on ONE OS and rely on electron-builder's cross-compilation (less reliable).
+          #
+          # For simplicity NOW, this workflow lets each OS job try to publish. The FIRST one
+          # will create the release, subsequent ones might fail to create the release but should
+          # still succeed in uploading their platform-specific asset to the *existing* release
+          # created by the first job. Check electron-builder logs if issues arise.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+# .github/workflows/release.yml (Manual Trigger Version)
+
+name: Build & Release Electron App (Manual Trigger)
+
+on:
+  workflow_dispatch: # ONLY allow manual trigger from Actions tab
+
+permissions:
+  contents: write # Still needed for electron-builder to create release/tag
+
+jobs:
+  build_and_publish: # Combined job is fine for manual trigger
+    # Prevent multiple concurrent release builds triggered manually close together
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest] # Build on all platforms
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Checkout code at the specific ref the workflow was triggered on (usually master/main)
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install Git LFS
+        run: |
+          git lfs install
+          git lfs pull
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      # Build the portable web content needed for Electron
+      # Reads version from package.json checked out at workflow start
+      - name: Build Portable Web App Content
+        run: npm run build:portable
+
+      # Build and Publish the Electron App for the current matrix OS
+      - name: Build and Publish Electron Application
+        run: npm run release:electron # This runs 'electron-builder --publish always'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # electron-builder will:
+          # 1. Read the version from the checked-out package.json.
+          # 2. Build the package for matrix.os.
+          # 3. Create a Git tag AND a Draft GitHub Release for that version.
+          # 4. Upload the package as an asset to the Draft Release.

--- a/css/components.css
+++ b/css/components.css
@@ -989,15 +989,6 @@ textarea[readonly]:focus {
 .contact-button svg { margin-right: var(--space-xs); width: 1em; height: 1em; }
 .contact-button:hover { background-color: var(--input-bg); color: var(--accent-color); border-color: var(--accent-color); transform: translateY(-1px); }
 
-.logo-text.text-align-left {
-  text-align: left !important;
-}
-.logo-text.text-align-center {
-  text-align: center !important;
-}
-.logo-text.text-align-right {
-  text-align: right !important;
-}
 
 /* 3. High contrast mode improvements for border visibility */
 @media (prefers-contrast: high) {
@@ -1016,9 +1007,9 @@ textarea[readonly]:focus {
 }
 
 /* 4. Add transition to text-align to make changes smoother */
-.logo-text {
-  transition: text-align 0.2s ease-out;
-}
+/* .logo-text { */
+  /* transition: text-align 0.2s ease-out; */
+/* } */
 
 /* 5. Improved focus indicators for better accessibility */
 select:focus-visible,

--- a/css/effects.css
+++ b/css/effects.css
@@ -100,9 +100,9 @@
 /* --- 3. Text Alignment Classes --- */
 /* Applied by SettingsManager._applyTextAlign */
 /* REMOVED !important - Ensure these don't conflict with components.css */
-.text-align-left { text-align: left; }
+/* .text-align-left { text-align: left; }
 .text-align-center { text-align: center; }
-.text-align-right { text-align: right; }
+.text-align-right { text-align: right; } */
 /* .text-align-justify { text-align: justify; } */ /* Justify might look odd for logos */
 
 
@@ -538,6 +538,16 @@ background-size: 200% auto;
 /* Or handle animation combination logic in JS */
 }
 
+/* Ensure text alignment */
+.logo-text.text-align-left {
+  text-align: left !important;
+}
+.logo-text.text-align-center {
+  text-align: center !important;
+}
+.logo-text.text-align-right {
+  text-align: right !important;
+}
 
 /* ============================================================ */
 /* == 8. Background Patterns & Effects (using bg-*)         == */

--- a/css/layout.css
+++ b/css/layout.css
@@ -202,17 +202,6 @@ header {
 
 /* Actual Logo Text Element */
 .logo-text {
-  /* --- FIX: Remove default styles that JS should control --- */
-  /* font-family: var(--font-family-logo); */ /* Let JS set font-family */
-  /* font-weight: var(--font-weight-bold); */ /* Let JS set font-weight */
-  /* background-image: var(--primary-gradient); */ /* Let JS set background-image */
-  /* -webkit-background-clip: text; */ /* Let JS handle this */
-  /* background-clip: text; */ /* Let JS handle this */
-  /* color: transparent; */ /* Let JS handle color/fill */
-  /* -webkit-text-fill-color: transparent; */ /* Let JS handle color/fill */
-  /* border: var(--dynamic-border-width, 2px) solid transparent; */ /* Let .logo-container handle border */
-  /* box-shadow: none; */
-
   /* --- Keep Essential Layout/Text Styles --- */
   font-size: clamp(48px, 12vw, 150px);
   letter-spacing: 0.03em; /* JS controls this */

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,77 @@
+# Electron App Release Process (Automated)
+
+This document outlines the automated process used to build, version, and release the Logomaker Electron application to GitHub Releases.
+
+## Overview
+
+The goal is to automatically create new releases with platform-specific installers/packages (`.exe`, `.dmg`, `.AppImage`) whenever significant changes (`feat`, `fix`, `BREAKING CHANGE`) are pushed to the main branch (`master` or `main`). This process relies on **Conventional Commits** for intelligent version bumping and **GitHub Actions** for automation.
+
+## Prerequisites & Setup
+
+1.  **Conventional Commits:** All developers should follow the [Conventional Commits specification](https://www.conventionalcommits.org/) for their commit messages. This format allows tools to automatically determine the semantic version bump (patch, minor, major) and generate changelogs. Examples:
+    * `feat: add border radius control` (results in a MINOR version bump)
+    * `fix: correct PNG export transparency issue` (results in a PATCH version bump)
+    * `perf: optimize font loading` (results in a PATCH version bump)
+    * `refactor!: change core rendering engine` (The `!` or `BREAKING CHANGE:` footer indicates a MAJOR version bump)
+    * `chore: update dependencies` (Does NOT trigger a release)
+    * `docs: update README` (Does NOT trigger a release)
+2.  **Install Dev Dependencies:** Ensure all development dependencies are installed:
+    ```bash
+    npm install
+    ```
+    This includes `electron`, `electron-builder`, `electron-updater`, `standard-version`, `commitizen`, `cz-conventional-changelog`.
+3.  **Commitizen (Optional but Recommended):** To make writing conventional commits easier, you can use Commitizen:
+    * Run `npm run commit` (or `git cz`) instead of `git commit`.
+    * It will prompt you through creating a correctly formatted commit message.
+    * No extra global install is needed if configured in `package.json` (which we did).
+
+## The `standard-version` Tool
+
+We use the `standard-version` npm package to handle the versioning and changelog workflow. When run (typically by the GitHub Action), it performs these steps based on commits since the last Git tag:
+
+1.  **Version Bump:** Determines the next version (e.g., 3.1.0 -> 3.2.0 if a `feat:` commit is found) based on Conventional Commits.
+2.  **Update Files:** Modifies `package.json` and `package-lock.json` with the new version number.
+3.  **Update Changelog:** Generates or updates `CHANGELOG.md` based on the new commits.
+4.  **Commit:** Creates a new Git commit containing these file changes (e.g., `chore(release): 3.2.0`).
+5.  **Tag:** Creates a new Git tag matching the version (e.g., `v3.2.0`).
+
+## GitHub Actions Workflow (`.github/workflows/release.yml`)
+
+This workflow automates the entire process when code is pushed to the main branch:
+
+1.  **Trigger:** Starts on push to `master`/`main` or manual trigger.
+2.  **`release` Job (Runs on Ubuntu):**
+    * Checks out the full Git history.
+    * Sets up Node.js and installs dependencies (`npm ci`).
+    * Configures Git credentials for committing.
+    * Runs `npx standard-version`: Performs the version bump, changelog update, commit, and tagging steps described above. **Important:** If no `feat`, `fix`, or `BREAKING CHANGE` commits are found, this step does nothing, and the workflow likely stops here.
+    * Pushes the new commit and tag back to the GitHub repository using the default `GITHUB_TOKEN`.
+3.  **`build_and_publish` Job (Runs on Windows, macOS, Linux in parallel):**
+    * Runs only *after* the `release` job succeeds (meaning a version bump occurred).
+    * Checks out the code again (now including the version bump commit).
+    * Sets up Node.js and installs dependencies (`npm ci`).
+    * Runs `npm run build:portable` to generate the necessary web content for Electron (`dist/portable/`).
+    * Runs `npm run release:electron` which executes `electron-builder --publish always`.
+        * `electron-builder` reads the **newly bumped version** from `package.json`.
+        * It packages the app for the specific OS the job is running on (Win, Mac, Linux).
+        * It uses the `GH_TOKEN` environment variable (`secrets.GITHUB_TOKEN`) to authenticate with GitHub.
+        * It finds the Git tag created by `standard-version`.
+        * It creates a **Draft GitHub Release** associated with that tag.
+        * It uploads the packaged application (`.exe`, `.dmg`, `.AppImage`) as an asset to the draft release.
+
+## Outcome & Final Steps
+
+* After the workflow runs successfully following relevant commits, a new commit and tag appear in your repository history.
+* A **Draft Release** is created on your repository's "Releases" page, containing the built application packages for Windows, macOS, and Linux.
+* **Manual Step:** You need to navigate to the Draft Release, review the automatically generated changelog notes (if desired), add any extra information, and manually click **"Publish release"**.
+
+## Auto-Updates
+
+Once a release is **published** on GitHub (not just drafted), the `electron-updater` module configured in `electron.js` can detect it. When users launch their installed application:
+
+1.  `autoUpdater.checkForUpdatesAndNotify()` runs.
+2.  It checks the GitHub Releases feed configured in `package.json` (`build.publish` section).
+3.  If a newer compatible version is found, it downloads the update package silently in the background.
+4.  Once downloaded, the update is automatically applied the next time the user quits and restarts the application.
+
+This provides a seamless update experience for your users.

--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,284 @@
+// electron.js - Electron Main Process (v1.4 - Disable GPU, Add 'ready' listener)
+const { app, BrowserWindow, Menu, shell, dialog } = require('electron'); // Keep dialog for potential errors
+const path = require('path');
+const fs = require('fs'); // Keep fs for file checks
+
+// ** Try disabling GPU acceleration early **
+// This MUST be called before the 'ready' event
+try {
+    app.disableHardwareAcceleration();
+    console.log('[DEBUG] Hardware acceleration DISABLED.'); // Use console for earliest possible log
+} catch (e) {
+    // This might happen if called too early in some edge cases, but usually safe here.
+    console.error('[DEBUG] Error attempting to disable hardware acceleration:', e);
+}
+// ** End Disable GPU **
+
+// Require other modules AFTER potential app modifications
+const { autoUpdater } = require('electron-updater');
+const logger = require('electron-log'); // Assumes `npm install --save-dev electron-log` was run
+
+// --- Configuration ---
+const CONFIG_FILE_NAME = 'logomaker-config.json';
+let configFilePath = null; // Will be set after 'ready'
+
+// --- Configure Logging ---
+try {
+    // Basic setup, can be configured further via package.json or log.transports
+    logger.transports.file.level = 'info';
+    logger.transports.console.level = 'info'; // Log info to console as well
+    autoUpdater.logger = logger;
+    autoUpdater.logger.transports.file.level = 'info';
+    logger.info('Logging configured (initial). Log file path depends on OS.');
+} catch(logError) {
+    console.error("Failed to configure electron-log:", logError);
+    logger.info = console.info; logger.warn = console.warn; logger.error = console.error;
+}
+
+// --- Global Variables ---
+let mainWindow;
+const isDev = !app.isPackaged; // Check if the app is packaged or running from source
+let skippedVersion = null; // Will be loaded after 'ready'
+logger.info(`Running in ${isDev ? 'development' : 'production'} mode.`);
+
+// --- Config Helper Functions --- (Keep as before)
+function readConfig() {
+    if (!configFilePath) { // Ensure path is set
+        logger.error("Config file path not set before readConfig called.");
+        return { skippedVersion: null };
+    }
+    try {
+        if (fs.existsSync(configFilePath)) {
+            const configData = fs.readFileSync(configFilePath, 'utf-8');
+            const config = JSON.parse(configData);
+            skippedVersion = config.skippedVersion || null;
+            logger.info(`Loaded config: Skipped version = ${skippedVersion}`);
+            return config;
+        }
+         logger.info('Config file not found, using defaults.');
+    } catch (error) {
+        logger.error('Error reading config file:', error);
+        skippedVersion = null;
+    }
+    return { skippedVersion: null };
+}
+
+function writeConfig(configData) {
+     if (!configFilePath) { // Ensure path is set
+        logger.error("Config file path not set before writeConfig called.");
+        return;
+    }
+    try {
+        // Ensure userData directory exists
+        const userDataPath = app.getPath('userData');
+        if (!fs.existsSync(userDataPath)) {
+            fs.mkdirSync(userDataPath, { recursive: true });
+        }
+        fs.writeFileSync(configFilePath, JSON.stringify(configData, null, 2), 'utf-8');
+        skippedVersion = configData.skippedVersion || null;
+        logger.info(`Wrote config: ${JSON.stringify(configData)}`);
+    } catch (error) {
+        logger.error('Error writing config file:', error);
+    }
+}
+
+// --- Main Window Creation ---
+function createWindow() {
+    logger.info('[createWindow] Called.'); // Changed log prefix
+    mainWindow = new BrowserWindow({
+        width: 1200,
+        height: 800,
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.js'),
+            contextIsolation: true,
+            nodeIntegration: false,
+            webSecurity: false, // Keep for file://
+        },
+        icon: path.join(__dirname, 'assets', 'icon.png') // Ensure this path is correct
+    });
+    logger.info('[createWindow] BrowserWindow created.');
+
+    const startPath = path.join(__dirname, 'dist', 'portable', 'index.html');
+    logger.info(`[createWindow] Attempting to load: file://${startPath}`);
+
+    if (!fs.existsSync(startPath)) {
+        logger.error(`[createWindow] ERROR: startPath does not exist! Path: ${startPath}`);
+        dialog.showErrorBox('Error', `Cannot load the application.\nRequired file not found:\n${startPath}\n\nPlease run 'npm run build:portable' first.`);
+        app.quit();
+        return;
+    }
+
+    mainWindow.loadFile(startPath)
+        .then(() => logger.info(`[createWindow] Window loaded successfully: ${startPath}`))
+        .catch(err => logger.error(`[createWindow] FAILED to load window URL: ${err}`));
+
+    if (isDev) {
+        logger.info('[createWindow] Opening DevTools in dev mode.');
+        mainWindow.webContents.openDevTools();
+    }
+
+    // --- Check for Updates on Startup ---
+    mainWindow.webContents.once('did-finish-load', () => {
+        logger.info('[createWindow] Window finished loading.');
+        if (!isDev) {
+           logger.info('[createWindow] Initiating background update check...');
+           try {
+               autoUpdater.checkForUpdates(); // Just check
+           } catch (error) { logger.error('[createWindow] Error initiating update check:', error); }
+        } else { logger.info(`[createWindow] Skipping update check in development mode.`); }
+    });
+
+    mainWindow.on('closed', () => {
+        logger.info('[createWindow] Main window closed.');
+        mainWindow = null;
+    });
+}
+
+// --- Application Lifecycle ---
+
+// *** Using explicit 'ready' listener for primary setup ***
+app.on('ready', () => {
+    logger.info('>>> App explicit "ready" event fired <<<');
+    // Now it's safe to get paths and read config
+    try {
+        const userDataPath = app.getPath('userData');
+        configFilePath = path.join(userDataPath, CONFIG_FILE_NAME); // Set the global path now
+        logger.info(`User data path: ${userDataPath}`);
+        logger.info(`Config file path: ${configFilePath}`);
+        readConfig(); // Load config now
+    } catch(e) {
+        logger.error("Error setting paths or reading config after ready:", e);
+    }
+
+    // Proceed with window creation etc.
+    createWindow();
+    setupMenu();
+});
+
+// Keep whenReady() as well, good practice, but avoid duplicate calls
+app.whenReady().then(() => {
+    logger.info('>>> App whenReady() promise resolved <<<');
+    // createWindow() and setupMenu() are called by the 'ready' listener now.
+    // We just log that the promise resolved.
+}).catch(err => {
+    logger.error('Error during app.whenReady() promise:', err);
+});
+
+app.on('activate', () => { // Keep activate listener for macOS
+    logger.info('App activate event.');
+    if (BrowserWindow.getAllWindows().length === 0) {
+        createWindow();
+    }
+});
+
+app.on('window-all-closed', () => {
+    logger.info('All windows closed.');
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});
+
+
+// --- Auto Updater Event Handling ---
+autoUpdater.on('checking-for-update', () => { logger.info('Checking for update...'); });
+// REMOVED: update-not-available listener here (handled in manual check context)
+autoUpdater.on('error', (err) => { logger.error('Error in auto-updater: ' + (err.message || err)); });
+autoUpdater.on('download-progress', (progressObj) => { /* ... */ });
+
+// *** NEW: Handle update availability ***
+autoUpdater.on('update-available', (info) => {
+    logger.info(`Update available: ${info.version}. Currently skipping: ${skippedVersion}`);
+    // Check against the stored skipped version
+    if (skippedVersion && skippedVersion === info.version) {
+        logger.info(`Update ${info.version} is available, but user has skipped it. Ignoring.`);
+        return; // Do nothing, don't download
+    }
+    // If not skipped, proceed to download
+    logger.info(`Update ${info.version} not skipped. Starting download...`);
+    dialog.showMessageBox({ title: 'Update Found', message: `Downloading update ${info.version}...`, buttons: [] }); // Inform user
+    autoUpdater.downloadUpdate();
+});
+
+// *** MODIFIED 'update-downloaded' HANDLER ***
+autoUpdater.on('update-downloaded', (info) => {
+    logger.info('Update downloaded.', info);
+    dialog.showMessageBox({
+        type: 'info',
+        title: 'Update Ready',
+        message: `Version ${info.version} has been downloaded. Restart now to install?`,
+        buttons: ['Restart Now', 'Later', 'Skip This Version'], // <<< Added Skip button
+        defaultId: 0,
+        cancelId: 1 // "Later" is the cancel action
+    }).then(({ response }) => {
+        if (response === 0) { // Restart Now
+            logger.info('User chose to restart. Quitting and installing update...');
+            autoUpdater.quitAndInstall();
+        } else if (response === 2) { // <<< Handle Skip This Version
+            logger.info(`User chose to skip version ${info.version}.`);
+            writeConfig({ skippedVersion: info.version }); // Store the skipped version
+        } else { // Later or closed dialog
+            logger.info('User chose to install update later.');
+        }
+    }).catch(err => { logger.error('Error showing update downloaded dialog:', err); });
+});
+// *** END MODIFIED HANDLER ***
+
+
+// --- Application Menu ---
+function setupMenu() {
+    const template = [
+        // ... (Keep File, Edit, View, Window menus as before) ...
+        { // Modify Help menu
+            role: 'help',
+            submenu: [
+                 {
+                     label: 'Check for Updates...', // <<< Add manual check item
+                     click: () => { manualCheckForUpdates(); } // Call the function
+                 },
+                 { type: 'separator' },
+                 { label: 'Learn More (GitHub)', click: async () => { await shell.openExternal('https://github.com/manicinc/logomaker') } }
+             ]
+        }
+    ];
+     // Add App menu for macOS
+    if (process.platform === 'darwin') {
+        template.unshift({
+            label: app.name,
+            submenu: [
+              { role: 'about' },
+              { type: 'separator' },
+              { label: 'Check for Updates...', click: () => { manualCheckForUpdates(); } }, // Add here too for macOS convention
+              { type: 'separator' },
+              { role: 'services' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideOthers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' }
+            ]
+        });
+    }
+
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+}
+
+// --- Security Considerations --- (Keep these)
+app.on('web-contents-created', (event, contents) => {
+    contents.on('will-navigate', (event, navigationUrl) => {
+      const parsedUrl = new URL(navigationUrl); if (!parsedUrl.protocol.startsWith('file:')) { logger.warn(`Blocked navigation to non-file URL: ${navigationUrl}`); event.preventDefault(); }
+    });
+    contents.setWindowOpenHandler(({ url }) => { logger.warn(`Blocked new window for URL: ${url}`); return { action: 'deny' }; });
+});
+
+// Catch unhandled exceptions
+process.on('uncaughtException', (error, origin) => {
+    logger.error('!!!!!!!!!!! UNCAUGHT EXCEPTION !!!!!!!!!!!');
+    logger.error('Origin:', origin);
+    logger.error(error);
+    logger.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+    // Attempt graceful exit
+    try { const { dialog } = require('electron'); dialog.showErrorBox('Unhandled Error', `A critical error occurred:\n\n${error.message}\n\nThe application will now close.`); } catch(e){}
+    app.quit();
+});

--- a/fonts.json
+++ b/fonts.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
-    "generationTimestamp": "2025-04-05T22:09:54.186Z",
+    "generationTimestamp": "2025-04-06T01:45:11.917Z",
     "familyCount": 407,
     "variantCount": 1738,
     "totalOriginalSizeMB": "40.67",
-    "base64Included": false,
+    "base64Included": true,
     "formatSummary": {
       "woff2": 407
     },
@@ -12,7 +12,8 @@
       "300": 151,
       "400": 1107,
       "700": 480
-    }
+    },
+    "totalBase64SizeMB": "54.27"
   },
   "fonts": [
     {
@@ -30,8 +31,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18912,
-          "url": "fonts/Aachen Std/AachenStd-Bold.woff2"
+          "fileSize": 18912
         }
       ]
     },
@@ -50,48 +50,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 104364,
-          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Italic.woff2"
+          "fileSize": 104364
         },
         {
           "name": "ACaslonPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 104220,
-          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Regular.woff2"
+          "fileSize": 104220
         },
         {
           "name": "ACaslonPro-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 105948,
-          "url": "fonts/Adobe Caslon Pro/ACaslonPro-BoldItalic.woff2"
+          "fileSize": 105948
         },
         {
           "name": "ACaslonPro-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 106864,
-          "url": "fonts/Adobe Caslon Pro/ACaslonPro-SemiboldItalic.woff2"
+          "fileSize": 106864
         },
         {
           "name": "ACaslonPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 95560,
-          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Bold.woff2"
+          "fileSize": 95560
         },
         {
           "name": "ACaslonPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 106852,
-          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Semibold.woff2"
+          "fileSize": 106852
         }
       ]
     },
@@ -110,48 +104,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 52140,
-          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Italic.woff2"
+          "fileSize": 52140
         },
         {
           "name": "AGaramondPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67016,
-          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Regular.woff2"
+          "fileSize": 67016
         },
         {
           "name": "AGaramondPro-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 44068,
-          "url": "fonts/Adobe Garamond Pro/AGaramondPro-BoldItalic.woff2"
+          "fileSize": 44068
         },
         {
           "name": "AGaramondPro-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 45504,
-          "url": "fonts/Adobe Garamond Pro/AGaramondPro-SemiboldItalic.woff2"
+          "fileSize": 45504
         },
         {
           "name": "AGaramondPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41964,
-          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Bold.woff2"
+          "fileSize": 41964
         },
         {
           "name": "AGaramondPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 51512,
-          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Semibold.woff2"
+          "fileSize": 51512
         }
       ]
     },
@@ -170,8 +158,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39776,
-          "url": "fonts/Adobe Wood Type Ornaments Std/WoodtypeOrnamentsStd.woff2"
+          "fileSize": 39776
         }
       ]
     },
@@ -190,24 +177,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20748,
-          "url": "fonts/Albertus MT Std/AlbertusMTStd-Light.woff2"
+          "fileSize": 20748
         },
         {
           "name": "AlbertusMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19692,
-          "url": "fonts/Albertus MT Std/AlbertusMTStd-Italic.woff2"
+          "fileSize": 19692
         },
         {
           "name": "AlbertusMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19596,
-          "url": "fonts/Albertus MT Std/AlbertusMTStd.woff2"
+          "fileSize": 19596
         }
       ]
     },
@@ -226,16 +210,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25160,
-          "url": "fonts/Aldus LT Std/AldusLTStd-Italic.woff2"
+          "fileSize": 25160
         },
         {
           "name": "AldusLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460,
-          "url": "fonts/Aldus LT Std/AldusLTStd-Roman.woff2"
+          "fileSize": 30460
         }
       ]
     },
@@ -254,8 +236,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24860,
-          "url": "fonts/Alexa Std/AlexaStd.woff2"
+          "fileSize": 24860
         }
       ]
     },
@@ -274,32 +255,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21364,
-          "url": "fonts/Americana Std/AmericanaStd-Italic.woff2"
+          "fileSize": 21364
         },
         {
           "name": "AmericanaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21452,
-          "url": "fonts/Americana Std/AmericanaStd.woff2"
+          "fileSize": 21452
         },
         {
           "name": "AmericanaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20684,
-          "url": "fonts/Americana Std/AmericanaStd-Bold.woff2"
+          "fileSize": 20684
         },
         {
           "name": "AmericanaStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18992,
-          "url": "fonts/Americana Std/AmericanaStd-ExtraBold.woff2"
+          "fileSize": 18992
         }
       ]
     },
@@ -318,8 +295,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36612,
-          "url": "fonts/Andreas Std/AndreasStd.woff2"
+          "fileSize": 36612
         }
       ]
     },
@@ -338,72 +314,63 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14864,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Light.woff2"
+          "fileSize": 14864
         },
         {
           "name": "AntiqueOliveStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15380,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Italic.woff2"
+          "fileSize": 15380
         },
         {
           "name": "AntiqueOliveStd-NordItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16312,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-NordItalic.woff2"
+          "fileSize": 16312
         },
         {
           "name": "AntiqueOliveStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15528,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Black.woff2"
+          "fileSize": 15528
         },
         {
           "name": "AntiqueOliveStd-Compact",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15552,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Compact.woff2"
+          "fileSize": 15552
         },
         {
           "name": "AntiqueOliveStd-Nord",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15496,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Nord.woff2"
+          "fileSize": 15496
         },
         {
           "name": "AntiqueOliveStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15156,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Roman.woff2"
+          "fileSize": 15156
         },
         {
           "name": "AntiqueOliveStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15360,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Bold.woff2"
+          "fileSize": 15360
         },
         {
           "name": "AntiqueOliveStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15008,
-          "url": "fonts/Antique Olive Std/AntiqueOliveStd-BoldCond.woff2"
+          "fileSize": 15008
         }
       ]
     },
@@ -422,24 +389,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32504,
-          "url": "fonts/Apollo MT Std/ApolloMTStd-Italic.woff2"
+          "fileSize": 32504
         },
         {
           "name": "ApolloMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 38800,
-          "url": "fonts/Apollo MT Std/ApolloMTStd.woff2"
+          "fileSize": 38800
         },
         {
           "name": "ApolloMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31152,
-          "url": "fonts/Apollo MT Std/ApolloMTStd-SemiBold.woff2"
+          "fileSize": 31152
         }
       ]
     },
@@ -458,8 +422,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13852,
-          "url": "fonts/Arcadia LT Std/ArcadiaLTStd.woff2"
+          "fileSize": 13852
         }
       ]
     },
@@ -478,8 +441,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 127792,
-          "url": "fonts/Arcana GMM Std/ArcanaGMMStd-Manuscript.woff2"
+          "fileSize": 127792
         }
       ]
     },
@@ -498,8 +460,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12852,
-          "url": "fonts/Ariadne LT Std/AriadneLTStd-Roman.woff2"
+          "fileSize": 12852
         }
       ]
     },
@@ -518,8 +479,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26548,
-          "url": "fonts/Arnold Boecklin Std/ArnoldBoecklinStd.woff2"
+          "fileSize": 26548
         }
       ]
     },
@@ -538,8 +498,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27668,
-          "url": "fonts/Ashley Script MT Std/AshleyScriptMTStd.woff2"
+          "fileSize": 27668
         }
       ]
     },
@@ -558,48 +517,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24124,
-          "url": "fonts/Auriol LT Std/AuriolLTStd-BlackItalic.woff2"
+          "fileSize": 24124
         },
         {
           "name": "AuriolLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23944,
-          "url": "fonts/Auriol LT Std/AuriolLTStd-Italic.woff2"
+          "fileSize": 23944
         },
         {
           "name": "AuriolLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21652,
-          "url": "fonts/Auriol LT Std/AuriolLTStd.woff2"
+          "fileSize": 21652
         },
         {
           "name": "AuriolLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22492,
-          "url": "fonts/Auriol LT Std/AuriolLTStd-Black.woff2"
+          "fileSize": 22492
         },
         {
           "name": "AuriolLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24136,
-          "url": "fonts/Auriol LT Std/AuriolLTStd-BoldItalic.woff2"
+          "fileSize": 24136
         },
         {
           "name": "AuriolLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22212,
-          "url": "fonts/Auriol LT Std/AuriolLTStd-Bold.woff2"
+          "fileSize": 22212
         }
       ]
     },
@@ -618,96 +571,84 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15004,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Light.woff2"
+          "fileSize": 15004
         },
         {
           "name": "AvenirLTStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16484,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-LightOblique.woff2"
+          "fileSize": 16484
         },
         {
           "name": "AvenirLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15392,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Black.woff2"
+          "fileSize": 15392
         },
         {
           "name": "AvenirLTStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15240,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Book.woff2"
+          "fileSize": 15240
         },
         {
           "name": "AvenirLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15432,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Heavy.woff2"
+          "fileSize": 15432
         },
         {
           "name": "AvenirLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15052,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Medium.woff2"
+          "fileSize": 15052
         },
         {
           "name": "AvenirLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15040,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Roman.woff2"
+          "fileSize": 15040
         },
         {
           "name": "AvenirLTStd-BlackOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16668,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-BlackOblique.woff2"
+          "fileSize": 16668
         },
         {
           "name": "AvenirLTStd-BookOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16512,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-BookOblique.woff2"
+          "fileSize": 16512
         },
         {
           "name": "AvenirLTStd-HeavyOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16452,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-HeavyOblique.woff2"
+          "fileSize": 16452
         },
         {
           "name": "AvenirLTStd-MediumOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16700,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-MediumOblique.woff2"
+          "fileSize": 16700
         },
         {
           "name": "AvenirLTStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16428,
-          "url": "fonts/Avenir LT Std/AvenirLTStd-Oblique.woff2"
+          "fileSize": 16428
         }
       ]
     },
@@ -726,8 +667,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24956,
-          "url": "fonts/Balzano Std/BalzanoStd.woff2"
+          "fileSize": 24956
         }
       ]
     },
@@ -746,8 +686,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13368,
-          "url": "fonts/Banco Std/BancoStd.woff2"
+          "fileSize": 13368
         }
       ]
     },
@@ -766,8 +705,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 61644,
-          "url": "fonts/Banshee Std/BansheeStd.woff2"
+          "fileSize": 61644
         }
       ]
     },
@@ -786,24 +724,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28784,
-          "url": "fonts/Baskerville Cyrillic LT Std/BaskervilleCyrLTStd-Incline.woff2"
+          "fileSize": 28784
         },
         {
           "name": "BaskervilleCyrLTStd-Upright",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27448,
-          "url": "fonts/Baskerville Cyrillic LT Std/BaskervilleCyrLTStd-Upright.woff2"
+          "fileSize": 27448
         },
         {
           "name": "BaskervilleCyrLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25496,
-          "url": "fonts/Baskerville Cyrillic LT Std/BaskervilleCyrLTStd-Bold.woff2"
+          "fileSize": 25496
         }
       ]
     },
@@ -822,64 +757,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20308,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BlackItalic.woff2"
+          "fileSize": 20308
         },
         {
           "name": "BauerBodoniStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21952,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Italic.woff2"
+          "fileSize": 21952
         },
         {
           "name": "BauerBodoniStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18696,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Black.woff2"
+          "fileSize": 18696
         },
         {
           "name": "BauerBodoniStd-BlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18076,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BlackCond.woff2"
+          "fileSize": 18076
         },
         {
           "name": "BauerBodoniStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25604,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Roman.woff2"
+          "fileSize": 25604
         },
         {
           "name": "BauerBodoniStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21960,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BoldItalic.woff2"
+          "fileSize": 21960
         },
         {
           "name": "BauerBodoniStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20880,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Bold.woff2"
+          "fileSize": 20880
         },
         {
           "name": "BauerBodoniStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17792,
-          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BoldCond.woff2"
+          "fileSize": 17792
         }
       ]
     },
@@ -898,40 +825,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15088,
-          "url": "fonts/Bauhaus Std/BauhausStd-Light.woff2"
+          "fileSize": 15088
         },
         {
           "name": "BauhausStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15236,
-          "url": "fonts/Bauhaus Std/BauhausStd-Demi.woff2"
+          "fileSize": 15236
         },
         {
           "name": "BauhausStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15320,
-          "url": "fonts/Bauhaus Std/BauhausStd-Heavy.woff2"
+          "fileSize": 15320
         },
         {
           "name": "BauhausStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14980,
-          "url": "fonts/Bauhaus Std/BauhausStd-Medium.woff2"
+          "fileSize": 14980
         },
         {
           "name": "BauhausStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15396,
-          "url": "fonts/Bauhaus Std/BauhausStd-Bold.woff2"
+          "fileSize": 15396
         }
       ]
     },
@@ -950,32 +872,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17016,
-          "url": "fonts/Bell Centennial Std/BellCentennialStd-Address.woff2"
+          "fileSize": 17016
         },
         {
           "name": "BellCentennialStd-BdListing",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27592,
-          "url": "fonts/Bell Centennial Std/BellCentennialStd-BdListing.woff2"
+          "fileSize": 27592
         },
         {
           "name": "BellCentennialStd-NameNum",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18528,
-          "url": "fonts/Bell Centennial Std/BellCentennialStd-NameNum.woff2"
+          "fileSize": 18528
         },
         {
           "name": "BellCentennialStd-SubCapt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17404,
-          "url": "fonts/Bell Centennial Std/BellCentennialStd-SubCapt.woff2"
+          "fileSize": 17404
         }
       ]
     },
@@ -994,24 +912,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17468,
-          "url": "fonts/Bell Gothic Std/BellGothicStd-Light.woff2"
+          "fileSize": 17468
         },
         {
           "name": "BellGothicStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17304,
-          "url": "fonts/Bell Gothic Std/BellGothicStd-Black.woff2"
+          "fileSize": 17304
         },
         {
           "name": "BellGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17816,
-          "url": "fonts/Bell Gothic Std/BellGothicStd-Bold.woff2"
+          "fileSize": 17816
         }
       ]
     },
@@ -1030,48 +945,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 37524,
-          "url": "fonts/Bell MT Std/BellMTStd-Italic.woff2"
+          "fileSize": 37524
         },
         {
           "name": "BellMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43832,
-          "url": "fonts/Bell MT Std/BellMTStd-Regular.woff2"
+          "fileSize": 43832
         },
         {
           "name": "BellMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 34648,
-          "url": "fonts/Bell MT Std/BellMTStd-BoldItalic.woff2"
+          "fileSize": 34648
         },
         {
           "name": "BellMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 36968,
-          "url": "fonts/Bell MT Std/BellMTStd-SemiBoldItalic.woff2"
+          "fileSize": 36968
         },
         {
           "name": "BellMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35088,
-          "url": "fonts/Bell MT Std/BellMTStd-Bold.woff2"
+          "fileSize": 35088
         },
         {
           "name": "BellMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43168,
-          "url": "fonts/Bell MT Std/BellMTStd-SemiBold.woff2"
+          "fileSize": 43168
         }
       ]
     },
@@ -1090,32 +999,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17980,
-          "url": "fonts/Belwe Std/BelweStd-Light.woff2"
+          "fileSize": 17980
         },
         {
           "name": "BelweStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17216,
-          "url": "fonts/Belwe Std/BelweStd-Condensed.woff2"
+          "fileSize": 17216
         },
         {
           "name": "BelweStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17764,
-          "url": "fonts/Belwe Std/BelweStd-Medium.woff2"
+          "fileSize": 17764
         },
         {
           "name": "BelweStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17412,
-          "url": "fonts/Belwe Std/BelweStd-Bold.woff2"
+          "fileSize": 17412
         }
       ]
     },
@@ -1134,64 +1039,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28908,
-          "url": "fonts/Bembo Std/BemboStd-Italic.woff2"
+          "fileSize": 28908
         },
         {
           "name": "BemboStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34672,
-          "url": "fonts/Bembo Std/BemboStd.woff2"
+          "fileSize": 34672
         },
         {
           "name": "BemboStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28628,
-          "url": "fonts/Bembo Std/BemboStd-BoldItalic.woff2"
+          "fileSize": 28628
         },
         {
           "name": "BemboStd-ExtraBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28620,
-          "url": "fonts/Bembo Std/BemboStd-ExtraBoldItalic.woff2"
+          "fileSize": 28620
         },
         {
           "name": "BemboStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29064,
-          "url": "fonts/Bembo Std/BemboStd-SemiboldItalic.woff2"
+          "fileSize": 29064
         },
         {
           "name": "BemboStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26512,
-          "url": "fonts/Bembo Std/BemboStd-Bold.woff2"
+          "fileSize": 26512
         },
         {
           "name": "BemboStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27276,
-          "url": "fonts/Bembo Std/BemboStd-ExtraBold.woff2"
+          "fileSize": 27276
         },
         {
           "name": "BemboStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26884,
-          "url": "fonts/Bembo Std/BemboStd-Semibold.woff2"
+          "fileSize": 26884
         }
       ]
     },
@@ -1210,32 +1107,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20172,
-          "url": "fonts/Berling LT Std/BerlingLTStd-Italic.woff2"
+          "fileSize": 20172
         },
         {
           "name": "BerlingLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19292,
-          "url": "fonts/Berling LT Std/BerlingLTStd-Roman.woff2"
+          "fileSize": 19292
         },
         {
           "name": "BerlingLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20140,
-          "url": "fonts/Berling LT Std/BerlingLTStd-BoldItalic.woff2"
+          "fileSize": 20140
         },
         {
           "name": "BerlingLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19056,
-          "url": "fonts/Berling LT Std/BerlingLTStd-Bold.woff2"
+          "fileSize": 19056
         }
       ]
     },
@@ -1254,32 +1147,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 59124,
-          "url": "fonts/Bermuda LP Std/BermudaLPStd-Dots.woff2"
+          "fileSize": 59124
         },
         {
           "name": "BermudaLPStd-Open",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42724,
-          "url": "fonts/Bermuda LP Std/BermudaLPStd-Open.woff2"
+          "fileSize": 42724
         },
         {
           "name": "BermudaLPStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40168,
-          "url": "fonts/Bermuda LP Std/BermudaLPStd-Solid.woff2"
+          "fileSize": 40168
         },
         {
           "name": "BermudaLPStd-Squiggle",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58124,
-          "url": "fonts/Bermuda LP Std/BermudaLPStd-Squiggle.woff2"
+          "fileSize": 58124
         }
       ]
     },
@@ -1298,32 +1187,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22516,
-          "url": "fonts/Bernhard Modern Std/BernhardModernStd-Italic.woff2"
+          "fileSize": 22516
         },
         {
           "name": "BernhardModernStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22612,
-          "url": "fonts/Bernhard Modern Std/BernhardModernStd-Roman.woff2"
+          "fileSize": 22612
         },
         {
           "name": "BernhardModernStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22796,
-          "url": "fonts/Bernhard Modern Std/BernhardModernStd-Bold.woff2"
+          "fileSize": 22796
         },
         {
           "name": "BernhardModernStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23232,
-          "url": "fonts/Bernhard Modern Std/BernhardModernStd-BoldIt.woff2"
+          "fileSize": 23232
         }
       ]
     },
@@ -1342,8 +1227,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39064,
-          "url": "fonts/Bernhard Std/BernhardStd-BoldCondensed.woff2"
+          "fileSize": 39064
         }
       ]
     },
@@ -1362,24 +1246,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 75912,
-          "url": "fonts/Bickham Script Std/BickhamScriptStd-Regular.woff2"
+          "fileSize": 75912
         },
         {
           "name": "BickhamScriptStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 75368,
-          "url": "fonts/Bickham Script Std/BickhamScriptStd-Bold.woff2"
+          "fileSize": 75368
         },
         {
           "name": "BickhamScriptStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 79424,
-          "url": "fonts/Bickham Script Std/BickhamScriptStd-Semibold.woff2"
+          "fileSize": 79424
         }
       ]
     },
@@ -1398,8 +1279,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22940,
-          "url": "fonts/Biffo MT Std/BiffoMTStd.woff2"
+          "fileSize": 22940
         }
       ]
     },
@@ -1418,8 +1298,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19724,
-          "url": "fonts/Birch Std/BirchStd.woff2"
+          "fileSize": 19724
         }
       ]
     },
@@ -1438,8 +1317,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24380,
-          "url": "fonts/Blackoak Std/BlackoakStd.woff2"
+          "fileSize": 24380
         }
       ]
     },
@@ -1458,8 +1336,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21228,
-          "url": "fonts/Blue Island Std/BlueIslandStd.woff2"
+          "fileSize": 21228
         }
       ]
     },
@@ -1478,80 +1355,70 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19108,
-          "url": "fonts/Bodoni Std/BodoniStd-BookItalic.woff2"
+          "fileSize": 19108
         },
         {
           "name": "BodoniStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20932,
-          "url": "fonts/Bodoni Std/BodoniStd-Italic.woff2"
+          "fileSize": 20932
         },
         {
           "name": "BodoniStd-PosterItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21612,
-          "url": "fonts/Bodoni Std/BodoniStd-PosterItalic.woff2"
+          "fileSize": 21612
         },
         {
           "name": "BodoniStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18128,
-          "url": "fonts/Bodoni Std/BodoniStd.woff2"
+          "fileSize": 18128
         },
         {
           "name": "BodoniStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18228,
-          "url": "fonts/Bodoni Std/BodoniStd-Book.woff2"
+          "fileSize": 18228
         },
         {
           "name": "BodoniStd-Poster",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19416,
-          "url": "fonts/Bodoni Std/BodoniStd-Poster.woff2"
+          "fileSize": 19416
         },
         {
           "name": "BodoniStd-PosterCompressed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17752,
-          "url": "fonts/Bodoni Std/BodoniStd-PosterCompressed.woff2"
+          "fileSize": 17752
         },
         {
           "name": "BodoniStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20636,
-          "url": "fonts/Bodoni Std/BodoniStd-BoldItalic.woff2"
+          "fileSize": 20636
         },
         {
           "name": "BodoniStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18888,
-          "url": "fonts/Bodoni Std/BodoniStd-Bold.woff2"
+          "fileSize": 18888
         },
         {
           "name": "BodoniStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18336,
-          "url": "fonts/Bodoni Std/BodoniStd-BoldCondensed.woff2"
+          "fileSize": 18336
         }
       ]
     },
@@ -1570,8 +1437,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 3552,
-          "url": "fonts/Border Pi Std/BorderPiStd-15159.woff2"
+          "fileSize": 3552
         }
       ]
     },
@@ -1590,8 +1456,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27608,
-          "url": "fonts/Bossa Nova MVB Std/BossaNovaMVBStd.woff2"
+          "fileSize": 27608
         }
       ]
     },
@@ -1610,96 +1475,84 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10668,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Black.woff2"
+          "fileSize": 10668
         },
         {
           "name": "BriemAkademiStd-BlackComp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11232,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BlackComp.woff2"
+          "fileSize": 11232
         },
         {
           "name": "BriemAkademiStd-BlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10820,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BlackCond.woff2"
+          "fileSize": 10820
         },
         {
           "name": "BriemAkademiStd-Comp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10260,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Comp.woff2"
+          "fileSize": 10260
         },
         {
           "name": "BriemAkademiStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10808,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Cond.woff2"
+          "fileSize": 10808
         },
         {
           "name": "BriemAkademiStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10408,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Regular.woff2"
+          "fileSize": 10408
         },
         {
           "name": "BriemAkademiStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11468,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Bold.woff2"
+          "fileSize": 11468
         },
         {
           "name": "BriemAkademiStd-BoldComp",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10900,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BoldComp.woff2"
+          "fileSize": 10900
         },
         {
           "name": "BriemAkademiStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11216,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BoldCond.woff2"
+          "fileSize": 11216
         },
         {
           "name": "BriemAkademiStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11408,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Semibold.woff2"
+          "fileSize": 11408
         },
         {
           "name": "BriemAkademiStd-SemiboldCmp",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10764,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-SemiboldCmp.woff2"
+          "fileSize": 10764
         },
         {
           "name": "BriemAkademiStd-SemiboldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11268,
-          "url": "fonts/Briem Akademi Std/BriemAkademiStd-SemiboldCn.woff2"
+          "fileSize": 11268
         }
       ]
     },
@@ -1718,48 +1571,42 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32924,
-          "url": "fonts/Briem Script Std/BriemScriptStd-Light.woff2"
+          "fileSize": 32924
         },
         {
           "name": "BriemScriptStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35096,
-          "url": "fonts/Briem Script Std/BriemScriptStd-Black.woff2"
+          "fileSize": 35096
         },
         {
           "name": "BriemScriptStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34944,
-          "url": "fonts/Briem Script Std/BriemScriptStd-Medium.woff2"
+          "fileSize": 34944
         },
         {
           "name": "BriemScriptStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35144,
-          "url": "fonts/Briem Script Std/BriemScriptStd-Regular.woff2"
+          "fileSize": 35144
         },
         {
           "name": "BriemScriptStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31968,
-          "url": "fonts/Briem Script Std/BriemScriptStd-Ultra.woff2"
+          "fileSize": 31968
         },
         {
           "name": "BriemScriptStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35176,
-          "url": "fonts/Briem Script Std/BriemScriptStd-Bold.woff2"
+          "fileSize": 35176
         }
       ]
     },
@@ -1778,16 +1625,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28152,
-          "url": "fonts/Bruno JB Std/BrunoJBStd.woff2"
+          "fileSize": 28152
         },
         {
           "name": "BrunoJBStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28728,
-          "url": "fonts/Bruno JB Std/BrunoJBStd-Bold.woff2"
+          "fileSize": 28728
         }
       ]
     },
@@ -1806,8 +1651,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23724,
-          "url": "fonts/Brush Script Std/BrushScriptStd.woff2"
+          "fileSize": 23724
         }
       ]
     },
@@ -1826,80 +1670,70 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 40712,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-Italic.woff2"
+          "fileSize": 40712
         },
         {
           "name": "BulmerMTStd-ItalicDisplay",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 34924,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-ItalicDisplay.woff2"
+          "fileSize": 34924
         },
         {
           "name": "BulmerMTStd-Display",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31668,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-Display.woff2"
+          "fileSize": 31668
         },
         {
           "name": "BulmerMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45212,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-Regular.woff2"
+          "fileSize": 45212
         },
         {
           "name": "BulmerMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 41352,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-BoldItalic.woff2"
+          "fileSize": 41352
         },
         {
           "name": "BulmerMTStd-BoldItalicDisp",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35980,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-BoldItalicDisp.woff2"
+          "fileSize": 35980
         },
         {
           "name": "BulmerMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 40148,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-SemiBoldItalic.woff2"
+          "fileSize": 40148
         },
         {
           "name": "BulmerMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37276,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-Bold.woff2"
+          "fileSize": 37276
         },
         {
           "name": "BulmerMTStd-BoldDisplay",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33220,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-BoldDisplay.woff2"
+          "fileSize": 33220
         },
         {
           "name": "BulmerMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44548,
-          "url": "fonts/Bulmer MT Std/BulmerMTStd-SemiBold.woff2"
+          "fileSize": 44548
         }
       ]
     },
@@ -1918,24 +1752,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 6784,
-          "url": "fonts/Bundesbahn Pi Std/BundesbahnPiStd-1.woff2"
+          "fileSize": 6784
         },
         {
           "name": "BundesbahnPiStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 5856,
-          "url": "fonts/Bundesbahn Pi Std/BundesbahnPiStd-2.woff2"
+          "fileSize": 5856
         },
         {
           "name": "BundesbahnPiStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 6724,
-          "url": "fonts/Bundesbahn Pi Std/BundesbahnPiStd-3.woff2"
+          "fileSize": 6724
         }
       ]
     },
@@ -1954,32 +1785,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 113372,
-          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Light.woff2"
+          "fileSize": 113372
         },
         {
           "name": "CaflischScriptPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 144272,
-          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Regular.woff2"
+          "fileSize": 144272
         },
         {
           "name": "CaflischScriptPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 110460,
-          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Bold.woff2"
+          "fileSize": 110460
         },
         {
           "name": "CaflischScriptPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 144912,
-          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Semibold.woff2"
+          "fileSize": 144912
         }
       ]
     },
@@ -1998,24 +1825,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26632,
-          "url": "fonts/Calcite Pro/CalcitePro-Black.woff2"
+          "fileSize": 26632
         },
         {
           "name": "CalcitePro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26168,
-          "url": "fonts/Calcite Pro/CalcitePro-Regular.woff2"
+          "fileSize": 26168
         },
         {
           "name": "CalcitePro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28328,
-          "url": "fonts/Calcite Pro/CalcitePro-Bold.woff2"
+          "fileSize": 28328
         }
       ]
     },
@@ -2034,8 +1858,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25688,
-          "url": "fonts/Caliban Std/CalibanStd.woff2"
+          "fileSize": 25688
         }
       ]
     },
@@ -2054,24 +1877,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17940,
-          "url": "fonts/Calvert MT Std/CalvertMTStd-Light.woff2"
+          "fileSize": 17940
         },
         {
           "name": "CalvertMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17676,
-          "url": "fonts/Calvert MT Std/CalvertMTStd.woff2"
+          "fileSize": 17676
         },
         {
           "name": "CalvertMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17752,
-          "url": "fonts/Calvert MT Std/CalvertMTStd-Bold.woff2"
+          "fileSize": 17752
         }
       ]
     },
@@ -2090,24 +1910,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18656,
-          "url": "fonts/Candida Std/CandidaStd-Italic.woff2"
+          "fileSize": 18656
         },
         {
           "name": "CandidaStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16904,
-          "url": "fonts/Candida Std/CandidaStd-Roman.woff2"
+          "fileSize": 16904
         },
         {
           "name": "CandidaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16984,
-          "url": "fonts/Candida Std/CandidaStd-Bold.woff2"
+          "fileSize": 16984
         }
       ]
     },
@@ -2126,80 +1943,70 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21492,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-LightItalic.woff2"
+          "fileSize": 21492
         },
         {
           "name": "CantoriaMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19944,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-Light.woff2"
+          "fileSize": 19944
         },
         {
           "name": "CantoriaMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21320,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-Italic.woff2"
+          "fileSize": 21320
         },
         {
           "name": "CantoriaMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20224,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd.woff2"
+          "fileSize": 20224
         },
         {
           "name": "CantoriaMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21264,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-BoldItalic.woff2"
+          "fileSize": 21264
         },
         {
           "name": "CantoriaMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20120,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-Bold.woff2"
+          "fileSize": 20120
         },
         {
           "name": "CantoriaMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20428,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-ExtraBold.woff2"
+          "fileSize": 20428
         },
         {
           "name": "CantoriaMTStd-ExtraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21064,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-ExtraBoldIt.woff2"
+          "fileSize": 21064
         },
         {
           "name": "CantoriaMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20128,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-SemiBold.woff2"
+          "fileSize": 20128
         },
         {
           "name": "CantoriaMTStd-SemiBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21124,
-          "url": "fonts/Cantoria MT Std/CantoriaMTStd-SemiBoldIt.woff2"
+          "fileSize": 21124
         }
       ]
     },
@@ -2218,32 +2025,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25284,
-          "url": "fonts/Caravan LT Std/CaravanLTStd-1.woff2"
+          "fileSize": 25284
         },
         {
           "name": "CaravanLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18432,
-          "url": "fonts/Caravan LT Std/CaravanLTStd-2.woff2"
+          "fileSize": 18432
         },
         {
           "name": "CaravanLTStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19504,
-          "url": "fonts/Caravan LT Std/CaravanLTStd-3.woff2"
+          "fileSize": 19504
         },
         {
           "name": "CaravanLTStd-4",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19456,
-          "url": "fonts/Caravan LT Std/CaravanLTStd-4.woff2"
+          "fileSize": 19456
         }
       ]
     },
@@ -2262,8 +2065,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22964,
-          "url": "fonts/Carolina LT Std/CarolinaLTStd.woff2"
+          "fileSize": 22964
         }
       ]
     },
@@ -2282,8 +2084,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20432,
-          "url": "fonts/Carta Std/CartaStd.woff2"
+          "fileSize": 20432
         }
       ]
     },
@@ -2302,8 +2103,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19980,
-          "url": "fonts/Cascade Script LT Std/CascadeScriptLTStd.woff2"
+          "fileSize": 19980
         }
       ]
     },
@@ -2322,16 +2122,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21320,
-          "url": "fonts/Caslon 3 LT Std/Caslon3LTStd-Italic.woff2"
+          "fileSize": 21320
         },
         {
           "name": "Caslon3LTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25312,
-          "url": "fonts/Caslon 3 LT Std/Caslon3LTStd-Roman.woff2"
+          "fileSize": 25312
         }
       ]
     },
@@ -2350,16 +2148,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21528,
-          "url": "fonts/Caslon 540 LT Std/Caslon540LTStd-Italic.woff2"
+          "fileSize": 21528
         },
         {
           "name": "Caslon540LTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26840,
-          "url": "fonts/Caslon 540 LT Std/Caslon540LTStd-Roman.woff2"
+          "fileSize": 26840
         }
       ]
     },
@@ -2378,8 +2174,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29988,
-          "url": "fonts/Caslon Open Face LT Std/CaslonOpenFaceLTStd.woff2"
+          "fileSize": 29988
         }
       ]
     },
@@ -2398,8 +2193,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21680,
-          "url": "fonts/Castellar MT Std/CastellarMTStd.woff2"
+          "fileSize": 21680
         }
       ]
     },
@@ -2418,48 +2212,42 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25344,
-          "url": "fonts/Caxton Std/CaxtonStd-LightItalic.woff2"
+          "fileSize": 25344
         },
         {
           "name": "CaxtonStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24208,
-          "url": "fonts/Caxton Std/CaxtonStd-Light.woff2"
+          "fileSize": 24208
         },
         {
           "name": "CaxtonStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24800,
-          "url": "fonts/Caxton Std/CaxtonStd-BookItalic.woff2"
+          "fileSize": 24800
         },
         {
           "name": "CaxtonStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23928,
-          "url": "fonts/Caxton Std/CaxtonStd-Book.woff2"
+          "fileSize": 23928
         },
         {
           "name": "CaxtonStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24696,
-          "url": "fonts/Caxton Std/CaxtonStd-BoldItalic.woff2"
+          "fileSize": 24696
         },
         {
           "name": "CaxtonStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23616,
-          "url": "fonts/Caxton Std/CaxtonStd-Bold.woff2"
+          "fileSize": 23616
         }
       ]
     },
@@ -2478,32 +2266,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 46740,
-          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd-Italic.woff2"
+          "fileSize": 46740
         },
         {
           "name": "CelestiaAntiquaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 110476,
-          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd.woff2"
+          "fileSize": 110476
         },
         {
           "name": "CelestiaAntiquaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 51296,
-          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd-Bold.woff2"
+          "fileSize": 51296
         },
         {
           "name": "CelestiaAntiquaStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 49324,
-          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd-Semibold.woff2"
+          "fileSize": 49324
         }
       ]
     },
@@ -2522,32 +2306,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 43436,
-          "url": "fonts/Centaur MT Std/CentaurMTStd-Italic.woff2"
+          "fileSize": 43436
         },
         {
           "name": "CentaurMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45208,
-          "url": "fonts/Centaur MT Std/CentaurMTStd.woff2"
+          "fileSize": 45208
         },
         {
           "name": "CentaurMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32892,
-          "url": "fonts/Centaur MT Std/CentaurMTStd-BoldItalic.woff2"
+          "fileSize": 32892
         },
         {
           "name": "CentaurMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35744,
-          "url": "fonts/Centaur MT Std/CentaurMTStd-Bold.woff2"
+          "fileSize": 35744
         }
       ]
     },
@@ -2566,16 +2346,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20968,
-          "url": "fonts/Century Expanded LT Std/CenturyExpandedLTStd-Italic.woff2"
+          "fileSize": 20968
         },
         {
           "name": "CenturyExpandedLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19336,
-          "url": "fonts/Century Expanded LT Std/CenturyExpandedLTStd.woff2"
+          "fileSize": 19336
         }
       ]
     },
@@ -2594,24 +2372,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19724,
-          "url": "fonts/Century Old Style Std/CenturyOldStyleStd-Italic.woff2"
+          "fileSize": 19724
         },
         {
           "name": "CenturyOldStyleStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18464,
-          "url": "fonts/Century Old Style Std/CenturyOldStyleStd-Regular.woff2"
+          "fileSize": 18464
         },
         {
           "name": "CenturyOldStyleStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18312,
-          "url": "fonts/Century Old Style Std/CenturyOldStyleStd-Bold.woff2"
+          "fileSize": 18312
         }
       ]
     },
@@ -2630,16 +2405,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19728,
-          "url": "fonts/Charlemagne Std/CharlemagneStd-Regular.woff2"
+          "fileSize": 19728
         },
         {
           "name": "CharlemagneStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19916,
-          "url": "fonts/Charlemagne Std/CharlemagneStd-Bold.woff2"
+          "fileSize": 19916
         }
       ]
     },
@@ -2658,8 +2431,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23208,
-          "url": "fonts/Charme Std/CharmeStd.woff2"
+          "fileSize": 23208
         }
       ]
     },
@@ -2678,8 +2450,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7608,
-          "url": "fonts/Cheq Std/CheqStd.woff2"
+          "fileSize": 7608
         }
       ]
     },
@@ -2698,8 +2469,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20844,
-          "url": "fonts/Clairvaux LT Std/ClairvauxLTStd.woff2"
+          "fileSize": 20844
         }
       ]
     },
@@ -2718,24 +2488,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19008,
-          "url": "fonts/Clarendon LT Std/ClarendonLTStd-Light.woff2"
+          "fileSize": 19008
         },
         {
           "name": "ClarendonLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19784,
-          "url": "fonts/Clarendon LT Std/ClarendonLTStd.woff2"
+          "fileSize": 19784
         },
         {
           "name": "ClarendonLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19736,
-          "url": "fonts/Clarendon LT Std/ClarendonLTStd-Bold.woff2"
+          "fileSize": 19736
         }
       ]
     },
@@ -2754,40 +2521,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17488,
-          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Light.woff2"
+          "fileSize": 17488
         },
         {
           "name": "ClearfaceGothicLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17872,
-          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Black.woff2"
+          "fileSize": 17872
         },
         {
           "name": "ClearfaceGothicLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18104,
-          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Medium.woff2"
+          "fileSize": 18104
         },
         {
           "name": "ClearfaceGothicLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17912,
-          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Roman.woff2"
+          "fileSize": 17912
         },
         {
           "name": "ClearfaceGothicLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17824,
-          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Bold.woff2"
+          "fileSize": 17824
         }
       ]
     },
@@ -2806,8 +2568,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37220,
-          "url": "fonts/Cloister Std/CloisterStd-OpenFace.woff2"
+          "fileSize": 37220
         }
       ]
     },
@@ -2826,48 +2587,42 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23536,
-          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-LightItalic.woff2"
+          "fileSize": 23536
         },
         {
           "name": "CTMercuriusStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22652,
-          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-Light.woff2"
+          "fileSize": 22652
         },
         {
           "name": "CTMercuriusStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23860,
-          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-BlackItalic.woff2"
+          "fileSize": 23860
         },
         {
           "name": "CTMercuriusStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24100,
-          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-MediumItalic.woff2"
+          "fileSize": 24100
         },
         {
           "name": "CTMercuriusStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22800,
-          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-Black.woff2"
+          "fileSize": 22800
         },
         {
           "name": "CTMercuriusStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22692,
-          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-Medium.woff2"
+          "fileSize": 22692
         }
       ]
     },
@@ -2886,32 +2641,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20560,
-          "url": "fonts/Cochin LT Std/CochinLTStd-Italic.woff2"
+          "fileSize": 20560
         },
         {
           "name": "CochinLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19952,
-          "url": "fonts/Cochin LT Std/CochinLTStd.woff2"
+          "fileSize": 19952
         },
         {
           "name": "CochinLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20840,
-          "url": "fonts/Cochin LT Std/CochinLTStd-BoldItalic.woff2"
+          "fileSize": 20840
         },
         {
           "name": "CochinLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20180,
-          "url": "fonts/Cochin LT Std/CochinLTStd-Bold.woff2"
+          "fileSize": 20180
         }
       ]
     },
@@ -2930,40 +2681,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26476,
-          "url": "fonts/Conga Brava Std/CongaBravaStd-Light.woff2"
+          "fileSize": 26476
         },
         {
           "name": "CongaBravaStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26332,
-          "url": "fonts/Conga Brava Std/CongaBravaStd-Black.woff2"
+          "fileSize": 26332
         },
         {
           "name": "CongaBravaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27628,
-          "url": "fonts/Conga Brava Std/CongaBravaStd-Regular.woff2"
+          "fileSize": 27628
         },
         {
           "name": "CongaBravaStd-SmBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27464,
-          "url": "fonts/Conga Brava Std/CongaBravaStd-SmBd.woff2"
+          "fileSize": 27464
         },
         {
           "name": "CongaBravaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27356,
-          "url": "fonts/Conga Brava Std/CongaBravaStd-Bold.woff2"
+          "fileSize": 27356
         }
       ]
     },
@@ -2982,32 +2728,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27380,
-          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-Black.woff2"
+          "fileSize": 27380
         },
         {
           "name": "CongaBravaStencilStd-Reg",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28852,
-          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-Reg.woff2"
+          "fileSize": 28852
         },
         {
           "name": "CongaBravaStencilStd-SmBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29152,
-          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-SmBd.woff2"
+          "fileSize": 29152
         },
         {
           "name": "CongaBravaStencilStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29144,
-          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-Bold.woff2"
+          "fileSize": 29144
         }
       ]
     },
@@ -3026,16 +2768,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24264,
-          "url": "fonts/Cooper Black Std/CooperBlackStd-Italic.woff2"
+          "fileSize": 24264
         },
         {
           "name": "CooperBlackStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22832,
-          "url": "fonts/Cooper Black Std/CooperBlackStd.woff2"
+          "fileSize": 22832
         }
       ]
     },
@@ -3054,24 +2794,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 98172,
-          "url": "fonts/Copal Std/CopalStd-Decorated.woff2"
+          "fileSize": 98172
         },
         {
           "name": "CopalStd-Outline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 57676,
-          "url": "fonts/Copal Std/CopalStd-Outline.woff2"
+          "fileSize": 57676
         },
         {
           "name": "CopalStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32396,
-          "url": "fonts/Copal Std/CopalStd-Solid.woff2"
+          "fileSize": 32396
         }
       ]
     },
@@ -3090,72 +2827,63 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18396,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-29AB.woff2"
+          "fileSize": 18396
         },
         {
           "name": "CopperplateGothicStd-29BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18640,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-29BC.woff2"
+          "fileSize": 18640
         },
         {
           "name": "CopperplateGothicStd-30AB",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18428,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-30AB.woff2"
+          "fileSize": 18428
         },
         {
           "name": "CopperplateGothicStd-30BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18588,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-30BC.woff2"
+          "fileSize": 18588
         },
         {
           "name": "CopperplateGothicStd-31AB",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19108,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-31AB.woff2"
+          "fileSize": 19108
         },
         {
           "name": "CopperplateGothicStd-31BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18720,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-31BC.woff2"
+          "fileSize": 18720
         },
         {
           "name": "CopperplateGothicStd-32AB",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18592,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-32AB.woff2"
+          "fileSize": 18592
         },
         {
           "name": "CopperplateGothicStd-32BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18720,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-32BC.woff2"
+          "fileSize": 18720
         },
         {
           "name": "CopperplateGothicStd-33BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18396,
-          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-33BC.woff2"
+          "fileSize": 18396
         }
       ]
     },
@@ -3174,8 +2902,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36092,
-          "url": "fonts/Coriander Std/CorianderStd.woff2"
+          "fileSize": 36092
         }
       ]
     },
@@ -3194,24 +2921,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21248,
-          "url": "fonts/Corona LT Std/CoronaLTStd-Italic.woff2"
+          "fileSize": 21248
         },
         {
           "name": "CoronaLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19696,
-          "url": "fonts/Corona LT Std/CoronaLTStd.woff2"
+          "fileSize": 19696
         },
         {
           "name": "CoronaLTStd-BoldFaceNo2",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19760,
-          "url": "fonts/Corona LT Std/CoronaLTStd-BoldFaceNo2.woff2"
+          "fileSize": 19760
         }
       ]
     },
@@ -3230,16 +2954,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25448,
-          "url": "fonts/Coronet LT Std/CoronetLTStd-Regular.woff2"
+          "fileSize": 25448
         },
         {
           "name": "CoronetLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25636,
-          "url": "fonts/Coronet LT Std/CoronetLTStd-Bold.woff2"
+          "fileSize": 25636
         }
       ]
     },
@@ -3258,8 +2980,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23196,
-          "url": "fonts/Cottonwood Std/CottonwoodStd.woff2"
+          "fileSize": 23196
         }
       ]
     },
@@ -3278,32 +2999,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23320,
-          "url": "fonts/Courier Std/CourierStd.woff2"
+          "fileSize": 23320
         },
         {
           "name": "CourierStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 24460,
-          "url": "fonts/Courier Std/CourierStd-Oblique.woff2"
+          "fileSize": 24460
         },
         {
           "name": "CourierStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23016,
-          "url": "fonts/Courier Std/CourierStd-Bold.woff2"
+          "fileSize": 23016
         },
         {
           "name": "CourierStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 24016,
-          "url": "fonts/Courier Std/CourierStd-BoldOblique.woff2"
+          "fileSize": 24016
         }
       ]
     },
@@ -3322,8 +3039,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32156,
-          "url": "fonts/Critter Std/CritterStd.woff2"
+          "fileSize": 32156
         }
       ]
     },
@@ -3342,8 +3058,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20580,
-          "url": "fonts/Cutout Std/CutoutStd.woff2"
+          "fileSize": 20580
         }
       ]
     },
@@ -3362,48 +3077,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35700,
-          "url": "fonts/Dante MT Std/DanteMTStd-Italic.woff2"
+          "fileSize": 35700
         },
         {
           "name": "DanteMTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35212,
-          "url": "fonts/Dante MT Std/DanteMTStd-MediumItalic.woff2"
+          "fileSize": 35212
         },
         {
           "name": "DanteMTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32620,
-          "url": "fonts/Dante MT Std/DanteMTStd-Medium.woff2"
+          "fileSize": 32620
         },
         {
           "name": "DanteMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 53384,
-          "url": "fonts/Dante MT Std/DanteMTStd-Regular.woff2"
+          "fileSize": 53384
         },
         {
           "name": "DanteMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35720,
-          "url": "fonts/Dante MT Std/DanteMTStd-BoldItalic.woff2"
+          "fileSize": 35720
         },
         {
           "name": "DanteMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33456,
-          "url": "fonts/Dante MT Std/DanteMTStd-Bold.woff2"
+          "fileSize": 33456
         }
       ]
     },
@@ -3422,16 +3131,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25096,
-          "url": "fonts/Delphin LT Std/DelphinLTStd-1.woff2"
+          "fileSize": 25096
         },
         {
           "name": "DelphinLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24056,
-          "url": "fonts/Delphin LT Std/DelphinLTStd-2.woff2"
+          "fileSize": 24056
         }
       ]
     },
@@ -3450,32 +3157,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15164,
-          "url": "fonts/DIN Std/DINNeuzeitGroteskStd-Light.woff2"
+          "fileSize": 15164
         },
         {
           "name": "DINEngschriftStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15464,
-          "url": "fonts/DIN Std/DINEngschriftStd.woff2"
+          "fileSize": 15464
         },
         {
           "name": "DINMittelschriftStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15316,
-          "url": "fonts/DIN Std/DINMittelschriftStd.woff2"
+          "fileSize": 15316
         },
         {
           "name": "DINNeuzeitGroteskStd-BdCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15348,
-          "url": "fonts/DIN Std/DINNeuzeitGroteskStd-BdCond.woff2"
+          "fileSize": 15348
         }
       ]
     },
@@ -3494,16 +3197,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25116,
-          "url": "fonts/Diotima LT Std/DiotimaLTStd-Italic.woff2"
+          "fileSize": 25116
         },
         {
           "name": "DiotimaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31440,
-          "url": "fonts/Diotima LT Std/DiotimaLTStd-Roman.woff2"
+          "fileSize": 31440
         }
       ]
     },
@@ -3522,16 +3223,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26308,
-          "url": "fonts/Diskus LT Std/DiskusLTStd.woff2"
+          "fileSize": 26308
         },
         {
           "name": "DiskusLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27388,
-          "url": "fonts/Diskus LT Std/DiskusLTStd-Bold.woff2"
+          "fileSize": 27388
         }
       ]
     },
@@ -3550,16 +3249,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20000,
-          "url": "fonts/Dom Casual Std/DomCasualStd.woff2"
+          "fileSize": 20000
         },
         {
           "name": "DomCasualStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22256,
-          "url": "fonts/Dom Casual Std/DomCasualStd-Bold.woff2"
+          "fileSize": 22256
         }
       ]
     },
@@ -3578,8 +3275,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26208,
-          "url": "fonts/Dorchester Script MT Std/DorchesterScriptMTStd.woff2"
+          "fileSize": 26208
         }
       ]
     },
@@ -3598,8 +3294,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15620,
-          "url": "fonts/Doric LT Std/DoricLTStd-Bold.woff2"
+          "fileSize": 15620
         }
       ]
     },
@@ -3618,8 +3313,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26856,
-          "url": "fonts/Duc De Berry LT Std/DucDeBerryLTStd.woff2"
+          "fileSize": 26856
         }
       ]
     },
@@ -3638,8 +3332,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15300,
-          "url": "fonts/Eccentric Std/EccentricStd.woff2"
+          "fileSize": 15300
         }
       ]
     },
@@ -3658,32 +3351,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19772,
-          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Italic.woff2"
+          "fileSize": 19772
         },
         {
           "name": "EgyptienneFLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18888,
-          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Black.woff2"
+          "fileSize": 18888
         },
         {
           "name": "EgyptienneFLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18476,
-          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Roman.woff2"
+          "fileSize": 18476
         },
         {
           "name": "EgyptienneFLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18348,
-          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Bold.woff2"
+          "fileSize": 18348
         }
       ]
     },
@@ -3702,32 +3391,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22300,
-          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-Italic.woff2"
+          "fileSize": 22300
         },
         {
           "name": "EhrhardtMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19980,
-          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-Regular.woff2"
+          "fileSize": 19980
         },
         {
           "name": "EhrhardtMTStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19952,
-          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-Semibold.woff2"
+          "fileSize": 19952
         },
         {
           "name": "EhrhardtMTStd-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22088,
-          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-SemiboldIt.woff2"
+          "fileSize": 22088
         }
       ]
     },
@@ -3746,64 +3431,56 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23648,
-          "url": "fonts/Electra LT Std/ElectraLTStd-Cursive.woff2"
+          "fileSize": 23648
         },
         {
           "name": "ElectraLTStd-CursiveDisplay",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22184,
-          "url": "fonts/Electra LT Std/ElectraLTStd-CursiveDisplay.woff2"
+          "fileSize": 22184
         },
         {
           "name": "ElectraLTStd-Display",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21384,
-          "url": "fonts/Electra LT Std/ElectraLTStd-Display.woff2"
+          "fileSize": 21384
         },
         {
           "name": "ElectraLTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28976,
-          "url": "fonts/Electra LT Std/ElectraLTStd-Regular.woff2"
+          "fileSize": 28976
         },
         {
           "name": "ElectraLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29196,
-          "url": "fonts/Electra LT Std/ElectraLTStd-Bold.woff2"
+          "fileSize": 29196
         },
         {
           "name": "ElectraLTStd-BoldCursive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23492,
-          "url": "fonts/Electra LT Std/ElectraLTStd-BoldCursive.woff2"
+          "fileSize": 23492
         },
         {
           "name": "ElectraLTStd-BoldCursiveDis",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22284,
-          "url": "fonts/Electra LT Std/ElectraLTStd-BoldCursiveDis.woff2"
+          "fileSize": 22284
         },
         {
           "name": "ElectraLTStd-BoldDisplay",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21412,
-          "url": "fonts/Electra LT Std/ElectraLTStd-BoldDisplay.woff2"
+          "fileSize": 21412
         }
       ]
     },
@@ -3822,64 +3499,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23372,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-LightItalic.woff2"
+          "fileSize": 23372
         },
         {
           "name": "EllingtonMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24424,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-Light.woff2"
+          "fileSize": 24424
         },
         {
           "name": "EllingtonMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24672,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-Italic.woff2"
+          "fileSize": 24672
         },
         {
           "name": "EllingtonMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24160,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd.woff2"
+          "fileSize": 24160
         },
         {
           "name": "EllingtonMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24960,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-BoldItalic.woff2"
+          "fileSize": 24960
         },
         {
           "name": "EllingtonMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24216,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-Bold.woff2"
+          "fileSize": 24216
         },
         {
           "name": "EllingtonMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25056,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-ExtraBold.woff2"
+          "fileSize": 25056
         },
         {
           "name": "EllingtonMTStd-ExtraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24828,
-          "url": "fonts/Ellington MT Std/EllingtonMTStd-ExtraBoldIt.woff2"
+          "fileSize": 24828
         }
       ]
     },
@@ -3898,32 +3567,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21448,
-          "url": "fonts/Else NPL Std/ElseNPLStd-Light.woff2"
+          "fileSize": 21448
         },
         {
           "name": "ElseNPLStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22072,
-          "url": "fonts/Else NPL Std/ElseNPLStd-Medium.woff2"
+          "fileSize": 22072
         },
         {
           "name": "ElseNPLStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21652,
-          "url": "fonts/Else NPL Std/ElseNPLStd-Bold.woff2"
+          "fileSize": 21652
         },
         {
           "name": "ElseNPLStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21792,
-          "url": "fonts/Else NPL Std/ElseNPLStd-SemiBold.woff2"
+          "fileSize": 21792
         }
       ]
     },
@@ -3942,8 +3607,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40188,
-          "url": "fonts/Emmascript MVB Std/EmmascriptMVBStd.woff2"
+          "fileSize": 40188
         }
       ]
     },
@@ -3962,8 +3626,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18632,
-          "url": "fonts/Engravers LT Std/EngraversLTStd-BoldFace.woff2"
+          "fileSize": 18632
         }
       ]
     },
@@ -3982,32 +3645,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1372,
-          "url": "fonts/Euro Mono Std/EuroMonoStd-Italic.woff2"
+          "fileSize": 1372
         },
         {
           "name": "EuroMonoStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1340,
-          "url": "fonts/Euro Mono Std/EuroMonoStd-Regular.woff2"
+          "fileSize": 1340
         },
         {
           "name": "EuroMonoStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1440,
-          "url": "fonts/Euro Mono Std/EuroMonoStd-BoldItalic.woff2"
+          "fileSize": 1440
         },
         {
           "name": "EuroMonoStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1368,
-          "url": "fonts/Euro Mono Std/EuroMonoStd-Bold.woff2"
+          "fileSize": 1368
         }
       ]
     },
@@ -4026,32 +3685,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1316,
-          "url": "fonts/Euro Sans Std/EuroSansStd-Italic.woff2"
+          "fileSize": 1316
         },
         {
           "name": "EuroSansStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1356,
-          "url": "fonts/Euro Sans Std/EuroSansStd-Regular.woff2"
+          "fileSize": 1356
         },
         {
           "name": "EuroSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1388,
-          "url": "fonts/Euro Sans Std/EuroSansStd-BoldItalic.woff2"
+          "fileSize": 1388
         },
         {
           "name": "EuroSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1424,
-          "url": "fonts/Euro Sans Std/EuroSansStd-Bold.woff2"
+          "fileSize": 1424
         }
       ]
     },
@@ -4070,32 +3725,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1404,
-          "url": "fonts/Euro Serif Std/EuroSerifStd-Italic.woff2"
+          "fileSize": 1404
         },
         {
           "name": "EuroSerifStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1408,
-          "url": "fonts/Euro Serif Std/EuroSerifStd-Regular.woff2"
+          "fileSize": 1408
         },
         {
           "name": "EuroSerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1408,
-          "url": "fonts/Euro Serif Std/EuroSerifStd-BoldItalic.woff2"
+          "fileSize": 1408
         },
         {
           "name": "EuroSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1392,
-          "url": "fonts/Euro Serif Std/EuroSerifStd-Bold.woff2"
+          "fileSize": 1392
         }
       ]
     },
@@ -4114,32 +3765,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7080,
-          "url": "fonts/European Pi Std/EuropeanPiStd-1.woff2"
+          "fileSize": 7080
         },
         {
           "name": "EuropeanPiStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7224,
-          "url": "fonts/European Pi Std/EuropeanPiStd-2.woff2"
+          "fileSize": 7224
         },
         {
           "name": "EuropeanPiStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8420,
-          "url": "fonts/European Pi Std/EuropeanPiStd-3.woff2"
+          "fileSize": 8420
         },
         {
           "name": "EuropeanPiStd-4",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 6068,
-          "url": "fonts/European Pi Std/EuropeanPiStd-4.woff2"
+          "fileSize": 6068
         }
       ]
     },
@@ -4158,80 +3805,70 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15328,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd.woff2"
+          "fileSize": 15328
         },
         {
           "name": "EurostileLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15024,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-Cn.woff2"
+          "fileSize": 15024
         },
         {
           "name": "EurostileLTStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15364,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-Demi.woff2"
+          "fileSize": 15364
         },
         {
           "name": "EurostileLTStd-Ex2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15780,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-Ex2.woff2"
+          "fileSize": 15780
         },
         {
           "name": "EurostileLTStd-DemiOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16496,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-DemiOblique.woff2"
+          "fileSize": 16496
         },
         {
           "name": "EurostileLTStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16420,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-Oblique.woff2"
+          "fileSize": 16420
         },
         {
           "name": "EurostileLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15760,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-Bold.woff2"
+          "fileSize": 15760
         },
         {
           "name": "EurostileLTStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16008,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-BoldCn.woff2"
+          "fileSize": 16008
         },
         {
           "name": "EurostileLTStd-BoldEx2",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16060,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-BoldEx2.woff2"
+          "fileSize": 16060
         },
         {
           "name": "EurostileLTStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16800,
-          "url": "fonts/Eurostile LT Std/EurostileLTStd-BoldOblique.woff2"
+          "fileSize": 16800
         }
       ]
     },
@@ -4250,24 +3887,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 108784,
-          "url": "fonts/Ex Ponto Pro/ExPontoPro-Light.woff2"
+          "fileSize": 108784
         },
         {
           "name": "ExPontoPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 133840,
-          "url": "fonts/Ex Ponto Pro/ExPontoPro-Regular.woff2"
+          "fileSize": 133840
         },
         {
           "name": "ExPontoPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 111916,
-          "url": "fonts/Ex Ponto Pro/ExPontoPro-Bold.woff2"
+          "fileSize": 111916
         }
       ]
     },
@@ -4286,24 +3920,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28972,
-          "url": "fonts/Excelsior LT Std/ExcelsiorLTStd-Italic.woff2"
+          "fileSize": 28972
         },
         {
           "name": "ExcelsiorLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28716,
-          "url": "fonts/Excelsior LT Std/ExcelsiorLTStd.woff2"
+          "fileSize": 28716
         },
         {
           "name": "ExcelsiorLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28492,
-          "url": "fonts/Excelsior LT Std/ExcelsiorLTStd-Bold.woff2"
+          "fileSize": 28492
         }
       ]
     },
@@ -4322,96 +3953,84 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30512,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-LightItalic.woff2"
+          "fileSize": 30512
         },
         {
           "name": "FairfieldLTStd-CaptionLight",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22440,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionLight.woff2"
+          "fileSize": 22440
         },
         {
           "name": "FairfieldLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30060,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Light.woff2"
+          "fileSize": 30060
         },
         {
           "name": "FairfieldLTStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31436,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-HeavyItalic.woff2"
+          "fileSize": 31436
         },
         {
           "name": "FairfieldLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30924,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-MediumItalic.woff2"
+          "fileSize": 30924
         },
         {
           "name": "FairfieldLTStd-CaptionHeavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22696,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionHeavy.woff2"
+          "fileSize": 22696
         },
         {
           "name": "FairfieldLTStd-CaptionMed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22284,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionMed.woff2"
+          "fileSize": 22284
         },
         {
           "name": "FairfieldLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30740,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Heavy.woff2"
+          "fileSize": 30740
         },
         {
           "name": "FairfieldLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30388,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Medium.woff2"
+          "fileSize": 30388
         },
         {
           "name": "FairfieldLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31360,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-BoldItalic.woff2"
+          "fileSize": 31360
         },
         {
           "name": "FairfieldLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30808,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Bold.woff2"
+          "fileSize": 30808
         },
         {
           "name": "FairfieldLTStd-CaptionBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23072,
-          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionBold.woff2"
+          "fileSize": 23072
         }
       ]
     },
@@ -4430,8 +4049,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22184,
-          "url": "fonts/Falstaff MT Std/FalstaffMTStd.woff2"
+          "fileSize": 22184
         }
       ]
     },
@@ -4450,8 +4068,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24900,
-          "url": "fonts/Fette Fraktur LT Std/FetteFrakturLTStd.woff2"
+          "fileSize": 24900
         }
       ]
     },
@@ -4470,8 +4087,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34028,
-          "url": "fonts/Flood Std/FloodStd.woff2"
+          "fileSize": 34028
         }
       ]
     },
@@ -4490,8 +4106,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42884,
-          "url": "fonts/Florens LP Std/FlorensLPStd.woff2"
+          "fileSize": 42884
         }
       ]
     },
@@ -4510,16 +4125,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15428,
-          "url": "fonts/Flyer LT Std/FlyerLTStd-BlackCondensed.woff2"
+          "fileSize": 15428
         },
         {
           "name": "FlyerLTStd-ExtraBlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15332,
-          "url": "fonts/Flyer LT Std/FlyerLTStd-ExtraBlackCond.woff2"
+          "fileSize": 15332
         }
       ]
     },
@@ -4538,40 +4151,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15048,
-          "url": "fonts/Folio Std/FolioStd-Light.woff2"
+          "fileSize": 15048
         },
         {
           "name": "FolioStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15752,
-          "url": "fonts/Folio Std/FolioStd-Medium.woff2"
+          "fileSize": 15752
         },
         {
           "name": "FolioStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15784,
-          "url": "fonts/Folio Std/FolioStd-Bold.woff2"
+          "fileSize": 15784
         },
         {
           "name": "FolioStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15336,
-          "url": "fonts/Folio Std/FolioStd-BoldCondensed.woff2"
+          "fileSize": 15336
         },
         {
           "name": "FolioStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16472,
-          "url": "fonts/Folio Std/FolioStd-ExtraBold.woff2"
+          "fileSize": 16472
         }
       ]
     },
@@ -4590,8 +4198,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23676,
-          "url": "fonts/Forte MT Std/ForteMTStd.woff2"
+          "fileSize": 23676
         }
       ]
     },
@@ -4610,16 +4217,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 44700,
-          "url": "fonts/Fournier MT Std/FournierMTStd-Italic.woff2"
+          "fileSize": 44700
         },
         {
           "name": "FournierMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58716,
-          "url": "fonts/Fournier MT Std/FournierMTStd-Regular.woff2"
+          "fileSize": 58716
         }
       ]
     },
@@ -4638,24 +4243,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15508,
-          "url": "fonts/Franklin Gothic Std/FranklinGothicStd-Condensed.woff2"
+          "fileSize": 15508
         },
         {
           "name": "FranklinGothicStd-ExtraCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15200,
-          "url": "fonts/Franklin Gothic Std/FranklinGothicStd-ExtraCond.woff2"
+          "fileSize": 15200
         },
         {
           "name": "FranklinGothicStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15308,
-          "url": "fonts/Franklin Gothic Std/FranklinGothicStd-Roman.woff2"
+          "fileSize": 15308
         }
       ]
     },
@@ -4674,8 +4276,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21580,
-          "url": "fonts/Freestyle Script Std/FreestyleScriptStd.woff2"
+          "fileSize": 21580
         }
       ]
     },
@@ -4694,16 +4295,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17924,
-          "url": "fonts/Friz Quadrata Std/FrizQuadrataStd.woff2"
+          "fileSize": 17924
         },
         {
           "name": "FrizQuadrataStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18268,
-          "url": "fonts/Friz Quadrata Std/FrizQuadrataStd-Bold.woff2"
+          "fileSize": 18268
         }
       ]
     },
@@ -4722,112 +4321,98 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15712,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-LightItalic.woff2"
+          "fileSize": 15712
         },
         {
           "name": "FrutigerLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15212,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Light.woff2"
+          "fileSize": 15212
         },
         {
           "name": "FrutigerLTStd-LightCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15344,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-LightCn.woff2"
+          "fileSize": 15344
         },
         {
           "name": "FrutigerLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16012,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BlackItalic.woff2"
+          "fileSize": 16012
         },
         {
           "name": "FrutigerLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15592,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Italic.woff2"
+          "fileSize": 15592
         },
         {
           "name": "FrutigerLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15352,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Black.woff2"
+          "fileSize": 15352
         },
         {
           "name": "FrutigerLTStd-BlackCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15520,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BlackCn.woff2"
+          "fileSize": 15520
         },
         {
           "name": "FrutigerLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15300,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Cn.woff2"
+          "fileSize": 15300
         },
         {
           "name": "FrutigerLTStd-ExtraBlackCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15936,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-ExtraBlackCn.woff2"
+          "fileSize": 15936
         },
         {
           "name": "FrutigerLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15188,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Roman.woff2"
+          "fileSize": 15188
         },
         {
           "name": "FrutigerLTStd-UltraBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15804,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-UltraBlack.woff2"
+          "fileSize": 15804
         },
         {
           "name": "FrutigerLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15940,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BoldItalic.woff2"
+          "fileSize": 15940
         },
         {
           "name": "FrutigerLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15596,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Bold.woff2"
+          "fileSize": 15596
         },
         {
           "name": "FrutigerLTStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15772,
-          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BoldCn.woff2"
+          "fileSize": 15772
         }
       ]
     },
@@ -4846,8 +4431,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17348,
-          "url": "fonts/Fusaka Std/FusakaStd.woff2"
+          "fileSize": 17348
         }
       ]
     },
@@ -4866,160 +4450,140 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15456,
-          "url": "fonts/Futura Std/FuturaStd-CondensedLight.woff2"
+          "fileSize": 15456
         },
         {
           "name": "FuturaStd-CondensedLightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16432,
-          "url": "fonts/Futura Std/FuturaStd-CondensedLightObl.woff2"
+          "fileSize": 16432
         },
         {
           "name": "FuturaStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14972,
-          "url": "fonts/Futura Std/FuturaStd-Light.woff2"
+          "fileSize": 14972
         },
         {
           "name": "FuturaStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16236,
-          "url": "fonts/Futura Std/FuturaStd-LightOblique.woff2"
+          "fileSize": 16236
         },
         {
           "name": "FuturaStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14588,
-          "url": "fonts/Futura Std/FuturaStd-Book.woff2"
+          "fileSize": 14588
         },
         {
           "name": "FuturaStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15080,
-          "url": "fonts/Futura Std/FuturaStd-Condensed.woff2"
+          "fileSize": 15080
         },
         {
           "name": "FuturaStd-CondensedExtraBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16148,
-          "url": "fonts/Futura Std/FuturaStd-CondensedExtraBd.woff2"
+          "fileSize": 16148
         },
         {
           "name": "FuturaStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14920,
-          "url": "fonts/Futura Std/FuturaStd-Heavy.woff2"
+          "fileSize": 14920
         },
         {
           "name": "FuturaStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14548,
-          "url": "fonts/Futura Std/FuturaStd-Medium.woff2"
+          "fileSize": 14548
         },
         {
           "name": "FuturaStd-BookOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15684,
-          "url": "fonts/Futura Std/FuturaStd-BookOblique.woff2"
+          "fileSize": 15684
         },
         {
           "name": "FuturaStd-CondensedOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16620,
-          "url": "fonts/Futura Std/FuturaStd-CondensedOblique.woff2"
+          "fileSize": 16620
         },
         {
           "name": "FuturaStd-HeavyOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15892,
-          "url": "fonts/Futura Std/FuturaStd-HeavyOblique.woff2"
+          "fileSize": 15892
         },
         {
           "name": "FuturaStd-MediumOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15644,
-          "url": "fonts/Futura Std/FuturaStd-MediumOblique.woff2"
+          "fileSize": 15644
         },
         {
           "name": "FuturaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15480,
-          "url": "fonts/Futura Std/FuturaStd-Bold.woff2"
+          "fileSize": 15480
         },
         {
           "name": "FuturaStd-CondensedBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15164,
-          "url": "fonts/Futura Std/FuturaStd-CondensedBold.woff2"
+          "fileSize": 15164
         },
         {
           "name": "FuturaStd-CondensedBoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16372,
-          "url": "fonts/Futura Std/FuturaStd-CondensedBoldObl.woff2"
+          "fileSize": 16372
         },
         {
           "name": "FuturaStd-CondExtraBoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17092,
-          "url": "fonts/Futura Std/FuturaStd-CondExtraBoldObl.woff2"
+          "fileSize": 17092
         },
         {
           "name": "FuturaStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15972,
-          "url": "fonts/Futura Std/FuturaStd-ExtraBold.woff2"
+          "fileSize": 15972
         },
         {
           "name": "FuturaStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16296,
-          "url": "fonts/Futura Std/FuturaStd-BoldOblique.woff2"
+          "fileSize": 16296
         },
         {
           "name": "FuturaStd-ExtraBoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16896,
-          "url": "fonts/Futura Std/FuturaStd-ExtraBoldOblique.woff2"
+          "fileSize": 16896
         }
       ]
     },
@@ -5038,8 +4602,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 98928,
-          "url": "fonts/Galahad Std/GalahadStd-Regular.woff2"
+          "fileSize": 98928
         }
       ]
     },
@@ -5058,32 +4621,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24468,
-          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd-Italic.woff2"
+          "fileSize": 24468
         },
         {
           "name": "Garamond3LTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30960,
-          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd.woff2"
+          "fileSize": 30960
         },
         {
           "name": "Garamond3LTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24636,
-          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd-BoldItalic.woff2"
+          "fileSize": 24636
         },
         {
           "name": "Garamond3LTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31592,
-          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd-Bold.woff2"
+          "fileSize": 31592
         }
       ]
     },
@@ -5102,24 +4661,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20768,
-          "url": "fonts/Gazette LT Std/GazetteLTStd-Italic.woff2"
+          "fileSize": 20768
         },
         {
           "name": "GazetteLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19840,
-          "url": "fonts/Gazette LT Std/GazetteLTStd-Roman.woff2"
+          "fileSize": 19840
         },
         {
           "name": "GazetteLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19852,
-          "url": "fonts/Gazette LT Std/GazetteLTStd-Bold.woff2"
+          "fileSize": 19852
         }
       ]
     },
@@ -5138,16 +4694,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460,
-          "url": "fonts/Giddyup Std/GiddyupStd.woff2"
+          "fileSize": 30460
         },
         {
           "name": "GiddyupStd-Thangs",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12228,
-          "url": "fonts/Giddyup Std/GiddyupStd-Thangs.woff2"
+          "fileSize": 12228
         }
       ]
     },
@@ -5166,8 +4720,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25704,
-          "url": "fonts/Gill Floriated Caps MT Std/GillFloriatedCapsMTStd.woff2"
+          "fileSize": 25704
         }
       ]
     },
@@ -5186,120 +4739,105 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15940,
-          "url": "fonts/Gill Sans Std/GillSansStd-LightItalic.woff2"
+          "fileSize": 15940
         },
         {
           "name": "GillSansStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15492,
-          "url": "fonts/Gill Sans Std/GillSansStd-Light.woff2"
+          "fileSize": 15492
         },
         {
           "name": "GillSansStd-LightShadowed",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21096,
-          "url": "fonts/Gill Sans Std/GillSansStd-LightShadowed.woff2"
+          "fileSize": 21096
         },
         {
           "name": "GillSansStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16184,
-          "url": "fonts/Gill Sans Std/GillSansStd-Italic.woff2"
+          "fileSize": 16184
         },
         {
           "name": "GillSansStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15868,
-          "url": "fonts/Gill Sans Std/GillSansStd.woff2"
+          "fileSize": 15868
         },
         {
           "name": "GillSansStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15180,
-          "url": "fonts/Gill Sans Std/GillSansStd-Condensed.woff2"
+          "fileSize": 15180
         },
         {
           "name": "GillSansStd-Shadowed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20668,
-          "url": "fonts/Gill Sans Std/GillSansStd-Shadowed.woff2"
+          "fileSize": 20668
         },
         {
           "name": "GillSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16392,
-          "url": "fonts/Gill Sans Std/GillSansStd-BoldItalic.woff2"
+          "fileSize": 16392
         },
         {
           "name": "GillSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16004,
-          "url": "fonts/Gill Sans Std/GillSansStd-Bold.woff2"
+          "fileSize": 16004
         },
         {
           "name": "GillSansStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15968,
-          "url": "fonts/Gill Sans Std/GillSansStd-BoldCondensed.woff2"
+          "fileSize": 15968
         },
         {
           "name": "GillSansStd-BoldExtraCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17084,
-          "url": "fonts/Gill Sans Std/GillSansStd-BoldExtraCond.woff2"
+          "fileSize": 17084
         },
         {
           "name": "GillSansStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16568,
-          "url": "fonts/Gill Sans Std/GillSansStd-ExtraBold.woff2"
+          "fileSize": 16568
         },
         {
           "name": "GillSansStd-ExtraBoldDisp",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17300,
-          "url": "fonts/Gill Sans Std/GillSansStd-ExtraBoldDisp.woff2"
+          "fileSize": 17300
         },
         {
           "name": "GillSansStd-UltraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16936,
-          "url": "fonts/Gill Sans Std/GillSansStd-UltraBold.woff2"
+          "fileSize": 16936
         },
         {
           "name": "GillSansStd-UltraBoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16728,
-          "url": "fonts/Gill Sans Std/GillSansStd-UltraBoldCond.woff2"
+          "fileSize": 16728
         }
       ]
     },
@@ -5318,80 +4856,70 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16876,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-Light.woff2"
+          "fileSize": 16876
         },
         {
           "name": "GlyphaLTStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17612,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-LightOblique.woff2"
+          "fileSize": 17612
         },
         {
           "name": "GlyphaLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18660,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd.woff2"
+          "fileSize": 18660
         },
         {
           "name": "GlyphaLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17184,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-Black.woff2"
+          "fileSize": 17184
         },
         {
           "name": "GlyphaLTStd-Thin",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16372,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-Thin.woff2"
+          "fileSize": 16372
         },
         {
           "name": "GlyphaLTStd-BlackOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 18024,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-BlackOblique.woff2"
+          "fileSize": 18024
         },
         {
           "name": "GlyphaLTStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 19152,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-Oblique.woff2"
+          "fileSize": 19152
         },
         {
           "name": "GlyphaLTStd-ThinOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17468,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-ThinOblique.woff2"
+          "fileSize": 17468
         },
         {
           "name": "GlyphaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18956,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-Bold.woff2"
+          "fileSize": 18956
         },
         {
           "name": "GlyphaLTStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 19636,
-          "url": "fonts/Glypha LT Std/GlyphaLTStd-BoldOblique.woff2"
+          "fileSize": 19636
         }
       ]
     },
@@ -5410,8 +4938,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15348,
-          "url": "fonts/Gothic Thirteen Std/GothicThirteenStd.woff2"
+          "fileSize": 15348
         }
       ]
     },
@@ -5430,24 +4957,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22756,
-          "url": "fonts/Goudy Heavyface Std/GoudyStd-HeavyfaceItalic.woff2"
+          "fileSize": 22756
         },
         {
           "name": "GoudyStd-Heavyface",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21636,
-          "url": "fonts/Goudy Heavyface Std/GoudyStd-Heavyface.woff2"
+          "fileSize": 21636
         },
         {
           "name": "GoudyStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21772,
-          "url": "fonts/Goudy Heavyface Std/GoudyStd-ExtraBold.woff2"
+          "fileSize": 21772
         }
       ]
     },
@@ -5466,16 +4990,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24908,
-          "url": "fonts/Goudy Modern MT Std/GoudyModernMTStd-Italic.woff2"
+          "fileSize": 24908
         },
         {
           "name": "GoudyModernMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24056,
-          "url": "fonts/Goudy Modern MT Std/GoudyModernMTStd.woff2"
+          "fileSize": 24056
         }
       ]
     },
@@ -5494,32 +5016,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22972,
-          "url": "fonts/Goudy Std/GoudyStd-Italic.woff2"
+          "fileSize": 22972
         },
         {
           "name": "GoudyStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28188,
-          "url": "fonts/Goudy Std/GoudyStd.woff2"
+          "fileSize": 28188
         },
         {
           "name": "GoudyStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22284,
-          "url": "fonts/Goudy Std/GoudyStd-BoldItalic.woff2"
+          "fileSize": 22284
         },
         {
           "name": "GoudyStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21512,
-          "url": "fonts/Goudy Std/GoudyStd-Bold.woff2"
+          "fileSize": 21512
         }
       ]
     },
@@ -5538,8 +5056,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45380,
-          "url": "fonts/Goudy Text MT Std/GoudyTextMTStd.woff2"
+          "fileSize": 45380
         }
       ]
     },
@@ -5558,24 +5075,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22124,
-          "url": "fonts/Granjon LT Std/GranjonLTStd-Italic.woff2"
+          "fileSize": 22124
         },
         {
           "name": "GranjonLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25648,
-          "url": "fonts/Granjon LT Std/GranjonLTStd.woff2"
+          "fileSize": 25648
         },
         {
           "name": "GranjonLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19608,
-          "url": "fonts/Granjon LT Std/GranjonLTStd-Bold.woff2"
+          "fileSize": 19608
         }
       ]
     },
@@ -5594,72 +5108,63 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17972,
-          "url": "fonts/Graphite Std/GraphiteStd-Light.woff2"
+          "fileSize": 17972
         },
         {
           "name": "GraphiteStd-LightNarrow",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17216,
-          "url": "fonts/Graphite Std/GraphiteStd-LightNarrow.woff2"
+          "fileSize": 17216
         },
         {
           "name": "GraphiteStd-LightWide",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17968,
-          "url": "fonts/Graphite Std/GraphiteStd-LightWide.woff2"
+          "fileSize": 17968
         },
         {
           "name": "GraphiteStd-Narrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18056,
-          "url": "fonts/Graphite Std/GraphiteStd-Narrow.woff2"
+          "fileSize": 18056
         },
         {
           "name": "GraphiteStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18440,
-          "url": "fonts/Graphite Std/GraphiteStd-Regular.woff2"
+          "fileSize": 18440
         },
         {
           "name": "GraphiteStd-Wide",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18516,
-          "url": "fonts/Graphite Std/GraphiteStd-Wide.woff2"
+          "fileSize": 18516
         },
         {
           "name": "GraphiteStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18100,
-          "url": "fonts/Graphite Std/GraphiteStd-Bold.woff2"
+          "fileSize": 18100
         },
         {
           "name": "GraphiteStd-BoldNarrow",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17368,
-          "url": "fonts/Graphite Std/GraphiteStd-BoldNarrow.woff2"
+          "fileSize": 17368
         },
         {
           "name": "GraphiteStd-BoldWide",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17928,
-          "url": "fonts/Graphite Std/GraphiteStd-BoldWide.woff2"
+          "fileSize": 17928
         }
       ]
     },
@@ -5678,16 +5183,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 118644,
-          "url": "fonts/Greymantle MVB Std/GreymantleMVBStd.woff2"
+          "fileSize": 118644
         },
         {
           "name": "GreymantleMVBStd-Ornaments",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31608,
-          "url": "fonts/Greymantle MVB Std/GreymantleMVBStd-Ornaments.woff2"
+          "fileSize": 31608
         }
       ]
     },
@@ -5706,80 +5209,70 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18004,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-LightItalic.woff2"
+          "fileSize": 18004
         },
         {
           "name": "GrotesqueMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17544,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Light.woff2"
+          "fileSize": 17544
         },
         {
           "name": "GrotesqueMTStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17304,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-LightCond.woff2"
+          "fileSize": 17304
         },
         {
           "name": "GrotesqueMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17228,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Italic.woff2"
+          "fileSize": 17228
         },
         {
           "name": "GrotesqueMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17540,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd.woff2"
+          "fileSize": 17540
         },
         {
           "name": "GrotesqueMTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17544,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Black.woff2"
+          "fileSize": 17544
         },
         {
           "name": "GrotesqueMTStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17248,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Condensed.woff2"
+          "fileSize": 17248
         },
         {
           "name": "GrotesqueMTStd-ExtraCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16052,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-ExtraCond.woff2"
+          "fileSize": 16052
         },
         {
           "name": "GrotesqueMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17424,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Bold.woff2"
+          "fileSize": 17424
         },
         {
           "name": "GrotesqueMTStd-BoldExtended",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16912,
-          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-BoldExtended.woff2"
+          "fileSize": 16912
         }
       ]
     },
@@ -5798,48 +5291,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21564,
-          "url": "fonts/Guardi LT Std/GuardiLTStd-BlackItalic.woff2"
+          "fileSize": 21564
         },
         {
           "name": "GuardiLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21248,
-          "url": "fonts/Guardi LT Std/GuardiLTStd-Italic.woff2"
+          "fileSize": 21248
         },
         {
           "name": "GuardiLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20728,
-          "url": "fonts/Guardi LT Std/GuardiLTStd-Black.woff2"
+          "fileSize": 20728
         },
         {
           "name": "GuardiLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20448,
-          "url": "fonts/Guardi LT Std/GuardiLTStd-Roman.woff2"
+          "fileSize": 20448
         },
         {
           "name": "GuardiLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20952,
-          "url": "fonts/Guardi LT Std/GuardiLTStd-BoldItalic.woff2"
+          "fileSize": 20952
         },
         {
           "name": "GuardiLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20948,
-          "url": "fonts/Guardi LT Std/GuardiLTStd-Bold.woff2"
+          "fileSize": 20948
         }
       ]
     },
@@ -5858,8 +5345,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16272,
-          "url": "fonts/Hardwood LP Std/HardwoodLPStd.woff2"
+          "fileSize": 16272
         }
       ]
     },
@@ -5878,8 +5364,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21932,
-          "url": "fonts/Helvetica Inserat LT Std/HelveticaInseratLTStd-Roman.woff2"
+          "fileSize": 21932
         }
       ]
     },
@@ -5898,168 +5383,147 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15676,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Light.woff2"
+          "fileSize": 15676
         },
         {
           "name": "HelveticaLTStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16168,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-LightCond.woff2"
+          "fileSize": 16168
         },
         {
           "name": "HelveticaLTStd-LightCondObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17316,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-LightCondObl.woff2"
+          "fileSize": 17316
         },
         {
           "name": "HelveticaLTStd-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16900,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-LightObl.woff2"
+          "fileSize": 16900
         },
         {
           "name": "HelveticaLTStd-Blk",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Blk.woff2"
+          "fileSize": 16316
         },
         {
           "name": "HelveticaLTStd-BlkCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16836,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BlkCond.woff2"
+          "fileSize": 16836
         },
         {
           "name": "HelveticaLTStd-BlkCondObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17736,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BlkCondObl.woff2"
+          "fileSize": 17736
         },
         {
           "name": "HelveticaLTStd-BlkObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17280,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BlkObl.woff2"
+          "fileSize": 17280
         },
         {
           "name": "HelveticaLTStd-Comp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15356,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Comp.woff2"
+          "fileSize": 15356
         },
         {
           "name": "HelveticaLTStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16908,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Cond.woff2"
+          "fileSize": 16908
         },
         {
           "name": "HelveticaLTStd-CondObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17820,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-CondObl.woff2"
+          "fileSize": 17820
         },
         {
           "name": "HelveticaLTStd-ExtraComp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14928,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-ExtraComp.woff2"
+          "fileSize": 14928
         },
         {
           "name": "HelveticaLTStd-Fractions",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7864,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Fractions.woff2"
+          "fileSize": 7864
         },
         {
           "name": "HelveticaLTStd-FractionsBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8040,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-FractionsBd.woff2"
+          "fileSize": 8040
         },
         {
           "name": "HelveticaLTStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25012,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Obl.woff2"
+          "fileSize": 25012
         },
         {
           "name": "HelveticaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24432,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Roman.woff2"
+          "fileSize": 24432
         },
         {
           "name": "HelveticaLTStd-UltraComp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15156,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-UltraComp.woff2"
+          "fileSize": 15156
         },
         {
           "name": "HelveticaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24132,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Bold.woff2"
+          "fileSize": 24132
         },
         {
           "name": "HelveticaLTStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17192,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BoldCond.woff2"
+          "fileSize": 17192
         },
         {
           "name": "HelveticaLTStd-BoldCondObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18492,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BoldCondObl.woff2"
+          "fileSize": 18492
         },
         {
           "name": "HelveticaLTStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24864,
-          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BoldObl.woff2"
+          "fileSize": 24864
         }
       ]
     },
@@ -6078,408 +5542,357 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15824,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Bd.woff2"
+          "fileSize": 15824
         },
         {
           "name": "HelveticaNeueLTStd-BdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15976,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdCn.woff2"
+          "fileSize": 15976
         },
         {
           "name": "HelveticaNeueLTStd-BdCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17076,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdCnO.woff2"
+          "fileSize": 17076
         },
         {
           "name": "HelveticaNeueLTStd-BdEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15648,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdEx.woff2"
+          "fileSize": 15648
         },
         {
           "name": "HelveticaNeueLTStd-BdExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17028,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdExO.woff2"
+          "fileSize": 17028
         },
         {
           "name": "HelveticaNeueLTStd-BdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16484,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdIt.woff2"
+          "fileSize": 16484
         },
         {
           "name": "HelveticaNeueLTStd-BdOu",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23848,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdOu.woff2"
+          "fileSize": 23848
         },
         {
           "name": "HelveticaNeueLTStd-Blk",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16796,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Blk.woff2"
+          "fileSize": 16796
         },
         {
           "name": "HelveticaNeueLTStd-BlkCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16244,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkCn.woff2"
+          "fileSize": 16244
         },
         {
           "name": "HelveticaNeueLTStd-BlkCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17060,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkCnO.woff2"
+          "fileSize": 17060
         },
         {
           "name": "HelveticaNeueLTStd-BlkEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkEx.woff2"
+          "fileSize": 16552
         },
         {
           "name": "HelveticaNeueLTStd-BlkExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17816,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkExO.woff2"
+          "fileSize": 17816
         },
         {
           "name": "HelveticaNeueLTStd-BlkIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17016,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkIt.woff2"
+          "fileSize": 17016
         },
         {
           "name": "HelveticaNeueLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15644,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Cn.woff2"
+          "fileSize": 15644
         },
         {
           "name": "HelveticaNeueLTStd-CnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16844,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-CnO.woff2"
+          "fileSize": 16844
         },
         {
           "name": "HelveticaNeueLTStd-Ex",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15628,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Ex.woff2"
+          "fileSize": 15628
         },
         {
           "name": "HelveticaNeueLTStd-ExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16672,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ExO.woff2"
+          "fileSize": 16672
         },
         {
           "name": "HelveticaNeueLTStd-Hv",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16432,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Hv.woff2"
+          "fileSize": 16432
         },
         {
           "name": "HelveticaNeueLTStd-HvCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16340,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvCn.woff2"
+          "fileSize": 16340
         },
         {
           "name": "HelveticaNeueLTStd-HvCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17224,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvCnO.woff2"
+          "fileSize": 17224
         },
         {
           "name": "HelveticaNeueLTStd-HvEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16180,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvEx.woff2"
+          "fileSize": 16180
         },
         {
           "name": "HelveticaNeueLTStd-HvExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17688,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvExO.woff2"
+          "fileSize": 17688
         },
         {
           "name": "HelveticaNeueLTStd-HvIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16944,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvIt.woff2"
+          "fileSize": 16944
         },
         {
           "name": "HelveticaNeueLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16304,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-It.woff2"
+          "fileSize": 16304
         },
         {
           "name": "HelveticaNeueLTStd-Lt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15760,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Lt.woff2"
+          "fileSize": 15760
         },
         {
           "name": "HelveticaNeueLTStd-LtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15608,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtCn.woff2"
+          "fileSize": 15608
         },
         {
           "name": "HelveticaNeueLTStd-LtCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16696,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtCnO.woff2"
+          "fileSize": 16696
         },
         {
           "name": "HelveticaNeueLTStd-LtEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15704,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtEx.woff2"
+          "fileSize": 15704
         },
         {
           "name": "HelveticaNeueLTStd-LtExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17064,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtExO.woff2"
+          "fileSize": 17064
         },
         {
           "name": "HelveticaNeueLTStd-LtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16512,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtIt.woff2"
+          "fileSize": 16512
         },
         {
           "name": "HelveticaNeueLTStd-Md",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15888,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Md.woff2"
+          "fileSize": 15888
         },
         {
           "name": "HelveticaNeueLTStd-MdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16116,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdCn.woff2"
+          "fileSize": 16116
         },
         {
           "name": "HelveticaNeueLTStd-MdCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17120,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdCnO.woff2"
+          "fileSize": 17120
         },
         {
           "name": "HelveticaNeueLTStd-MdEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15996,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdEx.woff2"
+          "fileSize": 15996
         },
         {
           "name": "HelveticaNeueLTStd-MdExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16852,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdExO.woff2"
+          "fileSize": 16852
         },
         {
           "name": "HelveticaNeueLTStd-MdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16624,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdIt.woff2"
+          "fileSize": 16624
         },
         {
           "name": "HelveticaNeueLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15624,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Roman.woff2"
+          "fileSize": 15624
         },
         {
           "name": "HelveticaNeueLTStd-Th",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15920,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Th.woff2"
+          "fileSize": 15920
         },
         {
           "name": "HelveticaNeueLTStd-ThCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15756,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThCn.woff2"
+          "fileSize": 15756
         },
         {
           "name": "HelveticaNeueLTStd-ThCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16924,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThCnO.woff2"
+          "fileSize": 16924
         },
         {
           "name": "HelveticaNeueLTStd-ThEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15620,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThEx.woff2"
+          "fileSize": 15620
         },
         {
           "name": "HelveticaNeueLTStd-ThExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16904,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThExO.woff2"
+          "fileSize": 16904
         },
         {
           "name": "HelveticaNeueLTStd-ThIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16572,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThIt.woff2"
+          "fileSize": 16572
         },
         {
           "name": "HelveticaNeueLTStd-UltLt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15488,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLt.woff2"
+          "fileSize": 15488
         },
         {
           "name": "HelveticaNeueLTStd-UltLtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15588,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtCn.woff2"
+          "fileSize": 15588
         },
         {
           "name": "HelveticaNeueLTStd-UltLtCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16436,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtCnO.woff2"
+          "fileSize": 16436
         },
         {
           "name": "HelveticaNeueLTStd-UltLtEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15288,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtEx.woff2"
+          "fileSize": 15288
         },
         {
           "name": "HelveticaNeueLTStd-UltLtExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16560,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtExO.woff2"
+          "fileSize": 16560
         },
         {
           "name": "HelveticaNeueLTStd-UltLtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16400,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtIt.woff2"
+          "fileSize": 16400
         },
         {
           "name": "HelveticaNeueLTStd-XBlkCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16564,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-XBlkCn.woff2"
+          "fileSize": 16564
         },
         {
           "name": "HelveticaNeueLTStd-XBlkCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17252,
-          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-XBlkCnO.woff2"
+          "fileSize": 17252
         }
       ]
     },
@@ -6498,48 +5911,42 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17820,
-          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-Bd.woff2"
+          "fileSize": 17820
         },
         {
           "name": "HelveticaRoundedLTStd-BdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17888,
-          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BdCn.woff2"
+          "fileSize": 17888
         },
         {
           "name": "HelveticaRoundedLTStd-BdCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19364,
-          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BdCnO.woff2"
+          "fileSize": 19364
         },
         {
           "name": "HelveticaRoundedLTStd-BdO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19744,
-          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BdO.woff2"
+          "fileSize": 19744
         },
         {
           "name": "HelveticaRoundedLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18072,
-          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-Black.woff2"
+          "fileSize": 18072
         },
         {
           "name": "HelveticaRoundedLTStd-BlkO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19488,
-          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BlkO.woff2"
+          "fileSize": 19488
         }
       ]
     },
@@ -6558,8 +5965,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19808,
-          "url": "fonts/Herculanum LT Std/HerculanumLTStd.woff2"
+          "fileSize": 19808
         }
       ]
     },
@@ -6578,64 +5984,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21528,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-BlackItalic.woff2"
+          "fileSize": 21528
         },
         {
           "name": "HiroshigeStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21296,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-BookItalic.woff2"
+          "fileSize": 21296
         },
         {
           "name": "HiroshigeStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22228,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-MediumItalic.woff2"
+          "fileSize": 22228
         },
         {
           "name": "HiroshigeStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21972,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-Black.woff2"
+          "fileSize": 21972
         },
         {
           "name": "HiroshigeStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20972,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-Book.woff2"
+          "fileSize": 20972
         },
         {
           "name": "HiroshigeStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22268,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-Medium.woff2"
+          "fileSize": 22268
         },
         {
           "name": "HiroshigeStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20960,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-BoldItalic.woff2"
+          "fileSize": 20960
         },
         {
           "name": "HiroshigeStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22328,
-          "url": "fonts/Hiroshige Std/HiroshigeStd-Bold.woff2"
+          "fileSize": 22328
         }
       ]
     },
@@ -6654,8 +6052,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19396,
-          "url": "fonts/Hobo Std/HoboStd.woff2"
+          "fileSize": 19396
         }
       ]
     },
@@ -6674,64 +6071,56 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26024,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Light.woff2"
+          "fileSize": 26024
         },
         {
           "name": "HorleyOldStyleMTStd-LightIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25668,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-LightIt.woff2"
+          "fileSize": 25668
         },
         {
           "name": "HorleyOldStyleMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 26552,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Italic.woff2"
+          "fileSize": 26552
         },
         {
           "name": "HorleyOldStyleMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26196,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd.woff2"
+          "fileSize": 26196
         },
         {
           "name": "HorleyOldStyleMTStd-Sb",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25972,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Sb.woff2"
+          "fileSize": 25972
         },
         {
           "name": "HorleyOldStyleMTStd-SbIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26156,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-SbIt.woff2"
+          "fileSize": 26156
         },
         {
           "name": "HorleyOldStyleMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26796,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Bold.woff2"
+          "fileSize": 26796
         },
         {
           "name": "HorleyOldStyleMTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26204,
-          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-BoldIt.woff2"
+          "fileSize": 26204
         }
       ]
     },
@@ -6750,8 +6139,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22328,
-          "url": "fonts/Immi Five O Five Std/ImmiFiveOFiveStd.woff2"
+          "fileSize": 22328
         }
       ]
     },
@@ -6770,8 +6158,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15348,
-          "url": "fonts/Impact LT Std/ImpactLTStd.woff2"
+          "fileSize": 15348
         }
       ]
     },
@@ -6790,24 +6177,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18900,
-          "url": "fonts/Impressum Std/ImpressumStd-Italic.woff2"
+          "fileSize": 18900
         },
         {
           "name": "ImpressumStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18468,
-          "url": "fonts/Impressum Std/ImpressumStd-Roman.woff2"
+          "fileSize": 18468
         },
         {
           "name": "ImpressumStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18540,
-          "url": "fonts/Impressum Std/ImpressumStd-Bold.woff2"
+          "fileSize": 18540
         }
       ]
     },
@@ -6826,16 +6210,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21136,
-          "url": "fonts/Industria LT Std/IndustriaLTStd-Inline.woff2"
+          "fileSize": 21136
         },
         {
           "name": "IndustriaLTStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13032,
-          "url": "fonts/Industria LT Std/IndustriaLTStd-Solid.woff2"
+          "fileSize": 13032
         }
       ]
     },
@@ -6854,8 +6236,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21792,
-          "url": "fonts/Inflex MT Std/InflexMTStd-Bold.woff2"
+          "fileSize": 21792
         }
       ]
     },
@@ -6874,8 +6255,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15716,
-          "url": "fonts/Insignia LT Std/InsigniaLTStd.woff2"
+          "fileSize": 15716
         }
       ]
     },
@@ -6894,8 +6274,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20644,
-          "url": "fonts/Ironwood Std/IronwoodStd.woff2"
+          "fileSize": 20644
         }
       ]
     },
@@ -6914,8 +6293,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20972,
-          "url": "fonts/Isabella Std/IsabellaStd.woff2"
+          "fileSize": 20972
         }
       ]
     },
@@ -6934,24 +6312,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19496,
-          "url": "fonts/Italia Std/ItaliaStd-Book.woff2"
+          "fileSize": 19496
         },
         {
           "name": "ItaliaStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19328,
-          "url": "fonts/Italia Std/ItaliaStd-Medium.woff2"
+          "fileSize": 19328
         },
         {
           "name": "ItaliaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19448,
-          "url": "fonts/Italia Std/ItaliaStd-Bold.woff2"
+          "fileSize": 19448
         }
       ]
     },
@@ -6970,32 +6345,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21752,
-          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd-Italic.woff2"
+          "fileSize": 21752
         },
         {
           "name": "ItalianOldStyleMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20172,
-          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd.woff2"
+          "fileSize": 20172
         },
         {
           "name": "ItalianOldStyleMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20652,
-          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd-Bold.woff2"
+          "fileSize": 20652
         },
         {
           "name": "ItalianOldStyleMTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22184,
-          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd-BoldIt.woff2"
+          "fileSize": 22184
         }
       ]
     },
@@ -7014,48 +6385,42 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25740,
-          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Light.woff2"
+          "fileSize": 25740
         },
         {
           "name": "AmericanTypewriterStd-BdCnd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25072,
-          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-BdCnd.woff2"
+          "fileSize": 25072
         },
         {
           "name": "AmericanTypewriterStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25188,
-          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Cond.woff2"
+          "fileSize": 25188
         },
         {
           "name": "AmericanTypewriterStd-LtCnd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25260,
-          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-LtCnd.woff2"
+          "fileSize": 25260
         },
         {
           "name": "AmericanTypewriterStd-Med",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27020,
-          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Med.woff2"
+          "fileSize": 27020
         },
         {
           "name": "AmericanTypewriterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26768,
-          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Bold.woff2"
+          "fileSize": 26768
         }
       ]
     },
@@ -7074,8 +6439,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12856,
-          "url": "fonts/ITC Anna Std/AnnaStd.woff2"
+          "fileSize": 12856
         }
       ]
     },
@@ -7094,160 +6458,140 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17060,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Bk.woff2"
+          "fileSize": 17060
         },
         {
           "name": "ITCAvantGardeStd-BkCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17028,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BkCn.woff2"
+          "fileSize": 17028
         },
         {
           "name": "ITCAvantGardeStd-BkCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18384,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BkCnObl.woff2"
+          "fileSize": 18384
         },
         {
           "name": "ITCAvantGardeStd-BkObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18252,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BkObl.woff2"
+          "fileSize": 18252
         },
         {
           "name": "ITCAvantGardeStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17456,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Demi.woff2"
+          "fileSize": 17456
         },
         {
           "name": "ITCAvantGardeStd-DemiCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16900,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-DemiCn.woff2"
+          "fileSize": 16900
         },
         {
           "name": "ITCAvantGardeStd-DemiCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18036,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-DemiCnObl.woff2"
+          "fileSize": 18036
         },
         {
           "name": "ITCAvantGardeStd-DemiObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18244,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-DemiObl.woff2"
+          "fileSize": 18244
         },
         {
           "name": "ITCAvantGardeStd-Md",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17116,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Md.woff2"
+          "fileSize": 17116
         },
         {
           "name": "ITCAvantGardeStd-MdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16892,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-MdCn.woff2"
+          "fileSize": 16892
         },
         {
           "name": "ITCAvantGardeStd-MdCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17968,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-MdCnObl.woff2"
+          "fileSize": 17968
         },
         {
           "name": "ITCAvantGardeStd-MdObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17968,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-MdObl.woff2"
+          "fileSize": 17968
         },
         {
           "name": "ITCAvantGardeStd-XLt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16372,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLt.woff2"
+          "fileSize": 16372
         },
         {
           "name": "ITCAvantGardeStd-XLtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15844,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLtCn.woff2"
+          "fileSize": 15844
         },
         {
           "name": "ITCAvantGardeStd-XLtCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16812,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLtCnObl.woff2"
+          "fileSize": 16812
         },
         {
           "name": "ITCAvantGardeStd-XLtObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17492,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLtObl.woff2"
+          "fileSize": 17492
         },
         {
           "name": "ITCAvantGardeStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16764,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Bold.woff2"
+          "fileSize": 16764
         },
         {
           "name": "ITCAvantGardeStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16060,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BoldCn.woff2"
+          "fileSize": 16060
         },
         {
           "name": "ITCAvantGardeStd-BoldCnObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17020,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BoldCnObl.woff2"
+          "fileSize": 17020
         },
         {
           "name": "ITCAvantGardeStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17540,
-          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BoldObl.woff2"
+          "fileSize": 17540
         }
       ]
     },
@@ -7266,8 +6610,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18528,
-          "url": "fonts/ITC Beesknees Std/BeeskneesStd.woff2"
+          "fileSize": 18528
         }
       ]
     },
@@ -7286,64 +6629,56 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16876,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Book.woff2"
+          "fileSize": 16876
         },
         {
           "name": "BenguiatGothicStd-BookObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18480,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-BookObl.woff2"
+          "fileSize": 18480
         },
         {
           "name": "BenguiatGothicStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17016,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Heavy.woff2"
+          "fileSize": 17016
         },
         {
           "name": "BenguiatGothicStd-HeavyObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18636,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-HeavyObl.woff2"
+          "fileSize": 18636
         },
         {
           "name": "BenguiatGothicStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16680,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Medium.woff2"
+          "fileSize": 16680
         },
         {
           "name": "BenguiatGothicStd-MediumObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18392,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-MediumObl.woff2"
+          "fileSize": 18392
         },
         {
           "name": "BenguiatGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17308,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Bold.woff2"
+          "fileSize": 17308
         },
         {
           "name": "BenguiatGothicStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18848,
-          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-BoldObl.woff2"
+          "fileSize": 18848
         }
       ]
     },
@@ -7362,48 +6697,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25848,
-          "url": "fonts/ITC Benguiat Std/BenguiatStd-BookItalic.woff2"
+          "fileSize": 25848
         },
         {
           "name": "BenguiatStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24972,
-          "url": "fonts/ITC Benguiat Std/BenguiatStd-MediumItalic.woff2"
+          "fileSize": 24972
         },
         {
           "name": "BenguiatStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22092,
-          "url": "fonts/ITC Benguiat Std/BenguiatStd-Book.woff2"
+          "fileSize": 22092
         },
         {
           "name": "BenguiatStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23912,
-          "url": "fonts/ITC Benguiat Std/BenguiatStd-Medium.woff2"
+          "fileSize": 23912
         },
         {
           "name": "BenguiatStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25756,
-          "url": "fonts/ITC Benguiat Std/BenguiatStd-BoldItalic.woff2"
+          "fileSize": 25756
         },
         {
           "name": "BenguiatStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23244,
-          "url": "fonts/ITC Benguiat Std/BenguiatStd-Bold.woff2"
+          "fileSize": 23244
         }
       ]
     },
@@ -7422,64 +6751,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20212,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-BlackItalic.woff2"
+          "fileSize": 20212
         },
         {
           "name": "BerkeleyStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20228,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-BookItalic.woff2"
+          "fileSize": 20228
         },
         {
           "name": "BerkeleyStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19728,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Italic.woff2"
+          "fileSize": 19728
         },
         {
           "name": "BerkeleyStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19288,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Black.woff2"
+          "fileSize": 19288
         },
         {
           "name": "BerkeleyStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18784,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Book.woff2"
+          "fileSize": 18784
         },
         {
           "name": "BerkeleyStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18824,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Medium.woff2"
+          "fileSize": 18824
         },
         {
           "name": "BerkeleyStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20492,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-BoldItalic.woff2"
+          "fileSize": 20492
         },
         {
           "name": "BerkeleyStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048,
-          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Bold.woff2"
+          "fileSize": 19048
         }
       ]
     },
@@ -7498,64 +6819,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21976,
-          "url": "fonts/ITC Bookman Std/BookmanStd-LightItalic.woff2"
+          "fileSize": 21976
         },
         {
           "name": "BookmanStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21092,
-          "url": "fonts/ITC Bookman Std/BookmanStd-Light.woff2"
+          "fileSize": 21092
         },
         {
           "name": "BookmanStd-DemiItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21428,
-          "url": "fonts/ITC Bookman Std/BookmanStd-DemiItalic.woff2"
+          "fileSize": 21428
         },
         {
           "name": "BookmanStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20576,
-          "url": "fonts/ITC Bookman Std/BookmanStd-MediumItalic.woff2"
+          "fileSize": 20576
         },
         {
           "name": "BookmanStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20756,
-          "url": "fonts/ITC Bookman Std/BookmanStd-Demi.woff2"
+          "fileSize": 20756
         },
         {
           "name": "BookmanStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19196,
-          "url": "fonts/ITC Bookman Std/BookmanStd-Medium.woff2"
+          "fileSize": 19196
         },
         {
           "name": "BookmanStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20372,
-          "url": "fonts/ITC Bookman Std/BookmanStd-BoldItalic.woff2"
+          "fileSize": 20372
         },
         {
           "name": "BookmanStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19588,
-          "url": "fonts/ITC Bookman Std/BookmanStd-Bold.woff2"
+          "fileSize": 19588
         }
       ]
     },
@@ -7574,64 +6887,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22400,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-BlackItalic.woff2"
+          "fileSize": 22400
         },
         {
           "name": "Caslon224Std-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21892,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-BookItalic.woff2"
+          "fileSize": 21892
         },
         {
           "name": "Caslon224Std-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22600,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-MediumItalic.woff2"
+          "fileSize": 22600
         },
         {
           "name": "Caslon224Std-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19784,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Black.woff2"
+          "fileSize": 19784
         },
         {
           "name": "Caslon224Std-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20120,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Book.woff2"
+          "fileSize": 20120
         },
         {
           "name": "Caslon224Std-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20104,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Medium.woff2"
+          "fileSize": 20104
         },
         {
           "name": "Caslon224Std-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22280,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-BoldItalic.woff2"
+          "fileSize": 22280
         },
         {
           "name": "Caslon224Std-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20192,
-          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Bold.woff2"
+          "fileSize": 20192
         }
       ]
     },
@@ -7650,16 +6955,14 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34320,
-          "url": "fonts/ITC Century Handtooled Std/CenturyStd-HandtooledBold.woff2"
+          "fileSize": 34320
         },
         {
           "name": "CenturyStd-HandtooledBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36984,
-          "url": "fonts/ITC Century Handtooled Std/CenturyStd-HandtooledBoldIt.woff2"
+          "fileSize": 36984
         }
       ]
     },
@@ -7678,128 +6981,112 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20820,
-          "url": "fonts/ITC Century Std/CenturyStd-LightItalic.woff2"
+          "fileSize": 20820
         },
         {
           "name": "CenturyStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19120,
-          "url": "fonts/ITC Century Std/CenturyStd-Light.woff2"
+          "fileSize": 19120
         },
         {
           "name": "CenturyStd-LightCondensed",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19420,
-          "url": "fonts/ITC Century Std/CenturyStd-LightCondensed.woff2"
+          "fileSize": 19420
         },
         {
           "name": "CenturyStd-LightCondensedIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20592,
-          "url": "fonts/ITC Century Std/CenturyStd-LightCondensedIt.woff2"
+          "fileSize": 20592
         },
         {
           "name": "CenturyStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21048,
-          "url": "fonts/ITC Century Std/CenturyStd-BookItalic.woff2"
+          "fileSize": 21048
         },
         {
           "name": "CenturyStd-UltraItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20616,
-          "url": "fonts/ITC Century Std/CenturyStd-UltraItalic.woff2"
+          "fileSize": 20616
         },
         {
           "name": "CenturyStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19192,
-          "url": "fonts/ITC Century Std/CenturyStd-Book.woff2"
+          "fileSize": 19192
         },
         {
           "name": "CenturyStd-BookCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19664,
-          "url": "fonts/ITC Century Std/CenturyStd-BookCondensed.woff2"
+          "fileSize": 19664
         },
         {
           "name": "CenturyStd-BookCondensedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20668,
-          "url": "fonts/ITC Century Std/CenturyStd-BookCondensedIt.woff2"
+          "fileSize": 20668
         },
         {
           "name": "CenturyStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19528,
-          "url": "fonts/ITC Century Std/CenturyStd-Ultra.woff2"
+          "fileSize": 19528
         },
         {
           "name": "CenturyStd-UltraCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19652,
-          "url": "fonts/ITC Century Std/CenturyStd-UltraCondensed.woff2"
+          "fileSize": 19652
         },
         {
           "name": "CenturyStd-UltraCondensedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20504,
-          "url": "fonts/ITC Century Std/CenturyStd-UltraCondensedIt.woff2"
+          "fileSize": 20504
         },
         {
           "name": "CenturyStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20920,
-          "url": "fonts/ITC Century Std/CenturyStd-BoldItalic.woff2"
+          "fileSize": 20920
         },
         {
           "name": "CenturyStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19356,
-          "url": "fonts/ITC Century Std/CenturyStd-Bold.woff2"
+          "fileSize": 19356
         },
         {
           "name": "CenturyStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19152,
-          "url": "fonts/ITC Century Std/CenturyStd-BoldCondensed.woff2"
+          "fileSize": 19152
         },
         {
           "name": "CenturyStd-BoldCondensedIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20104,
-          "url": "fonts/ITC Century Std/CenturyStd-BoldCondensedIt.woff2"
+          "fileSize": 20104
         }
       ]
     },
@@ -7818,48 +7105,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30356,
-          "url": "fonts/ITC Cerigo Std/CerigoStd-BookItalic.woff2"
+          "fileSize": 30356
         },
         {
           "name": "CerigoStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30900,
-          "url": "fonts/ITC Cerigo Std/CerigoStd-MediumItalic.woff2"
+          "fileSize": 30900
         },
         {
           "name": "CerigoStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29984,
-          "url": "fonts/ITC Cerigo Std/CerigoStd-Book.woff2"
+          "fileSize": 29984
         },
         {
           "name": "CerigoStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460,
-          "url": "fonts/ITC Cerigo Std/CerigoStd-Medium.woff2"
+          "fileSize": 30460
         },
         {
           "name": "CerigoStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31372,
-          "url": "fonts/ITC Cerigo Std/CerigoStd-BoldItalic.woff2"
+          "fileSize": 31372
         },
         {
           "name": "CerigoStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30220,
-          "url": "fonts/ITC Cerigo Std/CerigoStd-Bold.woff2"
+          "fileSize": 30220
         }
       ]
     },
@@ -7878,16 +7159,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37412,
-          "url": "fonts/ITC Cheltenham Handtooled Std/CheltenhamStd-HdtooledBdIt.woff2"
+          "fileSize": 37412
         },
         {
           "name": "CheltenhamStd-HdtooledBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35976,
-          "url": "fonts/ITC Cheltenham Handtooled Std/CheltenhamStd-HdtooledBold.woff2"
+          "fileSize": 35976
         }
       ]
     },
@@ -7906,128 +7185,112 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20660,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-LightItalic.woff2"
+          "fileSize": 20660
         },
         {
           "name": "CheltenhamStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19408,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Light.woff2"
+          "fileSize": 19408
         },
         {
           "name": "CheltenhamStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17712,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-LightCond.woff2"
+          "fileSize": 17712
         },
         {
           "name": "CheltenhamStd-LightCondIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19136,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-LightCondIt.woff2"
+          "fileSize": 19136
         },
         {
           "name": "CheltenhamStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20424,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BookItalic.woff2"
+          "fileSize": 20424
         },
         {
           "name": "CheltenhamStd-UltraItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21252,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-UltraItalic.woff2"
+          "fileSize": 21252
         },
         {
           "name": "CheltenhamStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19344,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Book.woff2"
+          "fileSize": 19344
         },
         {
           "name": "CheltenhamStd-BookCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17904,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BookCond.woff2"
+          "fileSize": 17904
         },
         {
           "name": "CheltenhamStd-BookCondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19284,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BookCondIt.woff2"
+          "fileSize": 19284
         },
         {
           "name": "CheltenhamStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20128,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Ultra.woff2"
+          "fileSize": 20128
         },
         {
           "name": "CheltenhamStd-UltraCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18496,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-UltraCond.woff2"
+          "fileSize": 18496
         },
         {
           "name": "CheltenhamStd-UltraCondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20044,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-UltraCondIt.woff2"
+          "fileSize": 20044
         },
         {
           "name": "CheltenhamStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20804,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BoldItalic.woff2"
+          "fileSize": 20804
         },
         {
           "name": "CheltenhamStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19516,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Bold.woff2"
+          "fileSize": 19516
         },
         {
           "name": "CheltenhamStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18096,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BoldCond.woff2"
+          "fileSize": 18096
         },
         {
           "name": "CheltenhamStd-BoldCondIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19604,
-          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BoldCondIt.woff2"
+          "fileSize": 19604
         }
       ]
     },
@@ -8046,64 +7309,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20108,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-BlackItalic.woff2"
+          "fileSize": 20108
         },
         {
           "name": "ClearfaceStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19824,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-HeavyItalic.woff2"
+          "fileSize": 19824
         },
         {
           "name": "ClearfaceStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20048,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-Italic.woff2"
+          "fileSize": 20048
         },
         {
           "name": "ClearfaceStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18580,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-Black.woff2"
+          "fileSize": 18580
         },
         {
           "name": "ClearfaceStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18996,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-Heavy.woff2"
+          "fileSize": 18996
         },
         {
           "name": "ClearfaceStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18796,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-Regular.woff2"
+          "fileSize": 18796
         },
         {
           "name": "ClearfaceStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20256,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-BoldItalic.woff2"
+          "fileSize": 20256
         },
         {
           "name": "ClearfaceStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18232,
-          "url": "fonts/ITC Clearface Std/ClearfaceStd-Bold.woff2"
+          "fileSize": 18232
         }
       ]
     },
@@ -8122,64 +7377,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19692,
-          "url": "fonts/ITC Cushing Std/CushingStd-BookItalic.woff2"
+          "fileSize": 19692
         },
         {
           "name": "CushingStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19308,
-          "url": "fonts/ITC Cushing Std/CushingStd-HeavyItalic.woff2"
+          "fileSize": 19308
         },
         {
           "name": "CushingStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19608,
-          "url": "fonts/ITC Cushing Std/CushingStd-MediumItalic.woff2"
+          "fileSize": 19608
         },
         {
           "name": "CushingStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18236,
-          "url": "fonts/ITC Cushing Std/CushingStd-Book.woff2"
+          "fileSize": 18236
         },
         {
           "name": "CushingStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18200,
-          "url": "fonts/ITC Cushing Std/CushingStd-Heavy.woff2"
+          "fileSize": 18200
         },
         {
           "name": "CushingStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17884,
-          "url": "fonts/ITC Cushing Std/CushingStd-Medium.woff2"
+          "fileSize": 17884
         },
         {
           "name": "CushingStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19108,
-          "url": "fonts/ITC Cushing Std/CushingStd-BoldItalic.woff2"
+          "fileSize": 19108
         },
         {
           "name": "CushingStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18756,
-          "url": "fonts/ITC Cushing Std/CushingStd-Bold.woff2"
+          "fileSize": 18756
         }
       ]
     },
@@ -8198,48 +7445,42 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17636,
-          "url": "fonts/ITC Eras Std/ITCErasStd-Light.woff2"
+          "fileSize": 17636
         },
         {
           "name": "ITCErasStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17288,
-          "url": "fonts/ITC Eras Std/ITCErasStd-Book.woff2"
+          "fileSize": 17288
         },
         {
           "name": "ITCErasStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17064,
-          "url": "fonts/ITC Eras Std/ITCErasStd-Demi.woff2"
+          "fileSize": 17064
         },
         {
           "name": "ITCErasStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17100,
-          "url": "fonts/ITC Eras Std/ITCErasStd-Medium.woff2"
+          "fileSize": 17100
         },
         {
           "name": "ITCErasStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17428,
-          "url": "fonts/ITC Eras Std/ITCErasStd-Ultra.woff2"
+          "fileSize": 17428
         },
         {
           "name": "ITCErasStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17200,
-          "url": "fonts/ITC Eras Std/ITCErasStd-Bold.woff2"
+          "fileSize": 17200
         }
       ]
     },
@@ -8258,64 +7499,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20668,
-          "url": "fonts/ITC Esprit Std/EspritStd-BlackItalic.woff2"
+          "fileSize": 20668
         },
         {
           "name": "EspritStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21388,
-          "url": "fonts/ITC Esprit Std/EspritStd-BookItalic.woff2"
+          "fileSize": 21388
         },
         {
           "name": "EspritStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21240,
-          "url": "fonts/ITC Esprit Std/EspritStd-MediumItalic.woff2"
+          "fileSize": 21240
         },
         {
           "name": "EspritStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20984,
-          "url": "fonts/ITC Esprit Std/EspritStd-Black.woff2"
+          "fileSize": 20984
         },
         {
           "name": "EspritStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20812,
-          "url": "fonts/ITC Esprit Std/EspritStd-Book.woff2"
+          "fileSize": 20812
         },
         {
           "name": "EspritStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20844,
-          "url": "fonts/ITC Esprit Std/EspritStd-Medium.woff2"
+          "fileSize": 20844
         },
         {
           "name": "EspritStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20832,
-          "url": "fonts/ITC Esprit Std/EspritStd-BoldItalic.woff2"
+          "fileSize": 20832
         },
         {
           "name": "EspritStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20892,
-          "url": "fonts/ITC Esprit Std/EspritStd-Bold.woff2"
+          "fileSize": 20892
         }
       ]
     },
@@ -8334,64 +7567,56 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16728,
-          "url": "fonts/ITC Fenice Std/FeniceStd-Light.woff2"
+          "fileSize": 16728
         },
         {
           "name": "FeniceStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17380,
-          "url": "fonts/ITC Fenice Std/FeniceStd-LightOblique.woff2"
+          "fileSize": 17380
         },
         {
           "name": "FeniceStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16876,
-          "url": "fonts/ITC Fenice Std/FeniceStd-Regular.woff2"
+          "fileSize": 16876
         },
         {
           "name": "FeniceStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17308,
-          "url": "fonts/ITC Fenice Std/FeniceStd-Ultra.woff2"
+          "fileSize": 17308
         },
         {
           "name": "FeniceStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17632,
-          "url": "fonts/ITC Fenice Std/FeniceStd-Oblique.woff2"
+          "fileSize": 17632
         },
         {
           "name": "FeniceStd-UltraOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 18180,
-          "url": "fonts/ITC Fenice Std/FeniceStd-UltraOblique.woff2"
+          "fileSize": 18180
         },
         {
           "name": "FeniceStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16760,
-          "url": "fonts/ITC Fenice Std/FeniceStd-Bold.woff2"
+          "fileSize": 16760
         },
         {
           "name": "FeniceStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17660,
-          "url": "fonts/ITC Fenice Std/FeniceStd-BoldOblique.woff2"
+          "fileSize": 17660
         }
       ]
     },
@@ -8410,16 +7635,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19404,
-          "url": "fonts/ITC Flora Std/FloraStd-Medium.woff2"
+          "fileSize": 19404
         },
         {
           "name": "FloraStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19292,
-          "url": "fonts/ITC Flora Std/FloraStd-Bold.woff2"
+          "fileSize": 19292
         }
       ]
     },
@@ -8438,160 +7661,140 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16408,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCd.woff2"
+          "fileSize": 16408
         },
         {
           "name": "ITCFranklinGothicStd-BkCdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16928,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCdIt.woff2"
+          "fileSize": 16928
         },
         {
           "name": "ITCFranklinGothicStd-BkCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15976,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCp.woff2"
+          "fileSize": 15976
         },
         {
           "name": "ITCFranklinGothicStd-BkCpIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16940,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCpIt.woff2"
+          "fileSize": 16940
         },
         {
           "name": "ITCFranklinGothicStd-BkXCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16424,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkXCp.woff2"
+          "fileSize": 16424
         },
         {
           "name": "ITCFranklinGothicStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16296,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Book.woff2"
+          "fileSize": 16296
         },
         {
           "name": "ITCFranklinGothicStd-BookIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17656,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BookIt.woff2"
+          "fileSize": 17656
         },
         {
           "name": "ITCFranklinGothicStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Demi.woff2"
+          "fileSize": 16552
         },
         {
           "name": "ITCFranklinGothicStd-DemiIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17584,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DemiIt.woff2"
+          "fileSize": 17584
         },
         {
           "name": "ITCFranklinGothicStd-DmCd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16500,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCd.woff2"
+          "fileSize": 16500
         },
         {
           "name": "ITCFranklinGothicStd-DmCdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17204,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCdIt.woff2"
+          "fileSize": 17204
         },
         {
           "name": "ITCFranklinGothicStd-DmCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16908,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCp.woff2"
+          "fileSize": 16908
         },
         {
           "name": "ITCFranklinGothicStd-DmCpIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17724,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCpIt.woff2"
+          "fileSize": 17724
         },
         {
           "name": "ITCFranklinGothicStd-DmXCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16772,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmXCp.woff2"
+          "fileSize": 16772
         },
         {
           "name": "ITCFranklinGothicStd-Hvy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Hvy.woff2"
+          "fileSize": 16552
         },
         {
           "name": "ITCFranklinGothicStd-HvyIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18052,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-HvyIt.woff2"
+          "fileSize": 18052
         },
         {
           "name": "ITCFranklinGothicStd-MdCd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16444,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-MdCd.woff2"
+          "fileSize": 16444
         },
         {
           "name": "ITCFranklinGothicStd-MdCdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17052,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-MdCdIt.woff2"
+          "fileSize": 17052
         },
         {
           "name": "ITCFranklinGothicStd-Med",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16684,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Med.woff2"
+          "fileSize": 16684
         },
         {
           "name": "ITCFranklinGothicStd-MedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17736,
-          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-MedIt.woff2"
+          "fileSize": 17736
         }
       ]
     },
@@ -8610,64 +7813,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20520,
-          "url": "fonts/ITC Galliard Std/GalliardStd-BlackItalic.woff2"
+          "fileSize": 20520
         },
         {
           "name": "GalliardStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19188,
-          "url": "fonts/ITC Galliard Std/GalliardStd-Italic.woff2"
+          "fileSize": 19188
         },
         {
           "name": "GalliardStd-UltraItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20272,
-          "url": "fonts/ITC Galliard Std/GalliardStd-UltraItalic.woff2"
+          "fileSize": 20272
         },
         {
           "name": "GalliardStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19600,
-          "url": "fonts/ITC Galliard Std/GalliardStd-Black.woff2"
+          "fileSize": 19600
         },
         {
           "name": "GalliardStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18004,
-          "url": "fonts/ITC Galliard Std/GalliardStd-Roman.woff2"
+          "fileSize": 18004
         },
         {
           "name": "GalliardStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19336,
-          "url": "fonts/ITC Galliard Std/GalliardStd-Ultra.woff2"
+          "fileSize": 19336
         },
         {
           "name": "GalliardStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19412,
-          "url": "fonts/ITC Galliard Std/GalliardStd-BoldItalic.woff2"
+          "fileSize": 19412
         },
         {
           "name": "GalliardStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18192,
-          "url": "fonts/ITC Galliard Std/GalliardStd-Bold.woff2"
+          "fileSize": 18192
         }
       ]
     },
@@ -8686,16 +7881,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45540,
-          "url": "fonts/ITC Garamond Handtooled Std/GaramondStd-HandtooledBdIt.woff2"
+          "fileSize": 45540
         },
         {
           "name": "GaramondStd-HandtooledBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42784,
-          "url": "fonts/ITC Garamond Handtooled Std/GaramondStd-HandtooledBold.woff2"
+          "fileSize": 42784
         }
       ]
     },
@@ -8714,192 +7907,168 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27232,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Bd.woff2"
+          "fileSize": 27232
         },
         {
           "name": "ITCGaramondStd-BdCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26688,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdCond.woff2"
+          "fileSize": 26688
         },
         {
           "name": "ITCGaramondStd-BdCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27668,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdCondIta.woff2"
+          "fileSize": 27668
         },
         {
           "name": "ITCGaramondStd-BdIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28208,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdIta.woff2"
+          "fileSize": 28208
         },
         {
           "name": "ITCGaramondStd-BdNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27320,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdNarrow.woff2"
+          "fileSize": 27320
         },
         {
           "name": "ITCGaramondStd-BdNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28672,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdNarrowIta.woff2"
+          "fileSize": 28672
         },
         {
           "name": "ITCGaramondStd-Bk",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27204,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Bk.woff2"
+          "fileSize": 27204
         },
         {
           "name": "ITCGaramondStd-BkCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26096,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkCond.woff2"
+          "fileSize": 26096
         },
         {
           "name": "ITCGaramondStd-BkCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27508,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkCondIta.woff2"
+          "fileSize": 27508
         },
         {
           "name": "ITCGaramondStd-BkIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28448,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkIta.woff2"
+          "fileSize": 28448
         },
         {
           "name": "ITCGaramondStd-BkNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27080,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkNarrow.woff2"
+          "fileSize": 27080
         },
         {
           "name": "ITCGaramondStd-BkNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28268,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkNarrowIta.woff2"
+          "fileSize": 28268
         },
         {
           "name": "ITCGaramondStd-Lt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23776,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Lt.woff2"
+          "fileSize": 23776
         },
         {
           "name": "ITCGaramondStd-LtCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24300,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtCond.woff2"
+          "fileSize": 24300
         },
         {
           "name": "ITCGaramondStd-LtCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25592,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtCondIta.woff2"
+          "fileSize": 25592
         },
         {
           "name": "ITCGaramondStd-LtIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26000,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtIta.woff2"
+          "fileSize": 26000
         },
         {
           "name": "ITCGaramondStd-LtNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25988,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtNarrow.woff2"
+          "fileSize": 25988
         },
         {
           "name": "ITCGaramondStd-LtNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27728,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtNarrowIta.woff2"
+          "fileSize": 27728
         },
         {
           "name": "ITCGaramondStd-Ult",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25636,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Ult.woff2"
+          "fileSize": 25636
         },
         {
           "name": "ITCGaramondStd-UltCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24724,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltCond.woff2"
+          "fileSize": 24724
         },
         {
           "name": "ITCGaramondStd-UltCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25488,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltCondIta.woff2"
+          "fileSize": 25488
         },
         {
           "name": "ITCGaramondStd-UltIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26436,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltIta.woff2"
+          "fileSize": 26436
         },
         {
           "name": "ITCGaramondStd-UltNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26576,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltNarrow.woff2"
+          "fileSize": 26576
         },
         {
           "name": "ITCGaramondStd-UltNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28064,
-          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltNarrowIta.woff2"
+          "fileSize": 28064
         }
       ]
     },
@@ -8918,48 +8087,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21012,
-          "url": "fonts/ITC Giovanni Std/GiovanniStd-BlackItalic.woff2"
+          "fileSize": 21012
         },
         {
           "name": "GiovanniStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20384,
-          "url": "fonts/ITC Giovanni Std/GiovanniStd-BookItalic.woff2"
+          "fileSize": 20384
         },
         {
           "name": "GiovanniStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19424,
-          "url": "fonts/ITC Giovanni Std/GiovanniStd-Black.woff2"
+          "fileSize": 19424
         },
         {
           "name": "GiovanniStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19416,
-          "url": "fonts/ITC Giovanni Std/GiovanniStd-Book.woff2"
+          "fileSize": 19416
         },
         {
           "name": "GiovanniStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20752,
-          "url": "fonts/ITC Giovanni Std/GiovanniStd-BoldItalic.woff2"
+          "fileSize": 20752
         },
         {
           "name": "GiovanniStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19800,
-          "url": "fonts/ITC Giovanni Std/GiovanniStd-Bold.woff2"
+          "fileSize": 19800
         }
       ]
     },
@@ -8978,64 +8141,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22492,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-BlackItalic.woff2"
+          "fileSize": 22492
         },
         {
           "name": "GoudySansStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22228,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-BookItalic.woff2"
+          "fileSize": 22228
         },
         {
           "name": "GoudySansStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22156,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-MediumItalic.woff2"
+          "fileSize": 22156
         },
         {
           "name": "GoudySansStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20172,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Black.woff2"
+          "fileSize": 20172
         },
         {
           "name": "GoudySansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19828,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Book.woff2"
+          "fileSize": 19828
         },
         {
           "name": "GoudySansStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19912,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Medium.woff2"
+          "fileSize": 19912
         },
         {
           "name": "GoudySansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22552,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-BoldItalic.woff2"
+          "fileSize": 22552
         },
         {
           "name": "GoudySansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20112,
-          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Bold.woff2"
+          "fileSize": 20112
         }
       ]
     },
@@ -9054,48 +8209,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27828,
-          "url": "fonts/ITC Highlander Std/HighlanderStd-BookItalic.woff2"
+          "fileSize": 27828
         },
         {
           "name": "HighlanderStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28048,
-          "url": "fonts/ITC Highlander Std/HighlanderStd-MediumItalic.woff2"
+          "fileSize": 28048
         },
         {
           "name": "HighlanderStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28272,
-          "url": "fonts/ITC Highlander Std/HighlanderStd-Book.woff2"
+          "fileSize": 28272
         },
         {
           "name": "HighlanderStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28776,
-          "url": "fonts/ITC Highlander Std/HighlanderStd-Medium.woff2"
+          "fileSize": 28776
         },
         {
           "name": "HighlanderStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28252,
-          "url": "fonts/ITC Highlander Std/HighlanderStd-BoldItalic.woff2"
+          "fileSize": 28252
         },
         {
           "name": "HighlanderStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29504,
-          "url": "fonts/ITC Highlander Std/HighlanderStd-Bold.woff2"
+          "fileSize": 29504
         }
       ]
     },
@@ -9114,16 +8263,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21232,
-          "url": "fonts/ITC Isadora Std/IsadoraStd-Regular.woff2"
+          "fileSize": 21232
         },
         {
           "name": "IsadoraStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20672,
-          "url": "fonts/ITC Isadora Std/IsadoraStd-Bold.woff2"
+          "fileSize": 20672
         }
       ]
     },
@@ -9142,40 +8289,35 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15332,
-          "url": "fonts/ITC Kabel Std/ITCKabelStd-Book.woff2"
+          "fileSize": 15332
         },
         {
           "name": "ITCKabelStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15596,
-          "url": "fonts/ITC Kabel Std/ITCKabelStd-Demi.woff2"
+          "fileSize": 15596
         },
         {
           "name": "ITCKabelStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15292,
-          "url": "fonts/ITC Kabel Std/ITCKabelStd-Medium.woff2"
+          "fileSize": 15292
         },
         {
           "name": "ITCKabelStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15320,
-          "url": "fonts/ITC Kabel Std/ITCKabelStd-Ultra.woff2"
+          "fileSize": 15320
         },
         {
           "name": "ITCKabelStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15064,
-          "url": "fonts/ITC Kabel Std/ITCKabelStd-Bold.woff2"
+          "fileSize": 15064
         }
       ]
     },
@@ -9194,32 +8336,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19044,
-          "url": "fonts/ITC Korinna Std/KorinnaStd-Kursiv.woff2"
+          "fileSize": 19044
         },
         {
           "name": "KorinnaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17956,
-          "url": "fonts/ITC Korinna Std/KorinnaStd-Regular.woff2"
+          "fileSize": 17956
         },
         {
           "name": "KorinnaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17680,
-          "url": "fonts/ITC Korinna Std/KorinnaStd-Bold.woff2"
+          "fileSize": 17680
         },
         {
           "name": "KorinnaStd-BoldKursiv",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18648,
-          "url": "fonts/ITC Korinna Std/KorinnaStd-BoldKursiv.woff2"
+          "fileSize": 18648
         }
       ]
     },
@@ -9238,64 +8376,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21288,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-BlackItalic.woff2"
+          "fileSize": 21288
         },
         {
           "name": "LeawoodStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20140,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-BookItalic.woff2"
+          "fileSize": 20140
         },
         {
           "name": "LeawoodStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20988,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-MediumItalic.woff2"
+          "fileSize": 20988
         },
         {
           "name": "LeawoodStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20980,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-Black.woff2"
+          "fileSize": 20980
         },
         {
           "name": "LeawoodStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20420,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-Book.woff2"
+          "fileSize": 20420
         },
         {
           "name": "LeawoodStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20712,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-Medium.woff2"
+          "fileSize": 20712
         },
         {
           "name": "LeawoodStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21176,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-BoldItalic.woff2"
+          "fileSize": 21176
         },
         {
           "name": "LeawoodStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21340,
-          "url": "fonts/ITC Leawood Std/LeawoodStd-Bold.woff2"
+          "fileSize": 21340
         }
       ]
     },
@@ -9314,56 +8444,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20228,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-BookItalic.woff2"
+          "fileSize": 20228
         },
         {
           "name": "LegacySansStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20656,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-MediumItalic.woff2"
+          "fileSize": 20656
         },
         {
           "name": "LegacySansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19516,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Book.woff2"
+          "fileSize": 19516
         },
         {
           "name": "LegacySansStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19240,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Medium.woff2"
+          "fileSize": 19240
         },
         {
           "name": "LegacySansStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20240,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Ultra.woff2"
+          "fileSize": 20240
         },
         {
           "name": "LegacySansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20348,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-BoldItalic.woff2"
+          "fileSize": 20348
         },
         {
           "name": "LegacySansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19264,
-          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Bold.woff2"
+          "fileSize": 19264
         }
       ]
     },
@@ -9382,56 +8505,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29428,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-BookItalic.woff2"
+          "fileSize": 29428
         },
         {
           "name": "LegacySerifStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29624,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-MediumItalic.woff2"
+          "fileSize": 29624
         },
         {
           "name": "LegacySerifStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30164,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Book.woff2"
+          "fileSize": 30164
         },
         {
           "name": "LegacySerifStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30240,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Medium.woff2"
+          "fileSize": 30240
         },
         {
           "name": "LegacySerifStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Ultra.woff2"
+          "fileSize": 30460
         },
         {
           "name": "LegacySerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30436,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-BoldItalic.woff2"
+          "fileSize": 30436
         },
         {
           "name": "LegacySerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30400,
-          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Bold.woff2"
+          "fileSize": 30400
         }
       ]
     },
@@ -9450,32 +8566,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16496,
-          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-Book.woff2"
+          "fileSize": 16496
         },
         {
           "name": "LubalinGraphStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17120,
-          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-Demi.woff2"
+          "fileSize": 17120
         },
         {
           "name": "LubalinGraphStd-BookOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17364,
-          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-BookOblique.woff2"
+          "fileSize": 17364
         },
         {
           "name": "LubalinGraphStd-DemiOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17808,
-          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-DemiOblique.woff2"
+          "fileSize": 17808
         }
       ]
     },
@@ -9494,16 +8606,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11112,
-          "url": "fonts/ITC Machine Std/MachineStd.woff2"
+          "fileSize": 11112
         },
         {
           "name": "MachineStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11252,
-          "url": "fonts/ITC Machine Std/MachineStd-Bold.woff2"
+          "fileSize": 11252
         }
       ]
     },
@@ -9522,48 +8632,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31300,
-          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-BookItalic.woff2"
+          "fileSize": 31300
         },
         {
           "name": "MendozaRomanStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30620,
-          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-Book.woff2"
+          "fileSize": 30620
         },
         {
           "name": "MendozaRomanStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31340,
-          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-Medium.woff2"
+          "fileSize": 31340
         },
         {
           "name": "MendozaRomanStd-MediumIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31620,
-          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-MediumIt.woff2"
+          "fileSize": 31620
         },
         {
           "name": "MendozaRomanStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31612,
-          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-BoldItalic.woff2"
+          "fileSize": 31612
         },
         {
           "name": "MendozaRomanStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31360,
-          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-Bold.woff2"
+          "fileSize": 31360
         }
       ]
     },
@@ -9582,16 +8686,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25480,
-          "url": "fonts/ITC Mona Lisa Std/MonaLisaStd-Recut.woff2"
+          "fileSize": 25480
         },
         {
           "name": "MonaLisaStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20204,
-          "url": "fonts/ITC Mona Lisa Std/MonaLisaStd-Solid.woff2"
+          "fileSize": 20204
         }
       ]
     },
@@ -9610,32 +8712,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22864,
-          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-Italic.woff2"
+          "fileSize": 22864
         },
         {
           "name": "NewBaskervilleStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27632,
-          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-Roman.woff2"
+          "fileSize": 27632
         },
         {
           "name": "NewBaskervilleStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28240,
-          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-Bold.woff2"
+          "fileSize": 28240
         },
         {
           "name": "NewBaskervilleStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23712,
-          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-BoldIt.woff2"
+          "fileSize": 23712
         }
       ]
     },
@@ -9654,56 +8752,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19220,
-          "url": "fonts/ITC Novarese Std/NovareseStd-BookItalic.woff2"
+          "fileSize": 19220
         },
         {
           "name": "NovareseStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18408,
-          "url": "fonts/ITC Novarese Std/NovareseStd-MediumItalic.woff2"
+          "fileSize": 18408
         },
         {
           "name": "NovareseStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18328,
-          "url": "fonts/ITC Novarese Std/NovareseStd-Book.woff2"
+          "fileSize": 18328
         },
         {
           "name": "NovareseStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17992,
-          "url": "fonts/ITC Novarese Std/NovareseStd-Medium.woff2"
+          "fileSize": 17992
         },
         {
           "name": "NovareseStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18600,
-          "url": "fonts/ITC Novarese Std/NovareseStd-Ultra.woff2"
+          "fileSize": 18600
         },
         {
           "name": "NovareseStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18440,
-          "url": "fonts/ITC Novarese Std/NovareseStd-BoldItalic.woff2"
+          "fileSize": 18440
         },
         {
           "name": "NovareseStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18060,
-          "url": "fonts/ITC Novarese Std/NovareseStd-Bold.woff2"
+          "fileSize": 18060
         }
       ]
     },
@@ -9722,32 +8813,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20844,
-          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-BookItalic.woff2"
+          "fileSize": 20844
         },
         {
           "name": "OfficinaSansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20012,
-          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-Book.woff2"
+          "fileSize": 20012
         },
         {
           "name": "OfficinaSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20608,
-          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-BoldItalic.woff2"
+          "fileSize": 20608
         },
         {
           "name": "OfficinaSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19392,
-          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-Bold.woff2"
+          "fileSize": 19392
         }
       ]
     },
@@ -9766,32 +8853,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21616,
-          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-BookItalic.woff2"
+          "fileSize": 21616
         },
         {
           "name": "OfficinaSerifStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20604,
-          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-Book.woff2"
+          "fileSize": 20604
         },
         {
           "name": "OfficinaSerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21208,
-          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-BoldItalic.woff2"
+          "fileSize": 21208
         },
         {
           "name": "OfficinaSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20092,
-          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-Bold.woff2"
+          "fileSize": 20092
         }
       ]
     },
@@ -9810,8 +8893,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35160,
-          "url": "fonts/ITC Ozwald Std/OzwaldStd.woff2"
+          "fileSize": 35160
         }
       ]
     },
@@ -9830,40 +8912,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18512,
-          "url": "fonts/ITC Quorum Std/QuorumStd-Light.woff2"
+          "fileSize": 18512
         },
         {
           "name": "QuorumStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18756,
-          "url": "fonts/ITC Quorum Std/QuorumStd-Black.woff2"
+          "fileSize": 18756
         },
         {
           "name": "QuorumStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18580,
-          "url": "fonts/ITC Quorum Std/QuorumStd-Book.woff2"
+          "fileSize": 18580
         },
         {
           "name": "QuorumStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18496,
-          "url": "fonts/ITC Quorum Std/QuorumStd-Medium.woff2"
+          "fileSize": 18496
         },
         {
           "name": "QuorumStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18772,
-          "url": "fonts/ITC Quorum Std/QuorumStd-Bold.woff2"
+          "fileSize": 18772
         }
       ]
     },
@@ -9882,48 +8959,42 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16644,
-          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Light.woff2"
+          "fileSize": 16644
         },
         {
           "name": "SerifGothicStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17228,
-          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd.woff2"
+          "fileSize": 17228
         },
         {
           "name": "SerifGothicStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17704,
-          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Black.woff2"
+          "fileSize": 17704
         },
         {
           "name": "SerifGothicStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17440,
-          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Heavy.woff2"
+          "fileSize": 17440
         },
         {
           "name": "SerifGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17432,
-          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Bold.woff2"
+          "fileSize": 17432
         },
         {
           "name": "SerifGothicStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17392,
-          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-ExtraBold.woff2"
+          "fileSize": 17392
         }
       ]
     },
@@ -9942,64 +9013,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21748,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-BlackItalic.woff2"
+          "fileSize": 21748
         },
         {
           "name": "SlimbachStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22480,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-BookItalic.woff2"
+          "fileSize": 22480
         },
         {
           "name": "SlimbachStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21744,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-MediumItalic.woff2"
+          "fileSize": 21744
         },
         {
           "name": "SlimbachStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20396,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-Black.woff2"
+          "fileSize": 20396
         },
         {
           "name": "SlimbachStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21420,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-Book.woff2"
+          "fileSize": 21420
         },
         {
           "name": "SlimbachStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21804,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-Medium.woff2"
+          "fileSize": 21804
         },
         {
           "name": "SlimbachStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21488,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-BoldItalic.woff2"
+          "fileSize": 21488
         },
         {
           "name": "SlimbachStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20192,
-          "url": "fonts/ITC Slimbach Std/SlimbachStd-Bold.woff2"
+          "fileSize": 20192
         }
       ]
     },
@@ -10018,64 +9081,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23352,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-LightItalic.woff2"
+          "fileSize": 23352
         },
         {
           "name": "SouvenirStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21560,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-Light.woff2"
+          "fileSize": 21560
         },
         {
           "name": "SouvenirStd-DemiItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22548,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-DemiItalic.woff2"
+          "fileSize": 22548
         },
         {
           "name": "SouvenirStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20652,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-MediumItalic.woff2"
+          "fileSize": 20652
         },
         {
           "name": "SouvenirStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21336,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-Demi.woff2"
+          "fileSize": 21336
         },
         {
           "name": "SouvenirStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19556,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-Medium.woff2"
+          "fileSize": 19556
         },
         {
           "name": "SouvenirStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20536,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-BoldItalic.woff2"
+          "fileSize": 20536
         },
         {
           "name": "SouvenirStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19412,
-          "url": "fonts/ITC Souvenir Std/SouvenirStd-Bold.woff2"
+          "fileSize": 19412
         }
       ]
     },
@@ -10094,48 +9149,42 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19540,
-          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-Medium.woff2"
+          "fileSize": 19540
         },
         {
           "name": "StoneInformalStd-MediumItal",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20140,
-          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-MediumItal.woff2"
+          "fileSize": 20140
         },
         {
           "name": "StoneInformalStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19988,
-          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-BoldItalic.woff2"
+          "fileSize": 19988
         },
         {
           "name": "StoneInformalStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19792,
-          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-Bold.woff2"
+          "fileSize": 19792
         },
         {
           "name": "StoneInformalStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19680,
-          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-Semibold.woff2"
+          "fileSize": 19680
         },
         {
           "name": "StoneInformalStd-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19652,
-          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-SemiboldIt.woff2"
+          "fileSize": 19652
         }
       ]
     },
@@ -10154,56 +9203,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16016,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-MediumItalic.woff2"
+          "fileSize": 16016
         },
         {
           "name": "StoneSansStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15316,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Medium.woff2"
+          "fileSize": 15316
         },
         {
           "name": "StoneSansStd-Phonetic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47660,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Phonetic.woff2"
+          "fileSize": 47660
         },
         {
           "name": "StoneSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16348,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-BoldItalic.woff2"
+          "fileSize": 16348
         },
         {
           "name": "StoneSansStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16064,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-SemiboldItalic.woff2"
+          "fileSize": 16064
         },
         {
           "name": "StoneSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15804,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Bold.woff2"
+          "fileSize": 15804
         },
         {
           "name": "StoneSansStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15416,
-          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Semibold.woff2"
+          "fileSize": 15416
         }
       ]
     },
@@ -10222,56 +9264,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19600,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-MediumItalic.woff2"
+          "fileSize": 19600
         },
         {
           "name": "StoneSerifStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18588,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Medium.woff2"
+          "fileSize": 18588
         },
         {
           "name": "StoneSerifStd-Phonetic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 53996,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Phonetic.woff2"
+          "fileSize": 53996
         },
         {
           "name": "StoneSerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19096,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-BoldItalic.woff2"
+          "fileSize": 19096
         },
         {
           "name": "StoneSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Bold.woff2"
+          "fileSize": 19048
         },
         {
           "name": "StoneSerifStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19152,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Semibold.woff2"
+          "fileSize": 19152
         },
         {
           "name": "StoneSerifStd-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19316,
-          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-SemiboldIt.woff2"
+          "fileSize": 19316
         }
       ]
     },
@@ -10290,64 +9325,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17684,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-BlackItalic.woff2"
+          "fileSize": 17684
         },
         {
           "name": "ITCSymbolStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17892,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-BookItalic.woff2"
+          "fileSize": 17892
         },
         {
           "name": "ITCSymbolStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17704,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-MediumItalic.woff2"
+          "fileSize": 17704
         },
         {
           "name": "ITCSymbolStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17348,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Black.woff2"
+          "fileSize": 17348
         },
         {
           "name": "ITCSymbolStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16808,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Book.woff2"
+          "fileSize": 16808
         },
         {
           "name": "ITCSymbolStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17024,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Medium.woff2"
+          "fileSize": 17024
         },
         {
           "name": "ITCSymbolStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17972,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-BoldItalic.woff2"
+          "fileSize": 17972
         },
         {
           "name": "ITCSymbolStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17316,
-          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Bold.woff2"
+          "fileSize": 17316
         }
       ]
     },
@@ -10366,48 +9393,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 26412,
-          "url": "fonts/ITC Tiepolo Std/TiepoloStd-BlackItalic.woff2"
+          "fileSize": 26412
         },
         {
           "name": "TiepoloStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25880,
-          "url": "fonts/ITC Tiepolo Std/TiepoloStd-BookItalic.woff2"
+          "fileSize": 25880
         },
         {
           "name": "TiepoloStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23772,
-          "url": "fonts/ITC Tiepolo Std/TiepoloStd-Black.woff2"
+          "fileSize": 23772
         },
         {
           "name": "TiepoloStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25332,
-          "url": "fonts/ITC Tiepolo Std/TiepoloStd-Book.woff2"
+          "fileSize": 25332
         },
         {
           "name": "TiepoloStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24440,
-          "url": "fonts/ITC Tiepolo Std/TiepoloStd-BoldItalic.woff2"
+          "fileSize": 24440
         },
         {
           "name": "TiepoloStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23792,
-          "url": "fonts/ITC Tiepolo Std/TiepoloStd-Bold.woff2"
+          "fileSize": 23792
         }
       ]
     },
@@ -10426,48 +9447,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23560,
-          "url": "fonts/ITC Tiffany Std/TiffanyStd-DemiItalic.woff2"
+          "fileSize": 23560
         },
         {
           "name": "TiffanyStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24052,
-          "url": "fonts/ITC Tiffany Std/TiffanyStd-HeavyItalic.woff2"
+          "fileSize": 24052
         },
         {
           "name": "TiffanyStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23492,
-          "url": "fonts/ITC Tiffany Std/TiffanyStd-Italic.woff2"
+          "fileSize": 23492
         },
         {
           "name": "TiffanyStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22360,
-          "url": "fonts/ITC Tiffany Std/TiffanyStd.woff2"
+          "fileSize": 22360
         },
         {
           "name": "TiffanyStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21900,
-          "url": "fonts/ITC Tiffany Std/TiffanyStd-Demi.woff2"
+          "fileSize": 21900
         },
         {
           "name": "TiffanyStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22120,
-          "url": "fonts/ITC Tiffany Std/TiffanyStd-Heavy.woff2"
+          "fileSize": 22120
         }
       ]
     },
@@ -10486,64 +9501,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21648,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-BlackItalic.woff2"
+          "fileSize": 21648
         },
         {
           "name": "UsherwoodStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22184,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-BookItalic.woff2"
+          "fileSize": 22184
         },
         {
           "name": "UsherwoodStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21540,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-MediumItalic.woff2"
+          "fileSize": 21540
         },
         {
           "name": "UsherwoodStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20684,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Black.woff2"
+          "fileSize": 20684
         },
         {
           "name": "UsherwoodStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22040,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Book.woff2"
+          "fileSize": 22040
         },
         {
           "name": "UsherwoodStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20804,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Medium.woff2"
+          "fileSize": 20804
         },
         {
           "name": "UsherwoodStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21120,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-BoldItalic.woff2"
+          "fileSize": 21120
         },
         {
           "name": "UsherwoodStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20748,
-          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Bold.woff2"
+          "fileSize": 20748
         }
       ]
     },
@@ -10562,64 +9569,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18300,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-BlackItalic.woff2"
+          "fileSize": 18300
         },
         {
           "name": "VeljovicStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17972,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-BookItalic.woff2"
+          "fileSize": 17972
         },
         {
           "name": "VeljovicStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18140,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-MediumItalic.woff2"
+          "fileSize": 18140
         },
         {
           "name": "VeljovicStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17672,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-Black.woff2"
+          "fileSize": 17672
         },
         {
           "name": "VeljovicStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17056,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-Book.woff2"
+          "fileSize": 17056
         },
         {
           "name": "VeljovicStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16924,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-Medium.woff2"
+          "fileSize": 16924
         },
         {
           "name": "VeljovicStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17992,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-BoldItalic.woff2"
+          "fileSize": 17992
         },
         {
           "name": "VeljovicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17396,
-          "url": "fonts/ITC Veljovic Std/VeljovicStd-Bold.woff2"
+          "fileSize": 17396
         }
       ]
     },
@@ -10638,48 +9637,42 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20280,
-          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-LightItalic.woff2"
+          "fileSize": 20280
         },
         {
           "name": "ZapfChanceryStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20696,
-          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Light.woff2"
+          "fileSize": 20696
         },
         {
           "name": "ZapfChanceryStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21908,
-          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Italic.woff2"
+          "fileSize": 21908
         },
         {
           "name": "ZapfChanceryStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21124,
-          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Demi.woff2"
+          "fileSize": 21124
         },
         {
           "name": "ZapfChanceryStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20628,
-          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Roman.woff2"
+          "fileSize": 20628
         },
         {
           "name": "ZapfChanceryStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21388,
-          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Bold.woff2"
+          "fileSize": 21388
         }
       ]
     },
@@ -10698,8 +9691,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25488,
-          "url": "fonts/ITC Zapf Dingbats Std/ZapfDingbatsStd.woff2"
+          "fileSize": 25488
         }
       ]
     },
@@ -10718,32 +9710,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24632,
-          "url": "fonts/Janson Text LT Std/JansonTextLTStd-Italic.woff2"
+          "fileSize": 24632
         },
         {
           "name": "JansonTextLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29660,
-          "url": "fonts/Janson Text LT Std/JansonTextLTStd-Roman.woff2"
+          "fileSize": 29660
         },
         {
           "name": "JansonTextLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24528,
-          "url": "fonts/Janson Text LT Std/JansonTextLTStd-BoldItalic.woff2"
+          "fileSize": 24528
         },
         {
           "name": "JansonTextLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22772,
-          "url": "fonts/Janson Text LT Std/JansonTextLTStd-Bold.woff2"
+          "fileSize": 22772
         }
       ]
     },
@@ -10762,72 +9750,63 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27632,
-          "url": "fonts/Jimbo Std/JimboStd-Black.woff2"
+          "fileSize": 27632
         },
         {
           "name": "JimboStd-BlackCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26248,
-          "url": "fonts/Jimbo Std/JimboStd-BlackCondensed.woff2"
+          "fileSize": 26248
         },
         {
           "name": "JimboStd-BlackExpanded",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26672,
-          "url": "fonts/Jimbo Std/JimboStd-BlackExpanded.woff2"
+          "fileSize": 26672
         },
         {
           "name": "JimboStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25364,
-          "url": "fonts/Jimbo Std/JimboStd-Condensed.woff2"
+          "fileSize": 25364
         },
         {
           "name": "JimboStd-Expanded",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26560,
-          "url": "fonts/Jimbo Std/JimboStd-Expanded.woff2"
+          "fileSize": 26560
         },
         {
           "name": "JimboStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27084,
-          "url": "fonts/Jimbo Std/JimboStd-Regular.woff2"
+          "fileSize": 27084
         },
         {
           "name": "JimboStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27744,
-          "url": "fonts/Jimbo Std/JimboStd-Bold.woff2"
+          "fileSize": 27744
         },
         {
           "name": "JimboStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27356,
-          "url": "fonts/Jimbo Std/JimboStd-BoldCondensed.woff2"
+          "fileSize": 27356
         },
         {
           "name": "JimboStd-BoldExpanded",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28564,
-          "url": "fonts/Jimbo Std/JimboStd-BoldExpanded.woff2"
+          "fileSize": 28564
         }
       ]
     },
@@ -10846,56 +9825,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18304,
-          "url": "fonts/Joanna MT Std/JoannaMTStd-Italic.woff2"
+          "fileSize": 18304
         },
         {
           "name": "JoannaMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17200,
-          "url": "fonts/Joanna MT Std/JoannaMTStd.woff2"
+          "fileSize": 17200
         },
         {
           "name": "JoannaMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18580,
-          "url": "fonts/Joanna MT Std/JoannaMTStd-BoldItalic.woff2"
+          "fileSize": 18580
         },
         {
           "name": "JoannaMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18620,
-          "url": "fonts/Joanna MT Std/JoannaMTStd-SemiBoldItalic.woff2"
+          "fileSize": 18620
         },
         {
           "name": "JoannaMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17468,
-          "url": "fonts/Joanna MT Std/JoannaMTStd-Bold.woff2"
+          "fileSize": 17468
         },
         {
           "name": "JoannaMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17664,
-          "url": "fonts/Joanna MT Std/JoannaMTStd-ExtraBold.woff2"
+          "fileSize": 17664
         },
         {
           "name": "JoannaMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17644,
-          "url": "fonts/Joanna MT Std/JoannaMTStd-SemiBold.woff2"
+          "fileSize": 17644
         }
       ]
     },
@@ -10914,8 +9886,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17332,
-          "url": "fonts/Juniper Std/JuniperStd.woff2"
+          "fileSize": 17332
         }
       ]
     },
@@ -10934,32 +9905,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14216,
-          "url": "fonts/Kabel LT Std/KabelLTStd-Light.woff2"
+          "fileSize": 14216
         },
         {
           "name": "KabelLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15168,
-          "url": "fonts/Kabel LT Std/KabelLTStd-Black.woff2"
+          "fileSize": 15168
         },
         {
           "name": "KabelLTStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14284,
-          "url": "fonts/Kabel LT Std/KabelLTStd-Book.woff2"
+          "fileSize": 14284
         },
         {
           "name": "KabelLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14744,
-          "url": "fonts/Kabel LT Std/KabelLTStd-Heavy.woff2"
+          "fileSize": 14744
         }
       ]
     },
@@ -10978,16 +9945,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21700,
-          "url": "fonts/Kaufmann Std/KaufmannStd.woff2"
+          "fileSize": 21700
         },
         {
           "name": "KaufmannStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21816,
-          "url": "fonts/Kaufmann Std/KaufmannStd-Bold.woff2"
+          "fileSize": 21816
         }
       ]
     },
@@ -11006,16 +9971,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27176,
-          "url": "fonts/Khaki Std/KhakiStd-1.woff2"
+          "fileSize": 27176
         },
         {
           "name": "KhakiStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33500,
-          "url": "fonts/Khaki Std/KhakiStd-2.woff2"
+          "fileSize": 33500
         }
       ]
     },
@@ -11034,24 +9997,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 49140,
-          "url": "fonts/Kigali Std/KigaliStd-Italic.woff2"
+          "fileSize": 49140
         },
         {
           "name": "KigaliStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47692,
-          "url": "fonts/Kigali Std/KigaliStd-Roman.woff2"
+          "fileSize": 47692
         },
         {
           "name": "KigaliStd-ZigZag",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67044,
-          "url": "fonts/Kigali Std/KigaliStd-ZigZag.woff2"
+          "fileSize": 67044
         }
       ]
     },
@@ -11070,80 +10030,70 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 39892,
-          "url": "fonts/Kinesis Std/KinesisStd-LightItalic.woff2"
+          "fileSize": 39892
         },
         {
           "name": "KinesisStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 38448,
-          "url": "fonts/Kinesis Std/KinesisStd-Light.woff2"
+          "fileSize": 38448
         },
         {
           "name": "KinesisStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 39060,
-          "url": "fonts/Kinesis Std/KinesisStd-BlackItalic.woff2"
+          "fileSize": 39060
         },
         {
           "name": "KinesisStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 41268,
-          "url": "fonts/Kinesis Std/KinesisStd-Italic.woff2"
+          "fileSize": 41268
         },
         {
           "name": "KinesisStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39184,
-          "url": "fonts/Kinesis Std/KinesisStd-Black.woff2"
+          "fileSize": 39184
         },
         {
           "name": "KinesisStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40320,
-          "url": "fonts/Kinesis Std/KinesisStd-Regular.woff2"
+          "fileSize": 40320
         },
         {
           "name": "KinesisStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 41464,
-          "url": "fonts/Kinesis Std/KinesisStd-BoldItalic.woff2"
+          "fileSize": 41464
         },
         {
           "name": "KinesisStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 42072,
-          "url": "fonts/Kinesis Std/KinesisStd-SemiboldItalic.woff2"
+          "fileSize": 42072
         },
         {
           "name": "KinesisStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40880,
-          "url": "fonts/Kinesis Std/KinesisStd-Bold.woff2"
+          "fileSize": 40880
         },
         {
           "name": "KinesisStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41224,
-          "url": "fonts/Kinesis Std/KinesisStd-Semibold.woff2"
+          "fileSize": 41224
         }
       ]
     },
@@ -11162,8 +10112,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15888,
-          "url": "fonts/Kino MT Std/KinoMTStd.woff2"
+          "fileSize": 15888
         }
       ]
     },
@@ -11182,8 +10131,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22780,
-          "url": "fonts/Klang MT Std/KlangMTStd.woff2"
+          "fileSize": 22780
         }
       ]
     },
@@ -11202,8 +10150,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22840,
-          "url": "fonts/Koch Antiqua LT Std/KochAntiquaLTStd.woff2"
+          "fileSize": 22840
         }
       ]
     },
@@ -11222,24 +10169,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20188,
-          "url": "fonts/Kolo LP Std/KoloLPStd-Narrow.woff2"
+          "fileSize": 20188
         },
         {
           "name": "KoloLPStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25940,
-          "url": "fonts/Kolo LP Std/KoloLPStd-Regular.woff2"
+          "fileSize": 25940
         },
         {
           "name": "KoloLPStd-Wide",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21496,
-          "url": "fonts/Kolo LP Std/KoloLPStd-Wide.woff2"
+          "fileSize": 21496
         }
       ]
     },
@@ -11258,8 +10202,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28296,
-          "url": "fonts/Kompakt LT Std/KompaktLTStd.woff2"
+          "fileSize": 28296
         }
       ]
     },
@@ -11278,24 +10221,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24808,
-          "url": "fonts/Kuenstler Script LT Std/KuenstlerScriptLTStd-Black.woff2"
+          "fileSize": 24808
         },
         {
           "name": "KuenstlerScriptLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24676,
-          "url": "fonts/Kuenstler Script LT Std/KuenstlerScriptLTStd-Medium.woff2"
+          "fileSize": 24676
         },
         {
           "name": "KuenstlerScriptLTStd-2Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25168,
-          "url": "fonts/Kuenstler Script LT Std/KuenstlerScriptLTStd-2Bold.woff2"
+          "fileSize": 25168
         }
       ]
     },
@@ -11314,8 +10254,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18884,
-          "url": "fonts/Latin MT Std/LatinMTStd-Condensed.woff2"
+          "fileSize": 18884
         }
       ]
     },
@@ -11334,16 +10273,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 52664,
-          "url": "fonts/Legault Std/LegaultStd.woff2"
+          "fileSize": 52664
         },
         {
           "name": "LegaultStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 51536,
-          "url": "fonts/Legault Std/LegaultStd-Bold.woff2"
+          "fileSize": 51536
         }
       ]
     },
@@ -11362,32 +10299,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21048,
-          "url": "fonts/Letter Gothic Std/LetterGothicStd.woff2"
+          "fileSize": 21048
         },
         {
           "name": "LetterGothicStd-Slanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22312,
-          "url": "fonts/Letter Gothic Std/LetterGothicStd-Slanted.woff2"
+          "fileSize": 22312
         },
         {
           "name": "LetterGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20744,
-          "url": "fonts/Letter Gothic Std/LetterGothicStd-Bold.woff2"
+          "fileSize": 20744
         },
         {
           "name": "LetterGothicStd-BoldSlanted",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22220,
-          "url": "fonts/Letter Gothic Std/LetterGothicStd-BoldSlanted.woff2"
+          "fileSize": 22220
         }
       ]
     },
@@ -11406,24 +10339,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20892,
-          "url": "fonts/Life LT Std/LifeLTStd-Italic.woff2"
+          "fileSize": 20892
         },
         {
           "name": "LifeLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19500,
-          "url": "fonts/Life LT Std/LifeLTStd-Roman.woff2"
+          "fileSize": 19500
         },
         {
           "name": "LifeLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19172,
-          "url": "fonts/Life LT Std/LifeLTStd-Bold.woff2"
+          "fileSize": 19172
         }
       ]
     },
@@ -11442,64 +10372,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24692,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-Italic.woff2"
+          "fileSize": 24692
         },
         {
           "name": "LinoLetterStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24668,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-MediumItalic.woff2"
+          "fileSize": 24668
         },
         {
           "name": "LinoLetterStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30052,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-Black.woff2"
+          "fileSize": 30052
         },
         {
           "name": "LinoLetterStd-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24680,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-BlackIt.woff2"
+          "fileSize": 24680
         },
         {
           "name": "LinoLetterStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29808,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-Medium.woff2"
+          "fileSize": 29808
         },
         {
           "name": "LinoLetterStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29500,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-Roman.woff2"
+          "fileSize": 29500
         },
         {
           "name": "LinoLetterStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24740,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-BoldItalic.woff2"
+          "fileSize": 24740
         },
         {
           "name": "LinoLetterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29880,
-          "url": "fonts/LinoLetter Std/LinoLetterStd-Bold.woff2"
+          "fileSize": 29880
         }
       ]
     },
@@ -11518,8 +10440,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23920,
-          "url": "fonts/Linoscript Std/LinoscriptStd.woff2"
+          "fileSize": 23920
         }
       ]
     },
@@ -11538,8 +10459,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27636,
-          "url": "fonts/Linotext Std/LinotextStd.woff2"
+          "fileSize": 27636
         }
       ]
     },
@@ -11558,16 +10478,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12932,
-          "url": "fonts/Linotype Astrology Pi Std/AstrologyPiLTStd-1.woff2"
+          "fileSize": 12932
         },
         {
           "name": "AstrologyPiLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40556,
-          "url": "fonts/Linotype Astrology Pi Std/AstrologyPiLTStd-2.woff2"
+          "fileSize": 40556
         }
       ]
     },
@@ -11586,8 +10504,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20088,
-          "url": "fonts/Linotype Audio Pi Std/AudioPiLTStd.woff2"
+          "fileSize": 20088
         }
       ]
     },
@@ -11606,64 +10523,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21692,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-LightItalic.woff2"
+          "fileSize": 21692
         },
         {
           "name": "CentennialLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25828,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Light.woff2"
+          "fileSize": 25828
         },
         {
           "name": "CentennialLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22060,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-BlackItalic.woff2"
+          "fileSize": 22060
         },
         {
           "name": "CentennialLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21292,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Italic.woff2"
+          "fileSize": 21292
         },
         {
           "name": "CentennialLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21268,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Black.woff2"
+          "fileSize": 21268
         },
         {
           "name": "CentennialLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26348,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Roman.woff2"
+          "fileSize": 26348
         },
         {
           "name": "CentennialLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20812,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-BoldItalic.woff2"
+          "fileSize": 20812
         },
         {
           "name": "CentennialLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20552,
-          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Bold.woff2"
+          "fileSize": 20552
         }
       ]
     },
@@ -11682,16 +10591,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18548,
-          "url": "fonts/Linotype Decoration Pi Std/DecorationPiLTStd-1.woff2"
+          "fileSize": 18548
         },
         {
           "name": "DecorationPiLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21388,
-          "url": "fonts/Linotype Decoration Pi Std/DecorationPiLTStd-2.woff2"
+          "fileSize": 21388
         }
       ]
     },
@@ -11710,40 +10617,35 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20912,
-          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Italic.woff2"
+          "fileSize": 20912
         },
         {
           "name": "DidotLTStd-Headline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24372,
-          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Headline.woff2"
+          "fileSize": 24372
         },
         {
           "name": "DidotLTStd-Ornaments",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 9340,
-          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Ornaments.woff2"
+          "fileSize": 9340
         },
         {
           "name": "DidotLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25000,
-          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Roman.woff2"
+          "fileSize": 25000
         },
         {
           "name": "DidotLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20140,
-          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Bold.woff2"
+          "fileSize": 20140
         }
       ]
     },
@@ -11762,32 +10664,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13752,
-          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-ChessDraughts.woff2"
+          "fileSize": 13752
         },
         {
           "name": "GamePiLTStd-DiceDominoes",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 5840,
-          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-DiceDominoes.woff2"
+          "fileSize": 5840
         },
         {
           "name": "GamePiLTStd-EnglishCards",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11060,
-          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-EnglishCards.woff2"
+          "fileSize": 11060
         },
         {
           "name": "GamePiLTStd-FrenchCards",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19152,
-          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-FrenchCards.woff2"
+          "fileSize": 19152
         }
       ]
     },
@@ -11806,24 +10704,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23428,
-          "url": "fonts/Linotype Holiday Pi Std/HolidayPiLTStd-1.woff2"
+          "fileSize": 23428
         },
         {
           "name": "HolidayPiLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18176,
-          "url": "fonts/Linotype Holiday Pi Std/HolidayPiLTStd-2.woff2"
+          "fileSize": 18176
         },
         {
           "name": "HolidayPiLTStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20112,
-          "url": "fonts/Linotype Holiday Pi Std/HolidayPiLTStd-3.woff2"
+          "fileSize": 20112
         }
       ]
     },
@@ -11842,8 +10737,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23944,
-          "url": "fonts/Linotype Warning Pi Std/WarningPiLTStd.woff2"
+          "fileSize": 23944
         }
       ]
     },
@@ -11862,40 +10756,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31044,
-          "url": "fonts/Lithos Pro/LithosPro-ExtraLight.woff2"
+          "fileSize": 31044
         },
         {
           "name": "LithosPro-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32004,
-          "url": "fonts/Lithos Pro/LithosPro-Light.woff2"
+          "fileSize": 32004
         },
         {
           "name": "LithosPro-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31912,
-          "url": "fonts/Lithos Pro/LithosPro-Black.woff2"
+          "fileSize": 31912
         },
         {
           "name": "LithosPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31488,
-          "url": "fonts/Lithos Pro/LithosPro-Regular.woff2"
+          "fileSize": 31488
         },
         {
           "name": "LithosPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31824,
-          "url": "fonts/Lithos Pro/LithosPro-Bold.woff2"
+          "fileSize": 31824
         }
       ]
     },
@@ -11914,24 +10803,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 12028,
-          "url": "fonts/Lucida Math Std/LucidaMathStd-Italic.woff2"
+          "fileSize": 12028
         },
         {
           "name": "LucidaMathStd-Extension",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8524,
-          "url": "fonts/Lucida Math Std/LucidaMathStd-Extension.woff2"
+          "fileSize": 8524
         },
         {
           "name": "LucidaMathStd-Symbol",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11444,
-          "url": "fonts/Lucida Math Std/LucidaMathStd-Symbol.woff2"
+          "fileSize": 11444
         }
       ]
     },
@@ -11950,32 +10836,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15940,
-          "url": "fonts/Lucida Sans Std/LucidaSansStd-Italic.woff2"
+          "fileSize": 15940
         },
         {
           "name": "LucidaSansStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15776,
-          "url": "fonts/Lucida Sans Std/LucidaSansStd.woff2"
+          "fileSize": 15776
         },
         {
           "name": "LucidaSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16344,
-          "url": "fonts/Lucida Sans Std/LucidaSansStd-BoldItalic.woff2"
+          "fileSize": 16344
         },
         {
           "name": "LucidaSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15876,
-          "url": "fonts/Lucida Sans Std/LucidaSansStd-Bold.woff2"
+          "fileSize": 15876
         }
       ]
     },
@@ -11994,32 +10876,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15620,
-          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd.woff2"
+          "fileSize": 15620
         },
         {
           "name": "LucidaSansTypewriterStd-Bd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16032,
-          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd-Bd.woff2"
+          "fileSize": 16032
         },
         {
           "name": "LucidaSansTypewriterStd-BOb",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16744,
-          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd-BOb.woff2"
+          "fileSize": 16744
         },
         {
           "name": "LucidaSansTypewriterStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16440,
-          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd-Obl.woff2"
+          "fileSize": 16440
         }
       ]
     },
@@ -12038,32 +10916,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18484,
-          "url": "fonts/Lucida Std/LucidaStd-Italic.woff2"
+          "fileSize": 18484
         },
         {
           "name": "LucidaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18008,
-          "url": "fonts/Lucida Std/LucidaStd.woff2"
+          "fileSize": 18008
         },
         {
           "name": "LucidaStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18776,
-          "url": "fonts/Lucida Std/LucidaStd-BoldItalic.woff2"
+          "fileSize": 18776
         },
         {
           "name": "LucidaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18592,
-          "url": "fonts/Lucida Std/LucidaStd-Bold.woff2"
+          "fileSize": 18592
         }
       ]
     },
@@ -12082,32 +10956,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17284,
-          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd.woff2"
+          "fileSize": 17284
         },
         {
           "name": "LucidaTypewriterStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17836,
-          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd-Obl.woff2"
+          "fileSize": 17836
         },
         {
           "name": "LucidaTypewriterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17296,
-          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd-Bold.woff2"
+          "fileSize": 17296
         },
         {
           "name": "LucidaTypewriterStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17992,
-          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd-BoldObl.woff2"
+          "fileSize": 17992
         }
       ]
     },
@@ -12126,8 +10996,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23116,
-          "url": "fonts/Madrone Std/MadroneStd.woff2"
+          "fileSize": 23116
         }
       ]
     },
@@ -12146,16 +11015,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14540,
-          "url": "fonts/Magnesium MVB Std/MagnesiumMVBStd.woff2"
+          "fileSize": 14540
         },
         {
           "name": "MagnesiumMVBStd-Grime",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 112300,
-          "url": "fonts/Magnesium MVB Std/MagnesiumMVBStd-Grime.woff2"
+          "fileSize": 112300
         }
       ]
     },
@@ -12174,8 +11041,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17884,
-          "url": "fonts/Magnolia MVB Std/MagnoliaMVBStd.woff2"
+          "fileSize": 17884
         }
       ]
     },
@@ -12194,8 +11060,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23396,
-          "url": "fonts/Manito LP Std/ManitoLPStd.woff2"
+          "fileSize": 23396
         }
       ]
     },
@@ -12214,8 +11079,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58680,
-          "url": "fonts/Mathematical Pi LT Std/MathematicalPiLTStd.woff2"
+          "fileSize": 58680
         }
       ]
     },
@@ -12234,8 +11098,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29544,
-          "url": "fonts/Matura MT Std/MaturaMTStd.woff2"
+          "fileSize": 29544
         }
       ]
     },
@@ -12254,8 +11117,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18460,
-          "url": "fonts/Maximus LT Std/MaximusLTStd.woff2"
+          "fileSize": 18460
         }
       ]
     },
@@ -12274,8 +11136,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21876,
-          "url": "fonts/Medici Script LT Std/MediciScriptLTStd.woff2"
+          "fileSize": 21876
         }
       ]
     },
@@ -12294,32 +11155,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21528,
-          "url": "fonts/Melior LT Std/MeliorLTStd-Italic.woff2"
+          "fileSize": 21528
         },
         {
           "name": "MeliorLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19284,
-          "url": "fonts/Melior LT Std/MeliorLTStd.woff2"
+          "fileSize": 19284
         },
         {
           "name": "MeliorLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20972,
-          "url": "fonts/Melior LT Std/MeliorLTStd-BoldItalic.woff2"
+          "fileSize": 20972
         },
         {
           "name": "MeliorLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19872,
-          "url": "fonts/Melior LT Std/MeliorLTStd-Bold.woff2"
+          "fileSize": 19872
         }
       ]
     },
@@ -12338,56 +11195,49 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17240,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-LightItalic.woff2"
+          "fileSize": 17240
         },
         {
           "name": "MemphisLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16512,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-Light.woff2"
+          "fileSize": 16512
         },
         {
           "name": "MemphisLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17256,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-MediumItalic.woff2"
+          "fileSize": 17256
         },
         {
           "name": "MemphisLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16628,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-Medium.woff2"
+          "fileSize": 16628
         },
         {
           "name": "MemphisLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17328,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-BoldItalic.woff2"
+          "fileSize": 17328
         },
         {
           "name": "MemphisLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16668,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-Bold.woff2"
+          "fileSize": 16668
         },
         {
           "name": "MemphisLTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17376,
-          "url": "fonts/Memphis LT Std/MemphisLTStd-ExtraBold.woff2"
+          "fileSize": 17376
         }
       ]
     },
@@ -12406,8 +11256,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20128,
-          "url": "fonts/Mercurius MT Std/MercuriusMTStd-BoldScript.woff2"
+          "fileSize": 20128
         }
       ]
     },
@@ -12426,48 +11275,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20904,
-          "url": "fonts/Meridien LT Std/MeridienLTStd-Italic.woff2"
+          "fileSize": 20904
         },
         {
           "name": "MeridienLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21056,
-          "url": "fonts/Meridien LT Std/MeridienLTStd-MediumItalic.woff2"
+          "fileSize": 21056
         },
         {
           "name": "MeridienLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20292,
-          "url": "fonts/Meridien LT Std/MeridienLTStd-Medium.woff2"
+          "fileSize": 20292
         },
         {
           "name": "MeridienLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20664,
-          "url": "fonts/Meridien LT Std/MeridienLTStd-Roman.woff2"
+          "fileSize": 20664
         },
         {
           "name": "MeridienLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21088,
-          "url": "fonts/Meridien LT Std/MeridienLTStd-BoldItalic.woff2"
+          "fileSize": 21088
         },
         {
           "name": "MeridienLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20688,
-          "url": "fonts/Meridien LT Std/MeridienLTStd-Bold.woff2"
+          "fileSize": 20688
         }
       ]
     },
@@ -12486,8 +11329,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26964,
-          "url": "fonts/Mesquite Std/MesquiteStd.woff2"
+          "fileSize": 26964
         }
       ]
     },
@@ -12506,40 +11348,35 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25720,
-          "url": "fonts/Mezz Std/MezzStd-Light.woff2"
+          "fileSize": 25720
         },
         {
           "name": "MezzStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25868,
-          "url": "fonts/Mezz Std/MezzStd-Black.woff2"
+          "fileSize": 25868
         },
         {
           "name": "MezzStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27440,
-          "url": "fonts/Mezz Std/MezzStd-Regular.woff2"
+          "fileSize": 27440
         },
         {
           "name": "MezzStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27260,
-          "url": "fonts/Mezz Std/MezzStd-Bold.woff2"
+          "fileSize": 27260
         },
         {
           "name": "MezzStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27128,
-          "url": "fonts/Mezz Std/MezzStd-Semibold.woff2"
+          "fileSize": 27128
         }
       ]
     },
@@ -12558,8 +11395,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1940,
-          "url": "fonts/MICR Std/MICRStd.woff2"
+          "fileSize": 1940
         }
       ]
     },
@@ -12578,8 +11414,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28972,
-          "url": "fonts/Minion Std/MinionStd-Black.woff2"
+          "fileSize": 28972
         }
       ]
     },
@@ -12598,64 +11433,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21360,
-          "url": "fonts/Minister Std/MinisterStd-LightItalic.woff2"
+          "fileSize": 21360
         },
         {
           "name": "MinisterStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20168,
-          "url": "fonts/Minister Std/MinisterStd-Light.woff2"
+          "fileSize": 20168
         },
         {
           "name": "MinisterStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21560,
-          "url": "fonts/Minister Std/MinisterStd-BlackItalic.woff2"
+          "fileSize": 21560
         },
         {
           "name": "MinisterStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21508,
-          "url": "fonts/Minister Std/MinisterStd-BookItalic.woff2"
+          "fileSize": 21508
         },
         {
           "name": "MinisterStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20660,
-          "url": "fonts/Minister Std/MinisterStd-Black.woff2"
+          "fileSize": 20660
         },
         {
           "name": "MinisterStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20276,
-          "url": "fonts/Minister Std/MinisterStd-Book.woff2"
+          "fileSize": 20276
         },
         {
           "name": "MinisterStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21560,
-          "url": "fonts/Minister Std/MinisterStd-BoldItalic.woff2"
+          "fileSize": 21560
         },
         {
           "name": "MinisterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20760,
-          "url": "fonts/Minister Std/MinisterStd-Bold.woff2"
+          "fileSize": 20760
         }
       ]
     },
@@ -12674,8 +11501,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31124,
-          "url": "fonts/Mistral Std/MistralStd.woff2"
+          "fileSize": 31124
         }
       ]
     },
@@ -12694,8 +11520,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17532,
-          "url": "fonts/Mojo Std/MojoStd.woff2"
+          "fileSize": 17532
         }
       ]
     },
@@ -12714,8 +11539,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29196,
-          "url": "fonts/Monoline Script MT Std/MonolineScriptMTStd.woff2"
+          "fileSize": 29196
         }
       ]
     },
@@ -12734,64 +11558,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22156,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-CondensedItalic.woff2"
+          "fileSize": 22156
         },
         {
           "name": "ModernMTStd-ExtendedItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23100,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-ExtendedItalic.woff2"
+          "fileSize": 23100
         },
         {
           "name": "ModernMTStd-WideItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22204,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-WideItalic.woff2"
+          "fileSize": 22204
         },
         {
           "name": "ModernMTStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20588,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-Condensed.woff2"
+          "fileSize": 20588
         },
         {
           "name": "ModernMTStd-Extended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22024,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-Extended.woff2"
+          "fileSize": 22024
         },
         {
           "name": "ModernMTStd-Wide",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20720,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-Wide.woff2"
+          "fileSize": 20720
         },
         {
           "name": "ModernMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23480,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-BoldItalic.woff2"
+          "fileSize": 23480
         },
         {
           "name": "ModernMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21808,
-          "url": "fonts/Monotype Modern Std/ModernMTStd-Bold.woff2"
+          "fileSize": 21808
         }
       ]
     },
@@ -12810,8 +11626,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33892,
-          "url": "fonts/Monotype Old Style MT Std/MonotypeOldStyleMTStd-BdOut.woff2"
+          "fileSize": 33892
         }
       ]
     },
@@ -12830,40 +11645,35 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 26352,
-          "url": "fonts/Montara Std/Montara-Italic.woff2"
+          "fileSize": 26352
         },
         {
           "name": "Montara-Gothic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26788,
-          "url": "fonts/Montara Std/Montara-Gothic.woff2"
+          "fileSize": 26788
         },
         {
           "name": "Montara-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25780,
-          "url": "fonts/Montara Std/Montara-BoldItalic.woff2"
+          "fileSize": 25780
         },
         {
           "name": "Montara-BoldGothic",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26012,
-          "url": "fonts/Montara Std/Montara-BoldGothic.woff2"
+          "fileSize": 26012
         },
         {
           "name": "Montara-BoldInitials",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44264,
-          "url": "fonts/Montara Std/Montara-BoldInitials.woff2"
+          "fileSize": 44264
         }
       ]
     },
@@ -12882,96 +11692,84 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32008,
-          "url": "fonts/Moonglow Std/Moonglow-Light.woff2"
+          "fileSize": 32008
         },
         {
           "name": "Moonglow-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31428,
-          "url": "fonts/Moonglow Std/Moonglow-LightCond.woff2"
+          "fileSize": 31428
         },
         {
           "name": "Moonglow-LightExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31184,
-          "url": "fonts/Moonglow Std/Moonglow-LightExt.woff2"
+          "fileSize": 31184
         },
         {
           "name": "Moonglow-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32428,
-          "url": "fonts/Moonglow Std/Moonglow-Cond.woff2"
+          "fileSize": 32428
         },
         {
           "name": "Moonglow-Ext",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32684,
-          "url": "fonts/Moonglow Std/Moonglow-Ext.woff2"
+          "fileSize": 32684
         },
         {
           "name": "Moonglow-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32404,
-          "url": "fonts/Moonglow Std/Moonglow-Regular.woff2"
+          "fileSize": 32404
         },
         {
           "name": "Moonglow-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32572,
-          "url": "fonts/Moonglow Std/Moonglow-Bold.woff2"
+          "fileSize": 32572
         },
         {
           "name": "Moonglow-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31956,
-          "url": "fonts/Moonglow Std/Moonglow-BoldCond.woff2"
+          "fileSize": 31956
         },
         {
           "name": "Moonglow-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31020,
-          "url": "fonts/Moonglow Std/Moonglow-BoldExt.woff2"
+          "fileSize": 31020
         },
         {
           "name": "Moonglow-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33028,
-          "url": "fonts/Moonglow Std/Moonglow-Semibold.woff2"
+          "fileSize": 33028
         },
         {
           "name": "Moonglow-SemiboldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32584,
-          "url": "fonts/Moonglow Std/Moonglow-SemiboldCond.woff2"
+          "fileSize": 32584
         },
         {
           "name": "Moonglow-SemiboldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32492,
-          "url": "fonts/Moonglow Std/Moonglow-SemiboldExt.woff2"
+          "fileSize": 32492
         }
       ]
     },
@@ -12990,24 +11788,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29568,
-          "url": "fonts/Motter Corpus Std/MotterCorpusStd-Condensed.woff2"
+          "fileSize": 29568
         },
         {
           "name": "MotterCorpusStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30420,
-          "url": "fonts/Motter Corpus Std/MotterCorpusStd-Regular.woff2"
+          "fileSize": 30420
         },
         {
           "name": "MotterCorpusStd-SemiCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31304,
-          "url": "fonts/Motter Corpus Std/MotterCorpusStd-SemiCond.woff2"
+          "fileSize": 31304
         }
       ]
     },
@@ -13026,320 +11821,280 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41736,
-          "url": "fonts/Myriad Pro/MyriadPro-Light.woff2"
+          "fileSize": 41736
         },
         {
           "name": "MyriadPro-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39684,
-          "url": "fonts/Myriad Pro/MyriadPro-LightCond.woff2"
+          "fileSize": 39684
         },
         {
           "name": "MyriadPro-LightCondIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42136,
-          "url": "fonts/Myriad Pro/MyriadPro-LightCondIt.woff2"
+          "fileSize": 42136
         },
         {
           "name": "MyriadPro-LightIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44372,
-          "url": "fonts/Myriad Pro/MyriadPro-LightIt.woff2"
+          "fileSize": 44372
         },
         {
           "name": "MyriadPro-LightSemiCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43612,
-          "url": "fonts/Myriad Pro/MyriadPro-LightSemiCn.woff2"
+          "fileSize": 43612
         },
         {
           "name": "MyriadPro-LightSemiCnIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46292,
-          "url": "fonts/Myriad Pro/MyriadPro-LightSemiCnIt.woff2"
+          "fileSize": 46292
         },
         {
           "name": "MyriadPro-LightSemiExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40668,
-          "url": "fonts/Myriad Pro/MyriadPro-LightSemiExt.woff2"
+          "fileSize": 40668
         },
         {
           "name": "MyriadPro-LightSemiExtIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43420,
-          "url": "fonts/Myriad Pro/MyriadPro-LightSemiExtIt.woff2"
+          "fileSize": 43420
         },
         {
           "name": "MyriadPro-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43096,
-          "url": "fonts/Myriad Pro/MyriadPro-Black.woff2"
+          "fileSize": 43096
         },
         {
           "name": "MyriadPro-BlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41856,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackCond.woff2"
+          "fileSize": 41856
         },
         {
           "name": "MyriadPro-BlackCondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44112,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackCondIt.woff2"
+          "fileSize": 44112
         },
         {
           "name": "MyriadPro-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45860,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackIt.woff2"
+          "fileSize": 45860
         },
         {
           "name": "MyriadPro-BlackSemiCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45284,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiCn.woff2"
+          "fileSize": 45284
         },
         {
           "name": "MyriadPro-BlackSemiCnIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47640,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiCnIt.woff2"
+          "fileSize": 47640
         },
         {
           "name": "MyriadPro-BlackSemiExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42368,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiExt.woff2"
+          "fileSize": 42368
         },
         {
           "name": "MyriadPro-BlackSemiExtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44260,
-          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiExtIt.woff2"
+          "fileSize": 44260
         },
         {
           "name": "MyriadPro-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41712,
-          "url": "fonts/Myriad Pro/MyriadPro-Cond.woff2"
+          "fileSize": 41712
         },
         {
           "name": "MyriadPro-CondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44508,
-          "url": "fonts/Myriad Pro/MyriadPro-CondIt.woff2"
+          "fileSize": 44508
         },
         {
           "name": "MyriadPro-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45008,
-          "url": "fonts/Myriad Pro/MyriadPro-It.woff2"
+          "fileSize": 45008
         },
         {
           "name": "MyriadPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42548,
-          "url": "fonts/Myriad Pro/MyriadPro-Regular.woff2"
+          "fileSize": 42548
         },
         {
           "name": "MyriadPro-SemiCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44464,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiCn.woff2"
+          "fileSize": 44464
         },
         {
           "name": "MyriadPro-SemiCnIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47112,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiCnIt.woff2"
+          "fileSize": 47112
         },
         {
           "name": "MyriadPro-SemiExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42780,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiExt.woff2"
+          "fileSize": 42780
         },
         {
           "name": "MyriadPro-SemiExtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45012,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiExtIt.woff2"
+          "fileSize": 45012
         },
         {
           "name": "MyriadPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43112,
-          "url": "fonts/Myriad Pro/MyriadPro-Bold.woff2"
+          "fileSize": 43112
         },
         {
           "name": "MyriadPro-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42332,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldCond.woff2"
+          "fileSize": 42332
         },
         {
           "name": "MyriadPro-BoldCondIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45360,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldCondIt.woff2"
+          "fileSize": 45360
         },
         {
           "name": "MyriadPro-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45404,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldIt.woff2"
+          "fileSize": 45404
         },
         {
           "name": "MyriadPro-BoldSemiCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44852,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiCn.woff2"
+          "fileSize": 44852
         },
         {
           "name": "MyriadPro-BoldSemiCnIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 48004,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiCnIt.woff2"
+          "fileSize": 48004
         },
         {
           "name": "MyriadPro-BoldSemiExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43040,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiExt.woff2"
+          "fileSize": 43040
         },
         {
           "name": "MyriadPro-BoldSemiExtIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45368,
-          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiExtIt.woff2"
+          "fileSize": 45368
         },
         {
           "name": "MyriadPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43016,
-          "url": "fonts/Myriad Pro/MyriadPro-Semibold.woff2"
+          "fileSize": 43016
         },
         {
           "name": "MyriadPro-SemiboldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41960,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldCond.woff2"
+          "fileSize": 41960
         },
         {
           "name": "MyriadPro-SemiboldCondIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45072,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldCondIt.woff2"
+          "fileSize": 45072
         },
         {
           "name": "MyriadPro-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45428,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldIt.woff2"
+          "fileSize": 45428
         },
         {
           "name": "MyriadPro-SemiboldSemiCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44664,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiCn.woff2"
+          "fileSize": 44664
         },
         {
           "name": "MyriadPro-SemiboldSemiCnIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47652,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiCnIt.woff2"
+          "fileSize": 47652
         },
         {
           "name": "MyriadPro-SemiboldSemiExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42936,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiExt.woff2"
+          "fileSize": 42936
         },
         {
           "name": "MyriadPro-SemiboldSemiExtIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45544,
-          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiExtIt.woff2"
+          "fileSize": 45544
         }
       ]
     },
@@ -13358,16 +12113,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 49964,
-          "url": "fonts/Myriad Std/MyriadStd-Sketch.woff2"
+          "fileSize": 49964
         },
         {
           "name": "MyriadStd-Tilt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20096,
-          "url": "fonts/Myriad Std/MyriadStd-Tilt.woff2"
+          "fileSize": 20096
         }
       ]
     },
@@ -13386,8 +12139,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41024,
-          "url": "fonts/Mythos Std/MythosStd.woff2"
+          "fileSize": 41024
         }
       ]
     },
@@ -13406,8 +12158,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21528,
-          "url": "fonts/National Code Pi Std/NationalCodePiStd-Universal.woff2"
+          "fileSize": 21528
         }
       ]
     },
@@ -13426,8 +12177,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39312,
-          "url": "fonts/Neue Hammer Unziale LT Std/NeueHammerUnzialeLTStd.woff2"
+          "fileSize": 39312
         }
       ]
     },
@@ -13446,8 +12196,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17500,
-          "url": "fonts/Neuland LT Std/NeulandLTStd.woff2"
+          "fileSize": 17500
         }
       ]
     },
@@ -13466,16 +12215,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15584,
-          "url": "fonts/Neuzeit S LT Std/NeuzeitSLTStd-Book.woff2"
+          "fileSize": 15584
         },
         {
           "name": "NeuzeitSLTStd-BookHeavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15872,
-          "url": "fonts/Neuzeit S LT Std/NeuzeitSLTStd-BookHeavy.woff2"
+          "fileSize": 15872
         }
       ]
     },
@@ -13494,64 +12241,56 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20344,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd.woff2"
+          "fileSize": 20344
         },
         {
           "name": "NewAsterLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20112,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-Black.woff2"
+          "fileSize": 20112
         },
         {
           "name": "NewAsterLTStd-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20732,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-BlackIt.woff2"
+          "fileSize": 20732
         },
         {
           "name": "NewAsterLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21060,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-It.woff2"
+          "fileSize": 21060
         },
         {
           "name": "NewAsterLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20212,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-Bold.woff2"
+          "fileSize": 20212
         },
         {
           "name": "NewAsterLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20948,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-BoldIt.woff2"
+          "fileSize": 20948
         },
         {
           "name": "NewAsterLTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20252,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-SemiBold.woff2"
+          "fileSize": 20252
         },
         {
           "name": "NewAsterLTStd-SemiBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20696,
-          "url": "fonts/New Aster LT Std/NewAsterLTStd-SemiBoldIt.woff2"
+          "fileSize": 20696
         }
       ]
     },
@@ -13570,8 +12309,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25872,
-          "url": "fonts/New Berolina MT Std/NewBerolinaMTStd.woff2"
+          "fileSize": 25872
         }
       ]
     },
@@ -13590,64 +12328,56 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28456,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd.woff2"
+          "fileSize": 28456
         },
         {
           "name": "NewCaledoniaLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21636,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-Black.woff2"
+          "fileSize": 21636
         },
         {
           "name": "NewCaledoniaLTStd-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23484,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-BlackIt.woff2"
+          "fileSize": 23484
         },
         {
           "name": "NewCaledoniaLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24752,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-It.woff2"
+          "fileSize": 24752
         },
         {
           "name": "NewCaledoniaLTStd-SemiBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22068,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-SemiBd.woff2"
+          "fileSize": 22068
         },
         {
           "name": "NewCaledoniaLTStd-SemiBdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22800,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-SemiBdIt.woff2"
+          "fileSize": 22800
         },
         {
           "name": "NewCaledoniaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28848,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-Bold.woff2"
+          "fileSize": 28848
         },
         {
           "name": "NewCaledoniaLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25164,
-          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-BoldIt.woff2"
+          "fileSize": 25164
         }
       ]
     },
@@ -13666,48 +12396,42 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19736,
-          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-Bd.woff2"
+          "fileSize": 19736
         },
         {
           "name": "NewCenturySchlbkLTStd-BdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20764,
-          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-BdIt.woff2"
+          "fileSize": 20764
         },
         {
           "name": "NewCenturySchlbkLTStd-Fra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8768,
-          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-Fra.woff2"
+          "fileSize": 8768
         },
         {
           "name": "NewCenturySchlbkLTStd-FraBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8900,
-          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-FraBd.woff2"
+          "fileSize": 8900
         },
         {
           "name": "NewCenturySchlbkLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20888,
-          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-It.woff2"
+          "fileSize": 20888
         },
         {
           "name": "NewCenturySchlbkLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19904,
-          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-Roman.woff2"
+          "fileSize": 19904
         }
       ]
     },
@@ -13726,32 +12450,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14452,
-          "url": "fonts/News Gothic Std/NewsGothicStd.woff2"
+          "fileSize": 14452
         },
         {
           "name": "NewsGothicStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15988,
-          "url": "fonts/News Gothic Std/NewsGothicStd-Oblique.woff2"
+          "fileSize": 15988
         },
         {
           "name": "NewsGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14728,
-          "url": "fonts/News Gothic Std/NewsGothicStd-Bold.woff2"
+          "fileSize": 14728
         },
         {
           "name": "NewsGothicStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15872,
-          "url": "fonts/News Gothic Std/NewsGothicStd-BoldOblique.woff2"
+          "fileSize": 15872
         }
       ]
     },
@@ -13770,16 +12490,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 3544,
-          "url": "fonts/Notre Dame LT Std/NotreDameLTStd-Ornaments.woff2"
+          "fileSize": 3544
         },
         {
           "name": "NotreDameLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27008,
-          "url": "fonts/Notre Dame LT Std/NotreDameLTStd-Roman.woff2"
+          "fileSize": 27008
         }
       ]
     },
@@ -13798,144 +12516,126 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30648,
-          "url": "fonts/Nueva Std/NuevaStd-LightCondItalic.woff2"
+          "fileSize": 30648
         },
         {
           "name": "NuevaStd-LightItalic",
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32184,
-          "url": "fonts/Nueva Std/NuevaStd-LightItalic.woff2"
+          "fileSize": 32184
         },
         {
           "name": "NuevaStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32308,
-          "url": "fonts/Nueva Std/NuevaStd-Light.woff2"
+          "fileSize": 32308
         },
         {
           "name": "NuevaStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30800,
-          "url": "fonts/Nueva Std/NuevaStd-LightCond.woff2"
+          "fileSize": 30800
         },
         {
           "name": "NuevaStd-LightExtended",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32096,
-          "url": "fonts/Nueva Std/NuevaStd-LightExtended.woff2"
+          "fileSize": 32096
         },
         {
           "name": "NuevaStd-LightExtendedItal",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32200,
-          "url": "fonts/Nueva Std/NuevaStd-LightExtendedItal.woff2"
+          "fileSize": 32200
         },
         {
           "name": "NuevaStd-CondItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31132,
-          "url": "fonts/Nueva Std/NuevaStd-CondItalic.woff2"
+          "fileSize": 31132
         },
         {
           "name": "NuevaStd-ExtendedItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32796,
-          "url": "fonts/Nueva Std/NuevaStd-ExtendedItalic.woff2"
+          "fileSize": 32796
         },
         {
           "name": "NuevaStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32472,
-          "url": "fonts/Nueva Std/NuevaStd-Italic.woff2"
+          "fileSize": 32472
         },
         {
           "name": "NuevaStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31500,
-          "url": "fonts/Nueva Std/NuevaStd-Cond.woff2"
+          "fileSize": 31500
         },
         {
           "name": "NuevaStd-Extended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32384,
-          "url": "fonts/Nueva Std/NuevaStd-Extended.woff2"
+          "fileSize": 32384
         },
         {
           "name": "NuevaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32328,
-          "url": "fonts/Nueva Std/NuevaStd-Regular.woff2"
+          "fileSize": 32328
         },
         {
           "name": "NuevaStd-BoldCondItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30984,
-          "url": "fonts/Nueva Std/NuevaStd-BoldCondItalic.woff2"
+          "fileSize": 30984
         },
         {
           "name": "NuevaStd-BoldExtendedItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32052,
-          "url": "fonts/Nueva Std/NuevaStd-BoldExtendedItalic.woff2"
+          "fileSize": 32052
         },
         {
           "name": "NuevaStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32280,
-          "url": "fonts/Nueva Std/NuevaStd-BoldItalic.woff2"
+          "fileSize": 32280
         },
         {
           "name": "NuevaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32092,
-          "url": "fonts/Nueva Std/NuevaStd-Bold.woff2"
+          "fileSize": 32092
         },
         {
           "name": "NuevaStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30756,
-          "url": "fonts/Nueva Std/NuevaStd-BoldCond.woff2"
+          "fileSize": 30756
         },
         {
           "name": "NuevaStd-BoldExtended",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32140,
-          "url": "fonts/Nueva Std/NuevaStd-BoldExtended.woff2"
+          "fileSize": 32140
         }
       ]
     },
@@ -13954,8 +12654,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23000,
-          "url": "fonts/Nuptial Script LT Std/NuptialScriptLTStd.woff2"
+          "fileSize": 23000
         }
       ]
     },
@@ -13974,8 +12673,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20644,
-          "url": "fonts/Nyx Std/NyxStd.woff2"
+          "fileSize": 20644
         }
       ]
     },
@@ -13994,192 +12692,168 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16160,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-Light.woff2"
+          "fileSize": 16160
         },
         {
           "name": "OceanSansStd-LightExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16560,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-LightExt.woff2"
+          "fileSize": 16560
         },
         {
           "name": "OceanSansStd-LightExtIta",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17232,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-LightExtIta.woff2"
+          "fileSize": 17232
         },
         {
           "name": "OceanSansStd-LightIta",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17308,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-LightIta.woff2"
+          "fileSize": 17308
         },
         {
           "name": "OceanSansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17028,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-Book.woff2"
+          "fileSize": 17028
         },
         {
           "name": "OceanSansStd-BookExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17204,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BookExt.woff2"
+          "fileSize": 17204
         },
         {
           "name": "OceanSansStd-BookExtIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18208,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BookExtIta.woff2"
+          "fileSize": 18208
         },
         {
           "name": "OceanSansStd-BookIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18156,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BookIta.woff2"
+          "fileSize": 18156
         },
         {
           "name": "OceanSansStd-BookSemiExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17456,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BookSemiExt.woff2"
+          "fileSize": 17456
         },
         {
           "name": "OceanSansStd-BookSemiExtIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18604,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BookSemiExtIta.woff2"
+          "fileSize": 18604
         },
         {
           "name": "OceanSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17080,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-Bold.woff2"
+          "fileSize": 17080
         },
         {
           "name": "OceanSansStd-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17336,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldExt.woff2"
+          "fileSize": 17336
         },
         {
           "name": "OceanSansStd-BoldExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18548,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldExtIta.woff2"
+          "fileSize": 18548
         },
         {
           "name": "OceanSansStd-BoldIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18036,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldIta.woff2"
+          "fileSize": 18036
         },
         {
           "name": "OceanSansStd-BoldSemiExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17280,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldSemiExt.woff2"
+          "fileSize": 17280
         },
         {
           "name": "OceanSansStd-BoldSemiExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18476,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldSemiExtIta.woff2"
+          "fileSize": 18476
         },
         {
           "name": "OceanSansStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17300,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-Semibold.woff2"
+          "fileSize": 17300
         },
         {
           "name": "OceanSansStd-SemiboldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17240,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-SemiboldExt.woff2"
+          "fileSize": 17240
         },
         {
           "name": "OceanSansStd-SemiboldExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18352,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-SemiboldExtIta.woff2"
+          "fileSize": 18352
         },
         {
           "name": "OceanSansStd-SemiboldIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18452,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-SemiboldIta.woff2"
+          "fileSize": 18452
         },
         {
           "name": "OceanSansStd-XBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16364,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-XBold.woff2"
+          "fileSize": 16364
         },
         {
           "name": "OceanSansStd-XBoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16516,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-XBoldExt.woff2"
+          "fileSize": 16516
         },
         {
           "name": "OceanSansStd-XBoldExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17416,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-XBoldExtIta.woff2"
+          "fileSize": 17416
         },
         {
           "name": "OceanSansStd-XBoldIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17288,
-          "url": "fonts/Ocean Sans Std/OceanSansStd-XBoldIta.woff2"
+          "fileSize": 17288
         }
       ]
     },
@@ -14198,8 +12872,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14644,
-          "url": "fonts/OCRA Std/OCRAStd.woff2"
+          "fileSize": 14644
         }
       ]
     },
@@ -14218,8 +12891,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14992,
-          "url": "fonts/OCRB Std/OCRBStd.woff2"
+          "fileSize": 14992
         }
       ]
     },
@@ -14238,16 +12910,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30520,
-          "url": "fonts/Octavian MT Std/OctavianMTStd-Italic.woff2"
+          "fileSize": 30520
         },
         {
           "name": "OctavianMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34852,
-          "url": "fonts/Octavian MT Std/OctavianMTStd.woff2"
+          "fileSize": 34852
         }
       ]
     },
@@ -14266,8 +12936,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 74084,
-          "url": "fonts/Old Claude LP Std/OldClaudeLPStd.woff2"
+          "fileSize": 74084
         }
       ]
     },
@@ -14286,16 +12955,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22128,
-          "url": "fonts/Old Style 7 Std/OldStyle7Std-Italic.woff2"
+          "fileSize": 22128
         },
         {
           "name": "OldStyle7Std",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25476,
-          "url": "fonts/Old Style 7 Std/OldStyle7Std.woff2"
+          "fileSize": 25476
         }
       ]
     },
@@ -14314,32 +12981,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20628,
-          "url": "fonts/Olympian LT Std/OlympianLTStd-Italic.woff2"
+          "fileSize": 20628
         },
         {
           "name": "OlympianLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19840,
-          "url": "fonts/Olympian LT Std/OlympianLTStd.woff2"
+          "fileSize": 19840
         },
         {
           "name": "OlympianLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20528,
-          "url": "fonts/Olympian LT Std/OlympianLTStd-BoldItalic.woff2"
+          "fileSize": 20528
         },
         {
           "name": "OlympianLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19988,
-          "url": "fonts/Olympian LT Std/OlympianLTStd-Bold.woff2"
+          "fileSize": 19988
         }
       ]
     },
@@ -14358,8 +13021,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16540,
-          "url": "fonts/Omnia LT Std/OmniaLTStd.woff2"
+          "fileSize": 16540
         }
       ]
     },
@@ -14378,8 +13040,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23648,
-          "url": "fonts/Ondine LT Std/OndineLTStd.woff2"
+          "fileSize": 23648
         }
       ]
     },
@@ -14398,8 +13059,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21444,
-          "url": "fonts/Onyx MT Std/OnyxMTStd.woff2"
+          "fileSize": 21444
         }
       ]
     },
@@ -14418,96 +13078,84 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21928,
-          "url": "fonts/Optima LT Std/OptimaLTStd-BlackItalic.woff2"
+          "fileSize": 21928
         },
         {
           "name": "OptimaLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21372,
-          "url": "fonts/Optima LT Std/OptimaLTStd-Italic.woff2"
+          "fileSize": 21372
         },
         {
           "name": "OptimaLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22948,
-          "url": "fonts/Optima LT Std/OptimaLTStd-MediumItalic.woff2"
+          "fileSize": 22948
         },
         {
           "name": "OptimaLTStd-XBlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22240,
-          "url": "fonts/Optima LT Std/OptimaLTStd-XBlackItalic.woff2"
+          "fileSize": 22240
         },
         {
           "name": "OptimaLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20008,
-          "url": "fonts/Optima LT Std/OptimaLTStd.woff2"
+          "fileSize": 20008
         },
         {
           "name": "OptimaLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22412,
-          "url": "fonts/Optima LT Std/OptimaLTStd-Black.woff2"
+          "fileSize": 22412
         },
         {
           "name": "OptimaLTStd-ExtraBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22088,
-          "url": "fonts/Optima LT Std/OptimaLTStd-ExtraBlack.woff2"
+          "fileSize": 22088
         },
         {
           "name": "OptimaLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22884,
-          "url": "fonts/Optima LT Std/OptimaLTStd-Medium.woff2"
+          "fileSize": 22884
         },
         {
           "name": "OptimaLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22076,
-          "url": "fonts/Optima LT Std/OptimaLTStd-BoldItalic.woff2"
+          "fileSize": 22076
         },
         {
           "name": "OptimaLTStd-DemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22456,
-          "url": "fonts/Optima LT Std/OptimaLTStd-DemiBoldItalic.woff2"
+          "fileSize": 22456
         },
         {
           "name": "OptimaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19976,
-          "url": "fonts/Optima LT Std/OptimaLTStd-Bold.woff2"
+          "fileSize": 19976
         },
         {
           "name": "OptimaLTStd-DemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22416,
-          "url": "fonts/Optima LT Std/OptimaLTStd-DemiBold.woff2"
+          "fileSize": 22416
         }
       ]
     },
@@ -14526,16 +13174,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20364,
-          "url": "fonts/Orator Std/OratorStd.woff2"
+          "fileSize": 20364
         },
         {
           "name": "OratorStd-Slanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21536,
-          "url": "fonts/Orator Std/OratorStd-Slanted.woff2"
+          "fileSize": 21536
         }
       ]
     },
@@ -14554,8 +13200,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17984,
-          "url": "fonts/Organica GMM Std/OrganicaGMMStd-SmSerifRoman.woff2"
+          "fileSize": 17984
         }
       ]
     },
@@ -14574,64 +13219,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29568,
-          "url": "fonts/Origami Std/OrigamiStd-Italic.woff2"
+          "fileSize": 29568
         },
         {
           "name": "OrigamiStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30200,
-          "url": "fonts/Origami Std/OrigamiStd-MediumItalic.woff2"
+          "fileSize": 30200
         },
         {
           "name": "OrigamiStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29568,
-          "url": "fonts/Origami Std/OrigamiStd-Medium.woff2"
+          "fileSize": 29568
         },
         {
           "name": "OrigamiStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28908,
-          "url": "fonts/Origami Std/OrigamiStd-Regular.woff2"
+          "fileSize": 28908
         },
         {
           "name": "OrigamiStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29012,
-          "url": "fonts/Origami Std/OrigamiStd-BoldItalic.woff2"
+          "fileSize": 29012
         },
         {
           "name": "OrigamiStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30316,
-          "url": "fonts/Origami Std/OrigamiStd-SemiBoldItalic.woff2"
+          "fileSize": 30316
         },
         {
           "name": "OrigamiStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28992,
-          "url": "fonts/Origami Std/OrigamiStd-Bold.woff2"
+          "fileSize": 28992
         },
         {
           "name": "OrigamiStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30016,
-          "url": "fonts/Origami Std/OrigamiStd-SemiBold.woff2"
+          "fileSize": 30016
         }
       ]
     },
@@ -14650,8 +13287,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30668,
-          "url": "fonts/Ouch Std/OuchStd.woff2"
+          "fileSize": 30668
         }
       ]
     },
@@ -14670,16 +13306,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26036,
-          "url": "fonts/Palace Script MT Std/PalaceScriptMTStd.woff2"
+          "fileSize": 26036
         },
         {
           "name": "PalaceScriptMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25356,
-          "url": "fonts/Palace Script MT Std/PalaceScriptMTStd-SemiBold.woff2"
+          "fileSize": 25356
         }
       ]
     },
@@ -14698,80 +13332,70 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24180,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-LightItalic.woff2"
+          "fileSize": 24180
         },
         {
           "name": "PalatinoLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22584,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-Light.woff2"
+          "fileSize": 22584
         },
         {
           "name": "PalatinoLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23304,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-BlackItalic.woff2"
+          "fileSize": 23304
         },
         {
           "name": "PalatinoLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24412,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-Italic.woff2"
+          "fileSize": 24412
         },
         {
           "name": "PalatinoLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23300,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-MediumItalic.woff2"
+          "fileSize": 23300
         },
         {
           "name": "PalatinoLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22984,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-Black.woff2"
+          "fileSize": 22984
         },
         {
           "name": "PalatinoLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22532,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-Medium.woff2"
+          "fileSize": 22532
         },
         {
           "name": "PalatinoLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29256,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-Roman.woff2"
+          "fileSize": 29256
         },
         {
           "name": "PalatinoLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24688,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-BoldItalic.woff2"
+          "fileSize": 24688
         },
         {
           "name": "PalatinoLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22428,
-          "url": "fonts/Palatino LT Std/PalatinoLTStd-Bold.woff2"
+          "fileSize": 22428
         }
       ]
     },
@@ -14790,8 +13414,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18228,
-          "url": "fonts/Parisian Std/ParisianStd.woff2"
+          "fileSize": 18228
         }
       ]
     },
@@ -14810,8 +13433,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22704,
-          "url": "fonts/Park Avenue Std/ParkAvenueStd.woff2"
+          "fileSize": 22704
         }
       ]
     },
@@ -14830,24 +13452,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15172,
-          "url": "fonts/Peignot LT Std/PeignotLTStd-Light.woff2"
+          "fileSize": 15172
         },
         {
           "name": "PeignotLTStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15432,
-          "url": "fonts/Peignot LT Std/PeignotLTStd-Demi.woff2"
+          "fileSize": 15432
         },
         {
           "name": "PeignotLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14916,
-          "url": "fonts/Peignot LT Std/PeignotLTStd-Bold.woff2"
+          "fileSize": 14916
         }
       ]
     },
@@ -14866,32 +13485,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18212,
-          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Light.woff2"
+          "fileSize": 18212
         },
         {
           "name": "PenumbraFlareStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19360,
-          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Regular.woff2"
+          "fileSize": 19360
         },
         {
           "name": "PenumbraFlareStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18964,
-          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Bold.woff2"
+          "fileSize": 18964
         },
         {
           "name": "PenumbraFlareStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19192,
-          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Semibold.woff2"
+          "fileSize": 19192
         }
       ]
     },
@@ -14910,32 +13525,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19404,
-          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-Light.woff2"
+          "fileSize": 19404
         },
         {
           "name": "PenumbraHalfSerifStd-Reg",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20308,
-          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-Reg.woff2"
+          "fileSize": 20308
         },
         {
           "name": "PenumbraHalfSerifStd-SeBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20292,
-          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-SeBd.woff2"
+          "fileSize": 20292
         },
         {
           "name": "PenumbraHalfSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19812,
-          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-Bold.woff2"
+          "fileSize": 19812
         }
       ]
     },
@@ -14954,32 +13565,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16800,
-          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Light.woff2"
+          "fileSize": 16800
         },
         {
           "name": "PenumbraSansStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18116,
-          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Regular.woff2"
+          "fileSize": 18116
         },
         {
           "name": "PenumbraSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17544,
-          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Bold.woff2"
+          "fileSize": 17544
         },
         {
           "name": "PenumbraSansStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18256,
-          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Semibold.woff2"
+          "fileSize": 18256
         }
       ]
     },
@@ -14998,32 +13605,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18812,
-          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Light.woff2"
+          "fileSize": 18812
         },
         {
           "name": "PenumbraSerifStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20396,
-          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Regular.woff2"
+          "fileSize": 20396
         },
         {
           "name": "PenumbraSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19144,
-          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Bold.woff2"
+          "fileSize": 19144
         },
         {
           "name": "PenumbraSerifStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20348,
-          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Semibold.woff2"
+          "fileSize": 20348
         }
       ]
     },
@@ -15042,8 +13645,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25048,
-          "url": "fonts/Pepita MT Std/PepitaMTStd.woff2"
+          "fileSize": 25048
         }
       ]
     },
@@ -15062,24 +13664,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21604,
-          "url": "fonts/Pepperwood Std/PepperwoodStd-Fill.woff2"
+          "fileSize": 21604
         },
         {
           "name": "PepperwoodStd-Outline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28980,
-          "url": "fonts/Pepperwood Std/PepperwoodStd-Outline.woff2"
+          "fileSize": 28980
         },
         {
           "name": "PepperwoodStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39372,
-          "url": "fonts/Pepperwood Std/PepperwoodStd-Regular.woff2"
+          "fileSize": 39372
         }
       ]
     },
@@ -15098,32 +13697,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28068,
-          "url": "fonts/Perpetua Std/PerpetuaStd-Italic.woff2"
+          "fileSize": 28068
         },
         {
           "name": "PerpetuaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33248,
-          "url": "fonts/Perpetua Std/PerpetuaStd.woff2"
+          "fileSize": 33248
         },
         {
           "name": "PerpetuaStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27948,
-          "url": "fonts/Perpetua Std/PerpetuaStd-BoldItalic.woff2"
+          "fileSize": 27948
         },
         {
           "name": "PerpetuaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27336,
-          "url": "fonts/Perpetua Std/PerpetuaStd-Bold.woff2"
+          "fileSize": 27336
         }
       ]
     },
@@ -15142,64 +13737,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23568,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-Italic.woff2"
+          "fileSize": 23568
         },
         {
           "name": "PhotinaMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23040,
-          "url": "fonts/Photina MT Std/PhotinaMTStd.woff2"
+          "fileSize": 23040
         },
         {
           "name": "PhotinaMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24188,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-BoldItalic.woff2"
+          "fileSize": 24188
         },
         {
           "name": "PhotinaMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22576,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-SemiBoldItalic.woff2"
+          "fileSize": 22576
         },
         {
           "name": "PhotinaMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23188,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-Bold.woff2"
+          "fileSize": 23188
         },
         {
           "name": "PhotinaMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22636,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-SemiBold.woff2"
+          "fileSize": 22636
         },
         {
           "name": "PhotinaMTStd-UltraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22432,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-UltraBold.woff2"
+          "fileSize": 22432
         },
         {
           "name": "PhotinaMTStd-UltraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22884,
-          "url": "fonts/Photina MT Std/PhotinaMTStd-UltraBoldIt.woff2"
+          "fileSize": 22884
         }
       ]
     },
@@ -15218,72 +13805,63 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21216,
-          "url": "fonts/Plantin Std/PlantinStd-LightItalic.woff2"
+          "fileSize": 21216
         },
         {
           "name": "PlantinStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19564,
-          "url": "fonts/Plantin Std/PlantinStd-Light.woff2"
+          "fileSize": 19564
         },
         {
           "name": "PlantinStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20416,
-          "url": "fonts/Plantin Std/PlantinStd-Italic.woff2"
+          "fileSize": 20416
         },
         {
           "name": "PlantinStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19168,
-          "url": "fonts/Plantin Std/PlantinStd.woff2"
+          "fileSize": 19168
         },
         {
           "name": "PlantinStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20720,
-          "url": "fonts/Plantin Std/PlantinStd-BoldItalic.woff2"
+          "fileSize": 20720
         },
         {
           "name": "PlantinStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21108,
-          "url": "fonts/Plantin Std/PlantinStd-SemiboldItalic.woff2"
+          "fileSize": 21108
         },
         {
           "name": "PlantinStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19652,
-          "url": "fonts/Plantin Std/PlantinStd-Bold.woff2"
+          "fileSize": 19652
         },
         {
           "name": "PlantinStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20032,
-          "url": "fonts/Plantin Std/PlantinStd-BoldCondensed.woff2"
+          "fileSize": 20032
         },
         {
           "name": "PlantinStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19320,
-          "url": "fonts/Plantin Std/PlantinStd-Semibold.woff2"
+          "fileSize": 19320
         }
       ]
     },
@@ -15302,64 +13880,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23888,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-LightItalic.woff2"
+          "fileSize": 23888
         },
         {
           "name": "CaeciliaLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23836,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Light.woff2"
+          "fileSize": 23836
         },
         {
           "name": "CaeciliaLTStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23204,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-HeavyItalic.woff2"
+          "fileSize": 23204
         },
         {
           "name": "CaeciliaLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23684,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Italic.woff2"
+          "fileSize": 23684
         },
         {
           "name": "CaeciliaLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23332,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Heavy.woff2"
+          "fileSize": 23332
         },
         {
           "name": "CaeciliaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23900,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Roman.woff2"
+          "fileSize": 23900
         },
         {
           "name": "CaeciliaLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24264,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-BoldItalic.woff2"
+          "fileSize": 24264
         },
         {
           "name": "CaeciliaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23704,
-          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Bold.woff2"
+          "fileSize": 23704
         }
       ]
     },
@@ -15378,8 +13948,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 251704,
-          "url": "fonts/Poetica Std/PoeticaStd.woff2"
+          "fileSize": 251704
         }
       ]
     },
@@ -15398,16 +13967,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27504,
-          "url": "fonts/Pompeia Std/PompeiaStd-InlineItalic.woff2"
+          "fileSize": 27504
         },
         {
           "name": "PompeiaStd-Inline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28852,
-          "url": "fonts/Pompeia Std/PompeiaStd-Inline.woff2"
+          "fileSize": 28852
         }
       ]
     },
@@ -15426,16 +13993,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 4796,
-          "url": "fonts/Pompeijana LT Std/PompeijanaLTStd-Borders.woff2"
+          "fileSize": 4796
         },
         {
           "name": "PompeijanaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19064,
-          "url": "fonts/Pompeijana LT Std/PompeijanaLTStd-Roman.woff2"
+          "fileSize": 19064
         }
       ]
     },
@@ -15454,8 +14019,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14972,
-          "url": "fonts/Ponderosa Std/PonderosaStd.woff2"
+          "fileSize": 14972
         }
       ]
     },
@@ -15474,8 +14038,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20392,
-          "url": "fonts/Poplar Std/PoplarStd.woff2"
+          "fileSize": 20392
         }
       ]
     },
@@ -15494,16 +14057,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21524,
-          "url": "fonts/Postino Std/PostinoStd-Italic.woff2"
+          "fileSize": 21524
         },
         {
           "name": "PostinoStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21332,
-          "url": "fonts/Postino Std/PostinoStd.woff2"
+          "fileSize": 21332
         }
       ]
     },
@@ -15522,48 +14083,42 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20896,
-          "url": "fonts/Present LT Std/PresentLTStd.woff2"
+          "fileSize": 20896
         },
         {
           "name": "PresentLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26568,
-          "url": "fonts/Present LT Std/PresentLTStd-Black.woff2"
+          "fileSize": 26568
         },
         {
           "name": "PresentLTStd-BlackCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26492,
-          "url": "fonts/Present LT Std/PresentLTStd-BlackCondensed.woff2"
+          "fileSize": 26492
         },
         {
           "name": "PresentLTStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23364,
-          "url": "fonts/Present LT Std/PresentLTStd-Condensed.woff2"
+          "fileSize": 23364
         },
         {
           "name": "PresentLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26088,
-          "url": "fonts/Present LT Std/PresentLTStd-Bold.woff2"
+          "fileSize": 26088
         },
         {
           "name": "PresentLTStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25200,
-          "url": "fonts/Present LT Std/PresentLTStd-BoldCondensed.woff2"
+          "fileSize": 25200
         }
       ]
     },
@@ -15582,32 +14137,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22524,
-          "url": "fonts/Prestige Elite Std/PrestigeEliteStd.woff2"
+          "fileSize": 22524
         },
         {
           "name": "PrestigeEliteStd-Bd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22376,
-          "url": "fonts/Prestige Elite Std/PrestigeEliteStd-Bd.woff2"
+          "fileSize": 22376
         },
         {
           "name": "PrestigeEliteStd-BdSlanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23760,
-          "url": "fonts/Prestige Elite Std/PrestigeEliteStd-BdSlanted.woff2"
+          "fileSize": 23760
         },
         {
           "name": "PrestigeEliteStd-Slanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23516,
-          "url": "fonts/Prestige Elite Std/PrestigeEliteStd-Slanted.woff2"
+          "fileSize": 23516
         }
       ]
     },
@@ -15626,8 +14177,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25188,
-          "url": "fonts/Quake Std/QuakeStd.woff2"
+          "fileSize": 25188
         }
       ]
     },
@@ -15646,8 +14196,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 70884,
-          "url": "fonts/Rad Std/RadStd.woff2"
+          "fileSize": 70884
         }
       ]
     },
@@ -15666,32 +14215,28 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18608,
-          "url": "fonts/Raleigh LT Std/RaleighLTStd.woff2"
+          "fileSize": 18608
         },
         {
           "name": "RaleighLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18448,
-          "url": "fonts/Raleigh LT Std/RaleighLTStd-Medium.woff2"
+          "fileSize": 18448
         },
         {
           "name": "RaleighLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18612,
-          "url": "fonts/Raleigh LT Std/RaleighLTStd-Bold.woff2"
+          "fileSize": 18612
         },
         {
           "name": "RaleighLTStd-DemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18448,
-          "url": "fonts/Raleigh LT Std/RaleighLTStd-DemiBold.woff2"
+          "fileSize": 18448
         }
       ]
     },
@@ -15710,8 +14255,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21256,
-          "url": "fonts/Raphael Std/RaphaelStd.woff2"
+          "fileSize": 21256
         }
       ]
     },
@@ -15730,96 +14274,84 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30848,
-          "url": "fonts/Reliq Std/ReliqStd-LightActive.woff2"
+          "fileSize": 30848
         },
         {
           "name": "ReliqStd-LightCalm",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28420,
-          "url": "fonts/Reliq Std/ReliqStd-LightCalm.woff2"
+          "fileSize": 28420
         },
         {
           "name": "ReliqStd-LightExtraActive",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29828,
-          "url": "fonts/Reliq Std/ReliqStd-LightExtraActive.woff2"
+          "fileSize": 29828
         },
         {
           "name": "ReliqStd-Active",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32476,
-          "url": "fonts/Reliq Std/ReliqStd-Active.woff2"
+          "fileSize": 32476
         },
         {
           "name": "ReliqStd-Calm",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32048,
-          "url": "fonts/Reliq Std/ReliqStd-Calm.woff2"
+          "fileSize": 32048
         },
         {
           "name": "ReliqStd-ExtraActive",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32288,
-          "url": "fonts/Reliq Std/ReliqStd-ExtraActive.woff2"
+          "fileSize": 32288
         },
         {
           "name": "ReliqStd-BoldActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32272,
-          "url": "fonts/Reliq Std/ReliqStd-BoldActive.woff2"
+          "fileSize": 32272
         },
         {
           "name": "ReliqStd-BoldCalm",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30748,
-          "url": "fonts/Reliq Std/ReliqStd-BoldCalm.woff2"
+          "fileSize": 30748
         },
         {
           "name": "ReliqStd-BoldExtraActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30224,
-          "url": "fonts/Reliq Std/ReliqStd-BoldExtraActive.woff2"
+          "fileSize": 30224
         },
         {
           "name": "ReliqStd-SemiboldActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32652,
-          "url": "fonts/Reliq Std/ReliqStd-SemiboldActive.woff2"
+          "fileSize": 32652
         },
         {
           "name": "ReliqStd-SemiboldCalm",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32204,
-          "url": "fonts/Reliq Std/ReliqStd-SemiboldCalm.woff2"
+          "fileSize": 32204
         },
         {
           "name": "ReliqStd-SemiboldExtActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32300,
-          "url": "fonts/Reliq Std/ReliqStd-SemiboldExtActive.woff2"
+          "fileSize": 32300
         }
       ]
     },
@@ -15838,8 +14370,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32684,
-          "url": "fonts/Reporter LT Std/ReporterLTStd-2.woff2"
+          "fileSize": 32684
         }
       ]
     },
@@ -15858,8 +14389,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14736,
-          "url": "fonts/Revue Std/RevueStd.woff2"
+          "fileSize": 14736
         }
       ]
     },
@@ -15878,72 +14408,63 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17492,
-          "url": "fonts/Rockwell Std/RockwellStd-LightItalic.woff2"
+          "fileSize": 17492
         },
         {
           "name": "RockwellStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17256,
-          "url": "fonts/Rockwell Std/RockwellStd-Light.woff2"
+          "fileSize": 17256
         },
         {
           "name": "RockwellStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17532,
-          "url": "fonts/Rockwell Std/RockwellStd-Italic.woff2"
+          "fileSize": 17532
         },
         {
           "name": "RockwellStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17260,
-          "url": "fonts/Rockwell Std/RockwellStd.woff2"
+          "fileSize": 17260
         },
         {
           "name": "RockwellStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17068,
-          "url": "fonts/Rockwell Std/RockwellStd-Condensed.woff2"
+          "fileSize": 17068
         },
         {
           "name": "RockwellStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17580,
-          "url": "fonts/Rockwell Std/RockwellStd-BoldItalic.woff2"
+          "fileSize": 17580
         },
         {
           "name": "RockwellStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17284,
-          "url": "fonts/Rockwell Std/RockwellStd-Bold.woff2"
+          "fileSize": 17284
         },
         {
           "name": "RockwellStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17400,
-          "url": "fonts/Rockwell Std/RockwellStd-BoldCondensed.woff2"
+          "fileSize": 17400
         },
         {
           "name": "RockwellStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17676,
-          "url": "fonts/Rockwell Std/RockwellStd-ExtraBold.woff2"
+          "fileSize": 17676
         }
       ]
     },
@@ -15962,40 +14483,35 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22148,
-          "url": "fonts/Romic Std/RomicStd-LightItalic.woff2"
+          "fileSize": 22148
         },
         {
           "name": "RomicStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22076,
-          "url": "fonts/Romic Std/RomicStd-Light.woff2"
+          "fileSize": 22076
         },
         {
           "name": "RomicStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21332,
-          "url": "fonts/Romic Std/RomicStd-Medium.woff2"
+          "fileSize": 21332
         },
         {
           "name": "RomicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21668,
-          "url": "fonts/Romic Std/RomicStd-Bold.woff2"
+          "fileSize": 21668
         },
         {
           "name": "RomicStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21248,
-          "url": "fonts/Romic Std/RomicStd-ExtraBold.woff2"
+          "fileSize": 21248
         }
       ]
     },
@@ -16014,16 +14530,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17516,
-          "url": "fonts/Rosewood Std/RosewoodStd-Fill.woff2"
+          "fileSize": 17516
         },
         {
           "name": "RosewoodStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36996,
-          "url": "fonts/Rosewood Std/RosewoodStd-Regular.woff2"
+          "fileSize": 36996
         }
       ]
     },
@@ -16042,24 +14556,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21728,
-          "url": "fonts/Rotation LT Std/RotationLTStd-Italic.woff2"
+          "fileSize": 21728
         },
         {
           "name": "RotationLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19820,
-          "url": "fonts/Rotation LT Std/RotationLTStd-Roman.woff2"
+          "fileSize": 19820
         },
         {
           "name": "RotationLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19620,
-          "url": "fonts/Rotation LT Std/RotationLTStd-Bold.woff2"
+          "fileSize": 19620
         }
       ]
     },
@@ -16078,8 +14589,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 65428,
-          "url": "fonts/Ruling Script LT Std/RulingScriptLTStd-2.woff2"
+          "fileSize": 65428
         }
       ]
     },
@@ -16098,8 +14608,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18996,
-          "url": "fonts/Runic MT Std/RunicMTStd-Condensed.woff2"
+          "fileSize": 18996
         }
       ]
     },
@@ -16118,16 +14627,14 @@
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 26344,
-          "url": "fonts/Russell Oblique Std/RussellObliqueStd.woff2"
+          "fileSize": 26344
         },
         {
           "name": "RussellObliqueStd-Informal",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 40756,
-          "url": "fonts/Russell Oblique Std/RussellObliqueStd-Informal.woff2"
+          "fileSize": 40756
         }
       ]
     },
@@ -16146,16 +14653,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 3884,
-          "url": "fonts/Rusticana LT Std/RusticanaLTStd-Borders.woff2"
+          "fileSize": 3884
         },
         {
           "name": "RusticanaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16180,
-          "url": "fonts/Rusticana LT Std/RusticanaLTStd-Roman.woff2"
+          "fileSize": 16180
         }
       ]
     },
@@ -16174,16 +14679,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30092,
-          "url": "fonts/Ruzicka Freehand LT Std/RuzickaFreehandLTStd-Roman.woff2"
+          "fileSize": 30092
         },
         {
           "name": "RuzickaFreehandLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30788,
-          "url": "fonts/Ruzicka Freehand LT Std/RuzickaFreehandLTStd-Bold.woff2"
+          "fileSize": 30788
         }
       ]
     },
@@ -16202,32 +14705,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22780,
-          "url": "fonts/Sabon LT Std/SabonLTStd-Italic.woff2"
+          "fileSize": 22780
         },
         {
           "name": "SabonLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26472,
-          "url": "fonts/Sabon LT Std/SabonLTStd-Roman.woff2"
+          "fileSize": 26472
         },
         {
           "name": "SabonLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21848,
-          "url": "fonts/Sabon LT Std/SabonLTStd-BoldItalic.woff2"
+          "fileSize": 21848
         },
         {
           "name": "SabonLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21668,
-          "url": "fonts/Sabon LT Std/SabonLTStd-Bold.woff2"
+          "fileSize": 21668
         }
       ]
     },
@@ -16246,8 +14745,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21236,
-          "url": "fonts/San Marco LT Std/SanMarcoLTStd.woff2"
+          "fileSize": 21236
         }
       ]
     },
@@ -16266,16 +14764,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 37892,
-          "url": "fonts/Sassafras Std/SassafrasStd-Italic.woff2"
+          "fileSize": 37892
         },
         {
           "name": "SassafrasStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37152,
-          "url": "fonts/Sassafras Std/SassafrasStd-Roman.woff2"
+          "fileSize": 37152
         }
       ]
     },
@@ -16294,16 +14790,14 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22920,
-          "url": "fonts/Scotch Roman MT Std/ScotchRomanMTStd-Italic.woff2"
+          "fileSize": 22920
         },
         {
           "name": "ScotchRomanMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20204,
-          "url": "fonts/Scotch Roman MT Std/ScotchRomanMTStd.woff2"
+          "fileSize": 20204
         }
       ]
     },
@@ -16322,8 +14816,7 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24588,
-          "url": "fonts/Script MT Std/ScriptMTStd-Bold.woff2"
+          "fileSize": 24588
         }
       ]
     },
@@ -16342,48 +14835,42 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16952,
-          "url": "fonts/Serifa Std/SerifaStd-LightItalic.woff2"
+          "fileSize": 16952
         },
         {
           "name": "SerifaStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16040,
-          "url": "fonts/Serifa Std/SerifaStd-Light.woff2"
+          "fileSize": 16040
         },
         {
           "name": "SerifaStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16800,
-          "url": "fonts/Serifa Std/SerifaStd-Italic.woff2"
+          "fileSize": 16800
         },
         {
           "name": "SerifaStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17528,
-          "url": "fonts/Serifa Std/SerifaStd-Black.woff2"
+          "fileSize": 17528
         },
         {
           "name": "SerifaStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16228,
-          "url": "fonts/Serifa Std/SerifaStd-Roman.woff2"
+          "fileSize": 16228
         },
         {
           "name": "SerifaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316,
-          "url": "fonts/Serifa Std/SerifaStd-Bold.woff2"
+          "fileSize": 16316
         }
       ]
     },
@@ -16402,8 +14889,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23748,
-          "url": "fonts/Serlio LT Std/SerlioLTStd.woff2"
+          "fileSize": 23748
         }
       ]
     },
@@ -16422,8 +14908,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43864,
-          "url": "fonts/Shelley Script LT Std/ShelleyLTStd-Script.woff2"
+          "fileSize": 43864
         }
       ]
     },
@@ -16442,8 +14927,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22368,
-          "url": "fonts/Sho LT Std/ShoLTStd-Roman.woff2"
+          "fileSize": 22368
         }
       ]
     },
@@ -16462,8 +14946,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19476,
-          "url": "fonts/Shuriken Boy Std/ShurikenStd-Boy.woff2"
+          "fileSize": 19476
         }
       ]
     },
@@ -16482,16 +14965,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 75064,
-          "url": "fonts/Silentium Pro/SilentiumPro-RomanI.woff2"
+          "fileSize": 75064
         },
         {
           "name": "SilentiumPro-RomanII",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 52612,
-          "url": "fonts/Silentium Pro/SilentiumPro-RomanII.woff2"
+          "fileSize": 52612
         }
       ]
     },
@@ -16510,24 +14991,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22012,
-          "url": "fonts/Simoncini Garamond Std/SimonciniGaramondStd-Italic.woff2"
+          "fileSize": 22012
         },
         {
           "name": "SimonciniGaramondStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20568,
-          "url": "fonts/Simoncini Garamond Std/SimonciniGaramondStd.woff2"
+          "fileSize": 20568
         },
         {
           "name": "SimonciniGaramondStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21128,
-          "url": "fonts/Simoncini Garamond Std/SimonciniGaramondStd-Bold.woff2"
+          "fileSize": 21128
         }
       ]
     },
@@ -16546,8 +15024,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24124,
-          "url": "fonts/Smaragd LT Std/SmaragdLTStd.woff2"
+          "fileSize": 24124
         }
       ]
     },
@@ -16566,24 +15043,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27428,
-          "url": "fonts/Snell Roundhand LT Std/SnellRoundhandLTStd-BdScr.woff2"
+          "fileSize": 27428
         },
         {
           "name": "SnellRoundhandLTStd-BlkScr",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27800,
-          "url": "fonts/Snell Roundhand LT Std/SnellRoundhandLTStd-BlkScr.woff2"
+          "fileSize": 27800
         },
         {
           "name": "SnellRoundhandLTStd-Scr",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27444,
-          "url": "fonts/Snell Roundhand LT Std/SnellRoundhandLTStd-Scr.woff2"
+          "fileSize": 27444
         }
       ]
     },
@@ -16602,8 +15076,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17384,
-          "url": "fonts/Sonata Std/SonataStd.woff2"
+          "fileSize": 17384
         }
       ]
     },
@@ -16622,16 +15095,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16052,
-          "url": "fonts/Spartan LT Std/SpartanLTStd-BookClass.woff2"
+          "fileSize": 16052
         },
         {
           "name": "SpartanLTStd-HeavyClass",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16120,
-          "url": "fonts/Spartan LT Std/SpartanLTStd-HeavyClass.woff2"
+          "fileSize": 16120
         }
       ]
     },
@@ -16650,24 +15121,21 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27808,
-          "url": "fonts/Spectrum MT Std/SpectrumMTStd-Italic.woff2"
+          "fileSize": 27808
         },
         {
           "name": "SpectrumMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32908,
-          "url": "fonts/Spectrum MT Std/SpectrumMTStd.woff2"
+          "fileSize": 32908
         },
         {
           "name": "SpectrumMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27476,
-          "url": "fonts/Spectrum MT Std/SpectrumMTStd-SemiBold.woff2"
+          "fileSize": 27476
         }
       ]
     },
@@ -16686,16 +15154,14 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30248,
-          "url": "fonts/Spring LP Std/SpringLPStd-Light.woff2"
+          "fileSize": 30248
         },
         {
           "name": "SpringLPStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31964,
-          "url": "fonts/Spring LP Std/SpringLPStd.woff2"
+          "fileSize": 31964
         }
       ]
     },
@@ -16714,8 +15180,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30484,
-          "url": "fonts/Spumoni LP Std/SpumoniLPStd.woff2"
+          "fileSize": 30484
         }
       ]
     },
@@ -16734,32 +15199,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24296,
-          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-Italic.woff2"
+          "fileSize": 24296
         },
         {
           "name": "StempelGaramondLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31232,
-          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-Roman.woff2"
+          "fileSize": 31232
         },
         {
           "name": "StempelGaramondLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24812,
-          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-Bold.woff2"
+          "fileSize": 24812
         },
         {
           "name": "StempelGaramondLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24104,
-          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-BoldIt.woff2"
+          "fileSize": 24104
         }
       ]
     },
@@ -16778,80 +15239,70 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20268,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Light.woff2"
+          "fileSize": 20268
         },
         {
           "name": "StempelSchneidlerStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21136,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Italic.woff2"
+          "fileSize": 21136
         },
         {
           "name": "StempelSchneidlerStd-BdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21536,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-BdIt.woff2"
+          "fileSize": 21536
         },
         {
           "name": "StempelSchneidlerStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21308,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Black.woff2"
+          "fileSize": 21308
         },
         {
           "name": "StempelSchneidlerStd-BlkIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22112,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-BlkIt.woff2"
+          "fileSize": 22112
         },
         {
           "name": "StempelSchneidlerStd-LtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20640,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-LtIt.woff2"
+          "fileSize": 20640
         },
         {
           "name": "StempelSchneidlerStd-MedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21144,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-MedIt.woff2"
+          "fileSize": 21144
         },
         {
           "name": "StempelSchneidlerStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20224,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Medium.woff2"
+          "fileSize": 20224
         },
         {
           "name": "StempelSchneidlerStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20808,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Roman.woff2"
+          "fileSize": 20808
         },
         {
           "name": "StempelSchneidlerStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20944,
-          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Bold.woff2"
+          "fileSize": 20944
         }
       ]
     },
@@ -16870,8 +15321,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17592,
-          "url": "fonts/Stencil Std/StencilStd.woff2"
+          "fileSize": 17592
         }
       ]
     },
@@ -16890,64 +15340,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24772,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-LightItalic.woff2"
+          "fileSize": 24772
         },
         {
           "name": "StrayhornMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30508,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Light.woff2"
+          "fileSize": 30508
         },
         {
           "name": "StrayhornMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25024,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Italic.woff2"
+          "fileSize": 25024
         },
         {
           "name": "StrayhornMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31180,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Regular.woff2"
+          "fileSize": 31180
         },
         {
           "name": "StrayhornMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24828,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-BoldItalic.woff2"
+          "fileSize": 24828
         },
         {
           "name": "StrayhornMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24576,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Bold.woff2"
+          "fileSize": 24576
         },
         {
           "name": "StrayhornMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24324,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-ExtraBold.woff2"
+          "fileSize": 24324
         },
         {
           "name": "StrayhornMTStd-ExtraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24472,
-          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-ExtraBoldIt.woff2"
+          "fileSize": 24472
         }
       ]
     },
@@ -16966,16 +15408,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45476,
-          "url": "fonts/Strumpf Std/StrumpfStd-Contour.woff2"
+          "fileSize": 45476
         },
         {
           "name": "StrumpfStd-Open",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34400,
-          "url": "fonts/Strumpf Std/StrumpfStd-Open.woff2"
+          "fileSize": 34400
         }
       ]
     },
@@ -16994,8 +15434,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44816,
-          "url": "fonts/Studz Std/StudzStd.woff2"
+          "fileSize": 44816
         }
       ]
     },
@@ -17014,8 +15453,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18240,
-          "url": "fonts/Symbol Std/SymbolStd.woff2"
+          "fileSize": 18240
         }
       ]
     },
@@ -17034,40 +15472,35 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15764,
-          "url": "fonts/Syntax LT Std/SyntaxLTStd-Italic.woff2"
+          "fileSize": 15764
         },
         {
           "name": "SyntaxLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15876,
-          "url": "fonts/Syntax LT Std/SyntaxLTStd-Black.woff2"
+          "fileSize": 15876
         },
         {
           "name": "SyntaxLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15512,
-          "url": "fonts/Syntax LT Std/SyntaxLTStd-Roman.woff2"
+          "fileSize": 15512
         },
         {
           "name": "SyntaxLTStd-UltraBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16464,
-          "url": "fonts/Syntax LT Std/SyntaxLTStd-UltraBlack.woff2"
+          "fileSize": 16464
         },
         {
           "name": "SyntaxLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15972,
-          "url": "fonts/Syntax LT Std/SyntaxLTStd-Bold.woff2"
+          "fileSize": 15972
         }
       ]
     },
@@ -17086,144 +15519,126 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45564,
-          "url": "fonts/Tekton Pro/TektonPro-Light.woff2"
+          "fileSize": 45564
         },
         {
           "name": "TektonPro-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43720,
-          "url": "fonts/Tekton Pro/TektonPro-LightCond.woff2"
+          "fileSize": 43720
         },
         {
           "name": "TektonPro-LightCondObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43736,
-          "url": "fonts/Tekton Pro/TektonPro-LightCondObl.woff2"
+          "fileSize": 43736
         },
         {
           "name": "TektonPro-LightExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45648,
-          "url": "fonts/Tekton Pro/TektonPro-LightExt.woff2"
+          "fileSize": 45648
         },
         {
           "name": "TektonPro-LightExtObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45800,
-          "url": "fonts/Tekton Pro/TektonPro-LightExtObl.woff2"
+          "fileSize": 45800
         },
         {
           "name": "TektonPro-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45664,
-          "url": "fonts/Tekton Pro/TektonPro-LightObl.woff2"
+          "fileSize": 45664
         },
         {
           "name": "TektonPro-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45492,
-          "url": "fonts/Tekton Pro/TektonPro-Cond.woff2"
+          "fileSize": 45492
         },
         {
           "name": "TektonPro-CondObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45584,
-          "url": "fonts/Tekton Pro/TektonPro-CondObl.woff2"
+          "fileSize": 45584
         },
         {
           "name": "TektonPro-Ext",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46740,
-          "url": "fonts/Tekton Pro/TektonPro-Ext.woff2"
+          "fileSize": 46740
         },
         {
           "name": "TektonPro-ExtObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46828,
-          "url": "fonts/Tekton Pro/TektonPro-ExtObl.woff2"
+          "fileSize": 46828
         },
         {
           "name": "TektonPro-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45764,
-          "url": "fonts/Tekton Pro/TektonPro-Obl.woff2"
+          "fileSize": 45764
         },
         {
           "name": "TektonPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45712,
-          "url": "fonts/Tekton Pro/TektonPro-Regular.woff2"
+          "fileSize": 45712
         },
         {
           "name": "TektonPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46044,
-          "url": "fonts/Tekton Pro/TektonPro-Bold.woff2"
+          "fileSize": 46044
         },
         {
           "name": "TektonPro-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45124,
-          "url": "fonts/Tekton Pro/TektonPro-BoldCond.woff2"
+          "fileSize": 45124
         },
         {
           "name": "TektonPro-BoldCondObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45052,
-          "url": "fonts/Tekton Pro/TektonPro-BoldCondObl.woff2"
+          "fileSize": 45052
         },
         {
           "name": "TektonPro-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46780,
-          "url": "fonts/Tekton Pro/TektonPro-BoldExt.woff2"
+          "fileSize": 46780
         },
         {
           "name": "TektonPro-BoldExtObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46932,
-          "url": "fonts/Tekton Pro/TektonPro-BoldExtObl.woff2"
+          "fileSize": 46932
         },
         {
           "name": "TektonPro-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46124,
-          "url": "fonts/Tekton Pro/TektonPro-BoldObl.woff2"
+          "fileSize": 46124
         }
       ]
     },
@@ -17242,16 +15657,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14964,
-          "url": "fonts/Tempo Std/TempoStd-HeavyCondensed.woff2"
+          "fileSize": 14964
         },
         {
           "name": "TempoStd-HeavyCondensedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15460,
-          "url": "fonts/Tempo Std/TempoStd-HeavyCondensedIt.woff2"
+          "fileSize": 15460
         }
       ]
     },
@@ -17270,32 +15683,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20340,
-          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-Italic.woff2"
+          "fileSize": 20340
         },
         {
           "name": "TimesEuropaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20404,
-          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-Roman.woff2"
+          "fileSize": 20404
         },
         {
           "name": "TimesEuropaLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20552,
-          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-BoldItalic.woff2"
+          "fileSize": 20552
         },
         {
           "name": "TimesEuropaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19936,
-          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-Bold.woff2"
+          "fileSize": 19936
         }
       ]
     },
@@ -17314,64 +15723,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22572,
-          "url": "fonts/Times LT Std/TimesLTStd-Italic.woff2"
+          "fileSize": 22572
         },
         {
           "name": "TimesLTStd-Phonetic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 49264,
-          "url": "fonts/Times LT Std/TimesLTStd-Phonetic.woff2"
+          "fileSize": 49264
         },
         {
           "name": "TimesLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27096,
-          "url": "fonts/Times LT Std/TimesLTStd-Roman.woff2"
+          "fileSize": 27096
         },
         {
           "name": "TimesLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22148,
-          "url": "fonts/Times LT Std/TimesLTStd-BoldItalic.woff2"
+          "fileSize": 22148
         },
         {
           "name": "TimesLTStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20160,
-          "url": "fonts/Times LT Std/TimesLTStd-SemiboldItalic.woff2"
+          "fileSize": 20160
         },
         {
           "name": "TimesLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26760,
-          "url": "fonts/Times LT Std/TimesLTStd-Bold.woff2"
+          "fileSize": 26760
         },
         {
           "name": "TimesLTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18660,
-          "url": "fonts/Times LT Std/TimesLTStd-ExtraBold.woff2"
+          "fileSize": 18660
         },
         {
           "name": "TimesLTStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18516,
-          "url": "fonts/Times LT Std/TimesLTStd-Semibold.woff2"
+          "fileSize": 18516
         }
       ]
     },
@@ -17390,56 +15791,49 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22640,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-Italic.woff2"
+          "fileSize": 22640
         },
         {
           "name": "TimesNewRomanMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20212,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd.woff2"
+          "fileSize": 20212
         },
         {
           "name": "TimesNewRomanMTStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19608,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-Cond.woff2"
+          "fileSize": 19608
         },
         {
           "name": "TimesNewRomanMTStd-CondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21188,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-CondIt.woff2"
+          "fileSize": 21188
         },
         {
           "name": "TimesNewRomanMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19676,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-Bold.woff2"
+          "fileSize": 19676
         },
         {
           "name": "TimesNewRomanMTStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19732,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-BoldCond.woff2"
+          "fileSize": 19732
         },
         {
           "name": "TimesNewRomanMTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21560,
-          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-BoldIt.woff2"
+          "fileSize": 21560
         }
       ]
     },
@@ -17458,32 +15852,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30852,
-          "url": "fonts/Times Ten LT Std/TimesTenLTStd-Italic.woff2"
+          "fileSize": 30852
         },
         {
           "name": "TimesTenLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33648,
-          "url": "fonts/Times Ten LT Std/TimesTenLTStd-Roman.woff2"
+          "fileSize": 33648
         },
         {
           "name": "TimesTenLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31700,
-          "url": "fonts/Times Ten LT Std/TimesTenLTStd-BoldItalic.woff2"
+          "fileSize": 31700
         },
         {
           "name": "TimesTenLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29040,
-          "url": "fonts/Times Ten LT Std/TimesTenLTStd-Bold.woff2"
+          "fileSize": 29040
         }
       ]
     },
@@ -17502,8 +15892,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28260,
-          "url": "fonts/Toolbox Std/ToolboxStd.woff2"
+          "fileSize": 28260
         }
       ]
     },
@@ -17522,112 +15911,98 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15180,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Light.woff2"
+          "fileSize": 15180
         },
         {
           "name": "TradeGothicLTStd-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16352,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-LightObl.woff2"
+          "fileSize": 16352
         },
         {
           "name": "TradeGothicLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15320,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd.woff2"
+          "fileSize": 15320
         },
         {
           "name": "TradeGothicLTStd-Bd2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15528,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Bd2.woff2"
+          "fileSize": 15528
         },
         {
           "name": "TradeGothicLTStd-Bd2Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16460,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Bd2Obl.woff2"
+          "fileSize": 16460
         },
         {
           "name": "TradeGothicLTStd-BdCn20",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15336,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BdCn20.woff2"
+          "fileSize": 15336
         },
         {
           "name": "TradeGothicLTStd-BdCn20Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16432,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BdCn20Obl.woff2"
+          "fileSize": 16432
         },
         {
           "name": "TradeGothicLTStd-Cn18",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15092,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Cn18.woff2"
+          "fileSize": 15092
         },
         {
           "name": "TradeGothicLTStd-Cn18Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16264,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Cn18Obl.woff2"
+          "fileSize": 16264
         },
         {
           "name": "TradeGothicLTStd-Extended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16064,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Extended.woff2"
+          "fileSize": 16064
         },
         {
           "name": "TradeGothicLTStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16700,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Obl.woff2"
+          "fileSize": 16700
         },
         {
           "name": "TradeGothicLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15388,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Bold.woff2"
+          "fileSize": 15388
         },
         {
           "name": "TradeGothicLTStd-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16344,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BoldExt.woff2"
+          "fileSize": 16344
         },
         {
           "name": "TradeGothicLTStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316,
-          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BoldObl.woff2"
+          "fileSize": 16316
         }
       ]
     },
@@ -17646,16 +16021,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35508,
-          "url": "fonts/Trajan Pro/TrajanPro-Regular.woff2"
+          "fileSize": 35508
         },
         {
           "name": "TrajanPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35184,
-          "url": "fonts/Trajan Pro/TrajanPro-Bold.woff2"
+          "fileSize": 35184
         }
       ]
     },
@@ -17674,32 +16047,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19660,
-          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-Italic.woff2"
+          "fileSize": 19660
         },
         {
           "name": "TrumpMediaevalLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24404,
-          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-Roman.woff2"
+          "fileSize": 24404
         },
         {
           "name": "TrumpMediaevalLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18992,
-          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-Bold.woff2"
+          "fileSize": 18992
         },
         {
           "name": "TrumpMediaevalLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19780,
-          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-BoldIt.woff2"
+          "fileSize": 19780
         }
       ]
     },
@@ -17718,8 +16087,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16088,
-          "url": "fonts/Umbra Std/UmbraStd.woff2"
+          "fileSize": 16088
         }
       ]
     },
@@ -17738,216 +16106,189 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16328,
-          "url": "fonts/Univers LT Std/UniversLTStd-Light.woff2"
+          "fileSize": 16328
         },
         {
           "name": "UniversLTStd-LightCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15580,
-          "url": "fonts/Univers LT Std/UniversLTStd-LightCn.woff2"
+          "fileSize": 15580
         },
         {
           "name": "UniversLTStd-LightCnObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16496,
-          "url": "fonts/Univers LT Std/UniversLTStd-LightCnObl.woff2"
+          "fileSize": 16496
         },
         {
           "name": "UniversLTStd-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17272,
-          "url": "fonts/Univers LT Std/UniversLTStd-LightObl.woff2"
+          "fileSize": 17272
         },
         {
           "name": "UniversLTStd-LightUltraCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14808,
-          "url": "fonts/Univers LT Std/UniversLTStd-LightUltraCn.woff2"
+          "fileSize": 14808
         },
         {
           "name": "UniversLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17740,
-          "url": "fonts/Univers LT Std/UniversLTStd.woff2"
+          "fileSize": 17740
         },
         {
           "name": "UniversLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18208,
-          "url": "fonts/Univers LT Std/UniversLTStd-Black.woff2"
+          "fileSize": 18208
         },
         {
           "name": "UniversLTStd-BlackEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16216,
-          "url": "fonts/Univers LT Std/UniversLTStd-BlackEx.woff2"
+          "fileSize": 16216
         },
         {
           "name": "UniversLTStd-BlackExObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17092,
-          "url": "fonts/Univers LT Std/UniversLTStd-BlackExObl.woff2"
+          "fileSize": 17092
         },
         {
           "name": "UniversLTStd-BlackObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18832,
-          "url": "fonts/Univers LT Std/UniversLTStd-BlackObl.woff2"
+          "fileSize": 18832
         },
         {
           "name": "UniversLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15404,
-          "url": "fonts/Univers LT Std/UniversLTStd-Cn.woff2"
+          "fileSize": 15404
         },
         {
           "name": "UniversLTStd-CnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16132,
-          "url": "fonts/Univers LT Std/UniversLTStd-CnObl.woff2"
+          "fileSize": 16132
         },
         {
           "name": "UniversLTStd-Ex",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16140,
-          "url": "fonts/Univers LT Std/UniversLTStd-Ex.woff2"
+          "fileSize": 16140
         },
         {
           "name": "UniversLTStd-ExObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16952,
-          "url": "fonts/Univers LT Std/UniversLTStd-ExObl.woff2"
+          "fileSize": 16952
         },
         {
           "name": "UniversLTStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18900,
-          "url": "fonts/Univers LT Std/UniversLTStd-Obl.woff2"
+          "fileSize": 18900
         },
         {
           "name": "UniversLTStd-ThinUltraCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14796,
-          "url": "fonts/Univers LT Std/UniversLTStd-ThinUltraCn.woff2"
+          "fileSize": 14796
         },
         {
           "name": "UniversLTStd-UltraCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15748,
-          "url": "fonts/Univers LT Std/UniversLTStd-UltraCn.woff2"
+          "fileSize": 15748
         },
         {
           "name": "UniversLTStd-XBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16740,
-          "url": "fonts/Univers LT Std/UniversLTStd-XBlack.woff2"
+          "fileSize": 16740
         },
         {
           "name": "UniversLTStd-XBlackEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17072,
-          "url": "fonts/Univers LT Std/UniversLTStd-XBlackEx.woff2"
+          "fileSize": 17072
         },
         {
           "name": "UniversLTStd-XBlackExObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18012,
-          "url": "fonts/Univers LT Std/UniversLTStd-XBlackExObl.woff2"
+          "fileSize": 18012
         },
         {
           "name": "UniversLTStd-XBlackObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17424,
-          "url": "fonts/Univers LT Std/UniversLTStd-XBlackObl.woff2"
+          "fileSize": 17424
         },
         {
           "name": "UniversLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18236,
-          "url": "fonts/Univers LT Std/UniversLTStd-Bold.woff2"
+          "fileSize": 18236
         },
         {
           "name": "UniversLTStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15660,
-          "url": "fonts/Univers LT Std/UniversLTStd-BoldCn.woff2"
+          "fileSize": 15660
         },
         {
           "name": "UniversLTStd-BoldCnObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16724,
-          "url": "fonts/Univers LT Std/UniversLTStd-BoldCnObl.woff2"
+          "fileSize": 16724
         },
         {
           "name": "UniversLTStd-BoldEx",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16504,
-          "url": "fonts/Univers LT Std/UniversLTStd-BoldEx.woff2"
+          "fileSize": 16504
         },
         {
           "name": "UniversLTStd-BoldExObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17420,
-          "url": "fonts/Univers LT Std/UniversLTStd-BoldExObl.woff2"
+          "fileSize": 17420
         },
         {
           "name": "UniversLTStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18952,
-          "url": "fonts/Univers LT Std/UniversLTStd-BoldObl.woff2"
+          "fileSize": 18952
         }
       ]
     },
@@ -17966,16 +16307,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10784,
-          "url": "fonts/Universal Std/UniversalStd-GreekwMathPi.woff2"
+          "fileSize": 10784
         },
         {
           "name": "UniversalStd-NewswithCommPi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 9984,
-          "url": "fonts/Universal Std/UniversalStd-NewswithCommPi.woff2"
+          "fileSize": 9984
         }
       ]
     },
@@ -17994,8 +16333,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048,
-          "url": "fonts/University Roman Std/UniversityRomanStd.woff2"
+          "fileSize": 19048
         }
       ]
     },
@@ -18014,32 +16352,28 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16144,
-          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Light.woff2"
+          "fileSize": 16144
         },
         {
           "name": "VAGRoundedStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16772,
-          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Black.woff2"
+          "fileSize": 16772
         },
         {
           "name": "VAGRoundedStd-Thin",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16036,
-          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Thin.woff2"
+          "fileSize": 16036
         },
         {
           "name": "VAGRoundedStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16872,
-          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Bold.woff2"
+          "fileSize": 16872
         }
       ]
     },
@@ -18058,64 +16392,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16084,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-LightItalic.woff2"
+          "fileSize": 16084
         },
         {
           "name": "VectoraLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15696,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-Light.woff2"
+          "fileSize": 15696
         },
         {
           "name": "VectoraLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16676,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-BlackItalic.woff2"
+          "fileSize": 16676
         },
         {
           "name": "VectoraLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16472,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-Italic.woff2"
+          "fileSize": 16472
         },
         {
           "name": "VectoraLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-Black.woff2"
+          "fileSize": 16316
         },
         {
           "name": "VectoraLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15836,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-Roman.woff2"
+          "fileSize": 15836
         },
         {
           "name": "VectoraLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16400,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-BoldItalic.woff2"
+          "fileSize": 16400
         },
         {
           "name": "VectoraLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16108,
-          "url": "fonts/Vectora LT Std/VectoraLTStd-Bold.woff2"
+          "fileSize": 16108
         }
       ]
     },
@@ -18134,64 +16460,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19640,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-LightItalic.woff2"
+          "fileSize": 19640
         },
         {
           "name": "VersaillesLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18488,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-Light.woff2"
+          "fileSize": 18488
         },
         {
           "name": "VersaillesLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19980,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-BlackItalic.woff2"
+          "fileSize": 19980
         },
         {
           "name": "VersaillesLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19412,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-Italic.woff2"
+          "fileSize": 19412
         },
         {
           "name": "VersaillesLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19076,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-Black.woff2"
+          "fileSize": 19076
         },
         {
           "name": "VersaillesLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18616,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-Roman.woff2"
+          "fileSize": 18616
         },
         {
           "name": "VersaillesLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19680,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-BoldItalic.woff2"
+          "fileSize": 19680
         },
         {
           "name": "VersaillesLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048,
-          "url": "fonts/Versailles LT Std/VersaillesLTStd-Bold.woff2"
+          "fileSize": 19048
         }
       ]
     },
@@ -18210,24 +16528,21 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552,
-          "url": "fonts/Verve Std/VerveStd-Black.woff2"
+          "fileSize": 16552
         },
         {
           "name": "VerveStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15640,
-          "url": "fonts/Verve Std/VerveStd-Regular.woff2"
+          "fileSize": 15640
         },
         {
           "name": "VerveStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16704,
-          "url": "fonts/Verve Std/VerveStd-Bold.woff2"
+          "fileSize": 16704
         }
       ]
     },
@@ -18246,72 +16561,63 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35468,
-          "url": "fonts/Viva Std/VivaStd-Light.woff2"
+          "fileSize": 35468
         },
         {
           "name": "VivaStd-LightCondensed",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33000,
-          "url": "fonts/Viva Std/VivaStd-LightCondensed.woff2"
+          "fileSize": 33000
         },
         {
           "name": "VivaStd-LightExtraExtended",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33952,
-          "url": "fonts/Viva Std/VivaStd-LightExtraExtended.woff2"
+          "fileSize": 33952
         },
         {
           "name": "VivaStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35664,
-          "url": "fonts/Viva Std/VivaStd-Condensed.woff2"
+          "fileSize": 35664
         },
         {
           "name": "VivaStd-ExtraExtended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37244,
-          "url": "fonts/Viva Std/VivaStd-ExtraExtended.woff2"
+          "fileSize": 37244
         },
         {
           "name": "VivaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36176,
-          "url": "fonts/Viva Std/VivaStd-Regular.woff2"
+          "fileSize": 36176
         },
         {
           "name": "VivaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35912,
-          "url": "fonts/Viva Std/VivaStd-Bold.woff2"
+          "fileSize": 35912
         },
         {
           "name": "VivaStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33860,
-          "url": "fonts/Viva Std/VivaStd-BoldCondensed.woff2"
+          "fileSize": 33860
         },
         {
           "name": "VivaStd-BoldExtraExtended",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35460,
-          "url": "fonts/Viva Std/VivaStd-BoldExtraExtended.woff2"
+          "fileSize": 35460
         }
       ]
     },
@@ -18330,8 +16636,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 68416,
-          "url": "fonts/Voluta Script Pro/VolutaScriptPro-Regular.woff2"
+          "fileSize": 68416
         }
       ]
     },
@@ -18350,96 +16655,84 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 61492,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Bd.woff2"
+          "fileSize": 61492
         },
         {
           "name": "WatersTitlingPro-BdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58876,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-BdCn.woff2"
+          "fileSize": 58876
         },
         {
           "name": "WatersTitlingPro-BdScn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 68688,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-BdScn.woff2"
+          "fileSize": 68688
         },
         {
           "name": "WatersTitlingPro-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67096,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Cn.woff2"
+          "fileSize": 67096
         },
         {
           "name": "WatersTitlingPro-Lt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 57952,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Lt.woff2"
+          "fileSize": 57952
         },
         {
           "name": "WatersTitlingPro-LtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 59032,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-LtCn.woff2"
+          "fileSize": 59032
         },
         {
           "name": "WatersTitlingPro-LtScn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67468,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-LtScn.woff2"
+          "fileSize": 67468
         },
         {
           "name": "WatersTitlingPro-Rg",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69480,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Rg.woff2"
+          "fileSize": 69480
         },
         {
           "name": "WatersTitlingPro-Sb",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69340,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Sb.woff2"
+          "fileSize": 69340
         },
         {
           "name": "WatersTitlingPro-SbCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67296,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-SbCn.woff2"
+          "fileSize": 67296
         },
         {
           "name": "WatersTitlingPro-SbScn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69488,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-SbScn.woff2"
+          "fileSize": 69488
         },
         {
           "name": "WatersTitlingPro-Scn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69868,
-          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Scn.woff2"
+          "fileSize": 69868
         }
       ]
     },
@@ -18458,64 +16751,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20080,
-          "url": "fonts/Weidemann Std/WeidemannStd-BlackItalic.woff2"
+          "fileSize": 20080
         },
         {
           "name": "WeidemannStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19384,
-          "url": "fonts/Weidemann Std/WeidemannStd-BookItalic.woff2"
+          "fileSize": 19384
         },
         {
           "name": "WeidemannStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19192,
-          "url": "fonts/Weidemann Std/WeidemannStd-MediumItalic.woff2"
+          "fileSize": 19192
         },
         {
           "name": "WeidemannStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19000,
-          "url": "fonts/Weidemann Std/WeidemannStd-Black.woff2"
+          "fileSize": 19000
         },
         {
           "name": "WeidemannStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18308,
-          "url": "fonts/Weidemann Std/WeidemannStd-Book.woff2"
+          "fileSize": 18308
         },
         {
           "name": "WeidemannStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18612,
-          "url": "fonts/Weidemann Std/WeidemannStd-Medium.woff2"
+          "fileSize": 18612
         },
         {
           "name": "WeidemannStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20132,
-          "url": "fonts/Weidemann Std/WeidemannStd-BoldItalic.woff2"
+          "fileSize": 20132
         },
         {
           "name": "WeidemannStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19104,
-          "url": "fonts/Weidemann Std/WeidemannStd-Bold.woff2"
+          "fileSize": 19104
         }
       ]
     },
@@ -18534,32 +16819,28 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19368,
-          "url": "fonts/Weiss Std/WeissStd-Italic.woff2"
+          "fileSize": 19368
         },
         {
           "name": "WeissStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19176,
-          "url": "fonts/Weiss Std/WeissStd.woff2"
+          "fileSize": 19176
         },
         {
           "name": "WeissStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19468,
-          "url": "fonts/Weiss Std/WeissStd-Bold.woff2"
+          "fileSize": 19468
         },
         {
           "name": "WeissStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19824,
-          "url": "fonts/Weiss Std/WeissStd-ExtraBold.woff2"
+          "fileSize": 19824
         }
       ]
     },
@@ -18578,24 +16859,21 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28276,
-          "url": "fonts/Wendy LP Std/WendyLPStd-Light.woff2"
+          "fileSize": 28276
         },
         {
           "name": "WendyLPStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27392,
-          "url": "fonts/Wendy LP Std/WendyLPStd-Medium.woff2"
+          "fileSize": 27392
         },
         {
           "name": "WendyLPStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27208,
-          "url": "fonts/Wendy LP Std/WendyLPStd-Bold.woff2"
+          "fileSize": 27208
         }
       ]
     },
@@ -18614,16 +16892,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 91240,
-          "url": "fonts/Wiesbaden Swing LT Std/WiesbadenSwingLTStd-Ding.woff2"
+          "fileSize": 91240
         },
         {
           "name": "WiesbadenSwingLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24180,
-          "url": "fonts/Wiesbaden Swing LT Std/WiesbadenSwingLTStd-Roman.woff2"
+          "fileSize": 24180
         }
       ]
     },
@@ -18642,8 +16918,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27692,
-          "url": "fonts/Wilhelm Klingspor Gothic LT Std/WilhelmKlingsporGotLTStd.woff2"
+          "fileSize": 27692
         }
       ]
     },
@@ -18662,48 +16937,42 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23944,
-          "url": "fonts/Wilke LT Std/WilkeLTStd-BlackItalic.woff2"
+          "fileSize": 23944
         },
         {
           "name": "WilkeLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22896,
-          "url": "fonts/Wilke LT Std/WilkeLTStd-Italic.woff2"
+          "fileSize": 22896
         },
         {
           "name": "WilkeLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24828,
-          "url": "fonts/Wilke LT Std/WilkeLTStd-Black.woff2"
+          "fileSize": 24828
         },
         {
           "name": "WilkeLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23652,
-          "url": "fonts/Wilke LT Std/WilkeLTStd-Roman.woff2"
+          "fileSize": 23652
         },
         {
           "name": "WilkeLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23916,
-          "url": "fonts/Wilke LT Std/WilkeLTStd-BoldItalic.woff2"
+          "fileSize": 23916
         },
         {
           "name": "WilkeLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23220,
-          "url": "fonts/Wilke LT Std/WilkeLTStd-Bold.woff2"
+          "fileSize": 23220
         }
       ]
     },
@@ -18722,8 +16991,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18944,
-          "url": "fonts/Willow Std/WillowStd.woff2"
+          "fileSize": 18944
         }
       ]
     },
@@ -18742,16 +17010,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26944,
-          "url": "fonts/Wittenberger Fraktur MT Std/WittenbergerFrakturMTStd.woff2"
+          "fileSize": 26944
         },
         {
           "name": "WittenbergerFrakturMTStd-Bd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26352,
-          "url": "fonts/Wittenberger Fraktur MT Std/WittenbergerFrakturMTStd-Bd.woff2"
+          "fileSize": 26352
         }
       ]
     },
@@ -18770,16 +17036,14 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22732,
-          "url": "fonts/Zebrawood Std/ZebrawoodStd-Fill.woff2"
+          "fileSize": 22732
         },
         {
           "name": "ZebrawoodStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 63840,
-          "url": "fonts/Zebrawood Std/ZebrawoodStd-Regular.woff2"
+          "fileSize": 63840
         }
       ]
     },
@@ -18798,8 +17062,7 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33828,
-          "url": "fonts/Zipty Do Std/ZiptyDoStd.woff2"
+          "fileSize": 33828
         }
       ]
     }

--- a/fonts.json
+++ b/fonts.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
-    "generationTimestamp": "2025-04-06T01:45:11.917Z",
+    "generationTimestamp": "2025-04-06T04:43:39.898Z",
     "familyCount": 407,
     "variantCount": 1738,
     "totalOriginalSizeMB": "40.67",
-    "base64Included": true,
+    "base64Included": false,
     "formatSummary": {
       "woff2": 407
     },
@@ -12,8 +12,7 @@
       "300": 151,
       "400": 1107,
       "700": 480
-    },
-    "totalBase64SizeMB": "54.27"
+    }
   },
   "fonts": [
     {
@@ -31,7 +30,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18912
+          "fileSize": 18912,
+          "url": "fonts/Aachen Std/AachenStd-Bold.woff2"
         }
       ]
     },
@@ -50,42 +50,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 104364
+          "fileSize": 104364,
+          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Italic.woff2"
         },
         {
           "name": "ACaslonPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 104220
+          "fileSize": 104220,
+          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Regular.woff2"
         },
         {
           "name": "ACaslonPro-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 105948
+          "fileSize": 105948,
+          "url": "fonts/Adobe Caslon Pro/ACaslonPro-BoldItalic.woff2"
         },
         {
           "name": "ACaslonPro-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 106864
+          "fileSize": 106864,
+          "url": "fonts/Adobe Caslon Pro/ACaslonPro-SemiboldItalic.woff2"
         },
         {
           "name": "ACaslonPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 95560
+          "fileSize": 95560,
+          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Bold.woff2"
         },
         {
           "name": "ACaslonPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 106852
+          "fileSize": 106852,
+          "url": "fonts/Adobe Caslon Pro/ACaslonPro-Semibold.woff2"
         }
       ]
     },
@@ -104,42 +110,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 52140
+          "fileSize": 52140,
+          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Italic.woff2"
         },
         {
           "name": "AGaramondPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67016
+          "fileSize": 67016,
+          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Regular.woff2"
         },
         {
           "name": "AGaramondPro-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 44068
+          "fileSize": 44068,
+          "url": "fonts/Adobe Garamond Pro/AGaramondPro-BoldItalic.woff2"
         },
         {
           "name": "AGaramondPro-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 45504
+          "fileSize": 45504,
+          "url": "fonts/Adobe Garamond Pro/AGaramondPro-SemiboldItalic.woff2"
         },
         {
           "name": "AGaramondPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41964
+          "fileSize": 41964,
+          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Bold.woff2"
         },
         {
           "name": "AGaramondPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 51512
+          "fileSize": 51512,
+          "url": "fonts/Adobe Garamond Pro/AGaramondPro-Semibold.woff2"
         }
       ]
     },
@@ -158,7 +170,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39776
+          "fileSize": 39776,
+          "url": "fonts/Adobe Wood Type Ornaments Std/WoodtypeOrnamentsStd.woff2"
         }
       ]
     },
@@ -177,21 +190,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20748
+          "fileSize": 20748,
+          "url": "fonts/Albertus MT Std/AlbertusMTStd-Light.woff2"
         },
         {
           "name": "AlbertusMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19692
+          "fileSize": 19692,
+          "url": "fonts/Albertus MT Std/AlbertusMTStd-Italic.woff2"
         },
         {
           "name": "AlbertusMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19596
+          "fileSize": 19596,
+          "url": "fonts/Albertus MT Std/AlbertusMTStd.woff2"
         }
       ]
     },
@@ -210,14 +226,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25160
+          "fileSize": 25160,
+          "url": "fonts/Aldus LT Std/AldusLTStd-Italic.woff2"
         },
         {
           "name": "AldusLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460
+          "fileSize": 30460,
+          "url": "fonts/Aldus LT Std/AldusLTStd-Roman.woff2"
         }
       ]
     },
@@ -236,7 +254,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24860
+          "fileSize": 24860,
+          "url": "fonts/Alexa Std/AlexaStd.woff2"
         }
       ]
     },
@@ -255,28 +274,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21364
+          "fileSize": 21364,
+          "url": "fonts/Americana Std/AmericanaStd-Italic.woff2"
         },
         {
           "name": "AmericanaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21452
+          "fileSize": 21452,
+          "url": "fonts/Americana Std/AmericanaStd.woff2"
         },
         {
           "name": "AmericanaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20684
+          "fileSize": 20684,
+          "url": "fonts/Americana Std/AmericanaStd-Bold.woff2"
         },
         {
           "name": "AmericanaStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18992
+          "fileSize": 18992,
+          "url": "fonts/Americana Std/AmericanaStd-ExtraBold.woff2"
         }
       ]
     },
@@ -295,7 +318,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36612
+          "fileSize": 36612,
+          "url": "fonts/Andreas Std/AndreasStd.woff2"
         }
       ]
     },
@@ -314,63 +338,72 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14864
+          "fileSize": 14864,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Light.woff2"
         },
         {
           "name": "AntiqueOliveStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15380
+          "fileSize": 15380,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Italic.woff2"
         },
         {
           "name": "AntiqueOliveStd-NordItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16312
+          "fileSize": 16312,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-NordItalic.woff2"
         },
         {
           "name": "AntiqueOliveStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15528
+          "fileSize": 15528,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Black.woff2"
         },
         {
           "name": "AntiqueOliveStd-Compact",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15552
+          "fileSize": 15552,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Compact.woff2"
         },
         {
           "name": "AntiqueOliveStd-Nord",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15496
+          "fileSize": 15496,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Nord.woff2"
         },
         {
           "name": "AntiqueOliveStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15156
+          "fileSize": 15156,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Roman.woff2"
         },
         {
           "name": "AntiqueOliveStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15360
+          "fileSize": 15360,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-Bold.woff2"
         },
         {
           "name": "AntiqueOliveStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15008
+          "fileSize": 15008,
+          "url": "fonts/Antique Olive Std/AntiqueOliveStd-BoldCond.woff2"
         }
       ]
     },
@@ -389,21 +422,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32504
+          "fileSize": 32504,
+          "url": "fonts/Apollo MT Std/ApolloMTStd-Italic.woff2"
         },
         {
           "name": "ApolloMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 38800
+          "fileSize": 38800,
+          "url": "fonts/Apollo MT Std/ApolloMTStd.woff2"
         },
         {
           "name": "ApolloMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31152
+          "fileSize": 31152,
+          "url": "fonts/Apollo MT Std/ApolloMTStd-SemiBold.woff2"
         }
       ]
     },
@@ -422,7 +458,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13852
+          "fileSize": 13852,
+          "url": "fonts/Arcadia LT Std/ArcadiaLTStd.woff2"
         }
       ]
     },
@@ -441,7 +478,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 127792
+          "fileSize": 127792,
+          "url": "fonts/Arcana GMM Std/ArcanaGMMStd-Manuscript.woff2"
         }
       ]
     },
@@ -460,7 +498,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12852
+          "fileSize": 12852,
+          "url": "fonts/Ariadne LT Std/AriadneLTStd-Roman.woff2"
         }
       ]
     },
@@ -479,7 +518,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26548
+          "fileSize": 26548,
+          "url": "fonts/Arnold Boecklin Std/ArnoldBoecklinStd.woff2"
         }
       ]
     },
@@ -498,7 +538,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27668
+          "fileSize": 27668,
+          "url": "fonts/Ashley Script MT Std/AshleyScriptMTStd.woff2"
         }
       ]
     },
@@ -517,42 +558,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24124
+          "fileSize": 24124,
+          "url": "fonts/Auriol LT Std/AuriolLTStd-BlackItalic.woff2"
         },
         {
           "name": "AuriolLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23944
+          "fileSize": 23944,
+          "url": "fonts/Auriol LT Std/AuriolLTStd-Italic.woff2"
         },
         {
           "name": "AuriolLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21652
+          "fileSize": 21652,
+          "url": "fonts/Auriol LT Std/AuriolLTStd.woff2"
         },
         {
           "name": "AuriolLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22492
+          "fileSize": 22492,
+          "url": "fonts/Auriol LT Std/AuriolLTStd-Black.woff2"
         },
         {
           "name": "AuriolLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24136
+          "fileSize": 24136,
+          "url": "fonts/Auriol LT Std/AuriolLTStd-BoldItalic.woff2"
         },
         {
           "name": "AuriolLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22212
+          "fileSize": 22212,
+          "url": "fonts/Auriol LT Std/AuriolLTStd-Bold.woff2"
         }
       ]
     },
@@ -571,84 +618,96 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15004
+          "fileSize": 15004,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Light.woff2"
         },
         {
           "name": "AvenirLTStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16484
+          "fileSize": 16484,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-LightOblique.woff2"
         },
         {
           "name": "AvenirLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15392
+          "fileSize": 15392,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Black.woff2"
         },
         {
           "name": "AvenirLTStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15240
+          "fileSize": 15240,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Book.woff2"
         },
         {
           "name": "AvenirLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15432
+          "fileSize": 15432,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Heavy.woff2"
         },
         {
           "name": "AvenirLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15052
+          "fileSize": 15052,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Medium.woff2"
         },
         {
           "name": "AvenirLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15040
+          "fileSize": 15040,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Roman.woff2"
         },
         {
           "name": "AvenirLTStd-BlackOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16668
+          "fileSize": 16668,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-BlackOblique.woff2"
         },
         {
           "name": "AvenirLTStd-BookOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16512
+          "fileSize": 16512,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-BookOblique.woff2"
         },
         {
           "name": "AvenirLTStd-HeavyOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16452
+          "fileSize": 16452,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-HeavyOblique.woff2"
         },
         {
           "name": "AvenirLTStd-MediumOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16700
+          "fileSize": 16700,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-MediumOblique.woff2"
         },
         {
           "name": "AvenirLTStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16428
+          "fileSize": 16428,
+          "url": "fonts/Avenir LT Std/AvenirLTStd-Oblique.woff2"
         }
       ]
     },
@@ -667,7 +726,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24956
+          "fileSize": 24956,
+          "url": "fonts/Balzano Std/BalzanoStd.woff2"
         }
       ]
     },
@@ -686,7 +746,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13368
+          "fileSize": 13368,
+          "url": "fonts/Banco Std/BancoStd.woff2"
         }
       ]
     },
@@ -705,7 +766,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 61644
+          "fileSize": 61644,
+          "url": "fonts/Banshee Std/BansheeStd.woff2"
         }
       ]
     },
@@ -724,21 +786,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28784
+          "fileSize": 28784,
+          "url": "fonts/Baskerville Cyrillic LT Std/BaskervilleCyrLTStd-Incline.woff2"
         },
         {
           "name": "BaskervilleCyrLTStd-Upright",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27448
+          "fileSize": 27448,
+          "url": "fonts/Baskerville Cyrillic LT Std/BaskervilleCyrLTStd-Upright.woff2"
         },
         {
           "name": "BaskervilleCyrLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25496
+          "fileSize": 25496,
+          "url": "fonts/Baskerville Cyrillic LT Std/BaskervilleCyrLTStd-Bold.woff2"
         }
       ]
     },
@@ -757,56 +822,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20308
+          "fileSize": 20308,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BlackItalic.woff2"
         },
         {
           "name": "BauerBodoniStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21952
+          "fileSize": 21952,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Italic.woff2"
         },
         {
           "name": "BauerBodoniStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18696
+          "fileSize": 18696,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Black.woff2"
         },
         {
           "name": "BauerBodoniStd-BlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18076
+          "fileSize": 18076,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BlackCond.woff2"
         },
         {
           "name": "BauerBodoniStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25604
+          "fileSize": 25604,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Roman.woff2"
         },
         {
           "name": "BauerBodoniStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21960
+          "fileSize": 21960,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BoldItalic.woff2"
         },
         {
           "name": "BauerBodoniStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20880
+          "fileSize": 20880,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-Bold.woff2"
         },
         {
           "name": "BauerBodoniStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17792
+          "fileSize": 17792,
+          "url": "fonts/Bauer Bodoni Std/BauerBodoniStd-BoldCond.woff2"
         }
       ]
     },
@@ -825,35 +898,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15088
+          "fileSize": 15088,
+          "url": "fonts/Bauhaus Std/BauhausStd-Light.woff2"
         },
         {
           "name": "BauhausStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15236
+          "fileSize": 15236,
+          "url": "fonts/Bauhaus Std/BauhausStd-Demi.woff2"
         },
         {
           "name": "BauhausStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15320
+          "fileSize": 15320,
+          "url": "fonts/Bauhaus Std/BauhausStd-Heavy.woff2"
         },
         {
           "name": "BauhausStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14980
+          "fileSize": 14980,
+          "url": "fonts/Bauhaus Std/BauhausStd-Medium.woff2"
         },
         {
           "name": "BauhausStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15396
+          "fileSize": 15396,
+          "url": "fonts/Bauhaus Std/BauhausStd-Bold.woff2"
         }
       ]
     },
@@ -872,28 +950,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17016
+          "fileSize": 17016,
+          "url": "fonts/Bell Centennial Std/BellCentennialStd-Address.woff2"
         },
         {
           "name": "BellCentennialStd-BdListing",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27592
+          "fileSize": 27592,
+          "url": "fonts/Bell Centennial Std/BellCentennialStd-BdListing.woff2"
         },
         {
           "name": "BellCentennialStd-NameNum",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18528
+          "fileSize": 18528,
+          "url": "fonts/Bell Centennial Std/BellCentennialStd-NameNum.woff2"
         },
         {
           "name": "BellCentennialStd-SubCapt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17404
+          "fileSize": 17404,
+          "url": "fonts/Bell Centennial Std/BellCentennialStd-SubCapt.woff2"
         }
       ]
     },
@@ -912,21 +994,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17468
+          "fileSize": 17468,
+          "url": "fonts/Bell Gothic Std/BellGothicStd-Light.woff2"
         },
         {
           "name": "BellGothicStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17304
+          "fileSize": 17304,
+          "url": "fonts/Bell Gothic Std/BellGothicStd-Black.woff2"
         },
         {
           "name": "BellGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17816
+          "fileSize": 17816,
+          "url": "fonts/Bell Gothic Std/BellGothicStd-Bold.woff2"
         }
       ]
     },
@@ -945,42 +1030,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 37524
+          "fileSize": 37524,
+          "url": "fonts/Bell MT Std/BellMTStd-Italic.woff2"
         },
         {
           "name": "BellMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43832
+          "fileSize": 43832,
+          "url": "fonts/Bell MT Std/BellMTStd-Regular.woff2"
         },
         {
           "name": "BellMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 34648
+          "fileSize": 34648,
+          "url": "fonts/Bell MT Std/BellMTStd-BoldItalic.woff2"
         },
         {
           "name": "BellMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 36968
+          "fileSize": 36968,
+          "url": "fonts/Bell MT Std/BellMTStd-SemiBoldItalic.woff2"
         },
         {
           "name": "BellMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35088
+          "fileSize": 35088,
+          "url": "fonts/Bell MT Std/BellMTStd-Bold.woff2"
         },
         {
           "name": "BellMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43168
+          "fileSize": 43168,
+          "url": "fonts/Bell MT Std/BellMTStd-SemiBold.woff2"
         }
       ]
     },
@@ -999,28 +1090,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17980
+          "fileSize": 17980,
+          "url": "fonts/Belwe Std/BelweStd-Light.woff2"
         },
         {
           "name": "BelweStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17216
+          "fileSize": 17216,
+          "url": "fonts/Belwe Std/BelweStd-Condensed.woff2"
         },
         {
           "name": "BelweStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17764
+          "fileSize": 17764,
+          "url": "fonts/Belwe Std/BelweStd-Medium.woff2"
         },
         {
           "name": "BelweStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17412
+          "fileSize": 17412,
+          "url": "fonts/Belwe Std/BelweStd-Bold.woff2"
         }
       ]
     },
@@ -1039,56 +1134,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28908
+          "fileSize": 28908,
+          "url": "fonts/Bembo Std/BemboStd-Italic.woff2"
         },
         {
           "name": "BemboStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34672
+          "fileSize": 34672,
+          "url": "fonts/Bembo Std/BemboStd.woff2"
         },
         {
           "name": "BemboStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28628
+          "fileSize": 28628,
+          "url": "fonts/Bembo Std/BemboStd-BoldItalic.woff2"
         },
         {
           "name": "BemboStd-ExtraBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28620
+          "fileSize": 28620,
+          "url": "fonts/Bembo Std/BemboStd-ExtraBoldItalic.woff2"
         },
         {
           "name": "BemboStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29064
+          "fileSize": 29064,
+          "url": "fonts/Bembo Std/BemboStd-SemiboldItalic.woff2"
         },
         {
           "name": "BemboStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26512
+          "fileSize": 26512,
+          "url": "fonts/Bembo Std/BemboStd-Bold.woff2"
         },
         {
           "name": "BemboStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27276
+          "fileSize": 27276,
+          "url": "fonts/Bembo Std/BemboStd-ExtraBold.woff2"
         },
         {
           "name": "BemboStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26884
+          "fileSize": 26884,
+          "url": "fonts/Bembo Std/BemboStd-Semibold.woff2"
         }
       ]
     },
@@ -1107,28 +1210,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20172
+          "fileSize": 20172,
+          "url": "fonts/Berling LT Std/BerlingLTStd-Italic.woff2"
         },
         {
           "name": "BerlingLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19292
+          "fileSize": 19292,
+          "url": "fonts/Berling LT Std/BerlingLTStd-Roman.woff2"
         },
         {
           "name": "BerlingLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20140
+          "fileSize": 20140,
+          "url": "fonts/Berling LT Std/BerlingLTStd-BoldItalic.woff2"
         },
         {
           "name": "BerlingLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19056
+          "fileSize": 19056,
+          "url": "fonts/Berling LT Std/BerlingLTStd-Bold.woff2"
         }
       ]
     },
@@ -1147,28 +1254,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 59124
+          "fileSize": 59124,
+          "url": "fonts/Bermuda LP Std/BermudaLPStd-Dots.woff2"
         },
         {
           "name": "BermudaLPStd-Open",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42724
+          "fileSize": 42724,
+          "url": "fonts/Bermuda LP Std/BermudaLPStd-Open.woff2"
         },
         {
           "name": "BermudaLPStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40168
+          "fileSize": 40168,
+          "url": "fonts/Bermuda LP Std/BermudaLPStd-Solid.woff2"
         },
         {
           "name": "BermudaLPStd-Squiggle",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58124
+          "fileSize": 58124,
+          "url": "fonts/Bermuda LP Std/BermudaLPStd-Squiggle.woff2"
         }
       ]
     },
@@ -1187,28 +1298,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22516
+          "fileSize": 22516,
+          "url": "fonts/Bernhard Modern Std/BernhardModernStd-Italic.woff2"
         },
         {
           "name": "BernhardModernStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22612
+          "fileSize": 22612,
+          "url": "fonts/Bernhard Modern Std/BernhardModernStd-Roman.woff2"
         },
         {
           "name": "BernhardModernStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22796
+          "fileSize": 22796,
+          "url": "fonts/Bernhard Modern Std/BernhardModernStd-Bold.woff2"
         },
         {
           "name": "BernhardModernStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23232
+          "fileSize": 23232,
+          "url": "fonts/Bernhard Modern Std/BernhardModernStd-BoldIt.woff2"
         }
       ]
     },
@@ -1227,7 +1342,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39064
+          "fileSize": 39064,
+          "url": "fonts/Bernhard Std/BernhardStd-BoldCondensed.woff2"
         }
       ]
     },
@@ -1246,21 +1362,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 75912
+          "fileSize": 75912,
+          "url": "fonts/Bickham Script Std/BickhamScriptStd-Regular.woff2"
         },
         {
           "name": "BickhamScriptStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 75368
+          "fileSize": 75368,
+          "url": "fonts/Bickham Script Std/BickhamScriptStd-Bold.woff2"
         },
         {
           "name": "BickhamScriptStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 79424
+          "fileSize": 79424,
+          "url": "fonts/Bickham Script Std/BickhamScriptStd-Semibold.woff2"
         }
       ]
     },
@@ -1279,7 +1398,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22940
+          "fileSize": 22940,
+          "url": "fonts/Biffo MT Std/BiffoMTStd.woff2"
         }
       ]
     },
@@ -1298,7 +1418,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19724
+          "fileSize": 19724,
+          "url": "fonts/Birch Std/BirchStd.woff2"
         }
       ]
     },
@@ -1317,7 +1438,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24380
+          "fileSize": 24380,
+          "url": "fonts/Blackoak Std/BlackoakStd.woff2"
         }
       ]
     },
@@ -1336,7 +1458,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21228
+          "fileSize": 21228,
+          "url": "fonts/Blue Island Std/BlueIslandStd.woff2"
         }
       ]
     },
@@ -1355,70 +1478,80 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19108
+          "fileSize": 19108,
+          "url": "fonts/Bodoni Std/BodoniStd-BookItalic.woff2"
         },
         {
           "name": "BodoniStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20932
+          "fileSize": 20932,
+          "url": "fonts/Bodoni Std/BodoniStd-Italic.woff2"
         },
         {
           "name": "BodoniStd-PosterItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21612
+          "fileSize": 21612,
+          "url": "fonts/Bodoni Std/BodoniStd-PosterItalic.woff2"
         },
         {
           "name": "BodoniStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18128
+          "fileSize": 18128,
+          "url": "fonts/Bodoni Std/BodoniStd.woff2"
         },
         {
           "name": "BodoniStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18228
+          "fileSize": 18228,
+          "url": "fonts/Bodoni Std/BodoniStd-Book.woff2"
         },
         {
           "name": "BodoniStd-Poster",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19416
+          "fileSize": 19416,
+          "url": "fonts/Bodoni Std/BodoniStd-Poster.woff2"
         },
         {
           "name": "BodoniStd-PosterCompressed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17752
+          "fileSize": 17752,
+          "url": "fonts/Bodoni Std/BodoniStd-PosterCompressed.woff2"
         },
         {
           "name": "BodoniStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20636
+          "fileSize": 20636,
+          "url": "fonts/Bodoni Std/BodoniStd-BoldItalic.woff2"
         },
         {
           "name": "BodoniStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18888
+          "fileSize": 18888,
+          "url": "fonts/Bodoni Std/BodoniStd-Bold.woff2"
         },
         {
           "name": "BodoniStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18336
+          "fileSize": 18336,
+          "url": "fonts/Bodoni Std/BodoniStd-BoldCondensed.woff2"
         }
       ]
     },
@@ -1437,7 +1570,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 3552
+          "fileSize": 3552,
+          "url": "fonts/Border Pi Std/BorderPiStd-15159.woff2"
         }
       ]
     },
@@ -1456,7 +1590,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27608
+          "fileSize": 27608,
+          "url": "fonts/Bossa Nova MVB Std/BossaNovaMVBStd.woff2"
         }
       ]
     },
@@ -1475,84 +1610,96 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10668
+          "fileSize": 10668,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Black.woff2"
         },
         {
           "name": "BriemAkademiStd-BlackComp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11232
+          "fileSize": 11232,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BlackComp.woff2"
         },
         {
           "name": "BriemAkademiStd-BlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10820
+          "fileSize": 10820,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BlackCond.woff2"
         },
         {
           "name": "BriemAkademiStd-Comp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10260
+          "fileSize": 10260,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Comp.woff2"
         },
         {
           "name": "BriemAkademiStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10808
+          "fileSize": 10808,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Cond.woff2"
         },
         {
           "name": "BriemAkademiStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10408
+          "fileSize": 10408,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Regular.woff2"
         },
         {
           "name": "BriemAkademiStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11468
+          "fileSize": 11468,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Bold.woff2"
         },
         {
           "name": "BriemAkademiStd-BoldComp",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10900
+          "fileSize": 10900,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BoldComp.woff2"
         },
         {
           "name": "BriemAkademiStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11216
+          "fileSize": 11216,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-BoldCond.woff2"
         },
         {
           "name": "BriemAkademiStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11408
+          "fileSize": 11408,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-Semibold.woff2"
         },
         {
           "name": "BriemAkademiStd-SemiboldCmp",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10764
+          "fileSize": 10764,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-SemiboldCmp.woff2"
         },
         {
           "name": "BriemAkademiStd-SemiboldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11268
+          "fileSize": 11268,
+          "url": "fonts/Briem Akademi Std/BriemAkademiStd-SemiboldCn.woff2"
         }
       ]
     },
@@ -1571,42 +1718,48 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32924
+          "fileSize": 32924,
+          "url": "fonts/Briem Script Std/BriemScriptStd-Light.woff2"
         },
         {
           "name": "BriemScriptStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35096
+          "fileSize": 35096,
+          "url": "fonts/Briem Script Std/BriemScriptStd-Black.woff2"
         },
         {
           "name": "BriemScriptStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34944
+          "fileSize": 34944,
+          "url": "fonts/Briem Script Std/BriemScriptStd-Medium.woff2"
         },
         {
           "name": "BriemScriptStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35144
+          "fileSize": 35144,
+          "url": "fonts/Briem Script Std/BriemScriptStd-Regular.woff2"
         },
         {
           "name": "BriemScriptStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31968
+          "fileSize": 31968,
+          "url": "fonts/Briem Script Std/BriemScriptStd-Ultra.woff2"
         },
         {
           "name": "BriemScriptStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35176
+          "fileSize": 35176,
+          "url": "fonts/Briem Script Std/BriemScriptStd-Bold.woff2"
         }
       ]
     },
@@ -1625,14 +1778,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28152
+          "fileSize": 28152,
+          "url": "fonts/Bruno JB Std/BrunoJBStd.woff2"
         },
         {
           "name": "BrunoJBStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28728
+          "fileSize": 28728,
+          "url": "fonts/Bruno JB Std/BrunoJBStd-Bold.woff2"
         }
       ]
     },
@@ -1651,7 +1806,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23724
+          "fileSize": 23724,
+          "url": "fonts/Brush Script Std/BrushScriptStd.woff2"
         }
       ]
     },
@@ -1670,70 +1826,80 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 40712
+          "fileSize": 40712,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-Italic.woff2"
         },
         {
           "name": "BulmerMTStd-ItalicDisplay",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 34924
+          "fileSize": 34924,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-ItalicDisplay.woff2"
         },
         {
           "name": "BulmerMTStd-Display",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31668
+          "fileSize": 31668,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-Display.woff2"
         },
         {
           "name": "BulmerMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45212
+          "fileSize": 45212,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-Regular.woff2"
         },
         {
           "name": "BulmerMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 41352
+          "fileSize": 41352,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-BoldItalic.woff2"
         },
         {
           "name": "BulmerMTStd-BoldItalicDisp",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35980
+          "fileSize": 35980,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-BoldItalicDisp.woff2"
         },
         {
           "name": "BulmerMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 40148
+          "fileSize": 40148,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-SemiBoldItalic.woff2"
         },
         {
           "name": "BulmerMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37276
+          "fileSize": 37276,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-Bold.woff2"
         },
         {
           "name": "BulmerMTStd-BoldDisplay",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33220
+          "fileSize": 33220,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-BoldDisplay.woff2"
         },
         {
           "name": "BulmerMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44548
+          "fileSize": 44548,
+          "url": "fonts/Bulmer MT Std/BulmerMTStd-SemiBold.woff2"
         }
       ]
     },
@@ -1752,21 +1918,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 6784
+          "fileSize": 6784,
+          "url": "fonts/Bundesbahn Pi Std/BundesbahnPiStd-1.woff2"
         },
         {
           "name": "BundesbahnPiStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 5856
+          "fileSize": 5856,
+          "url": "fonts/Bundesbahn Pi Std/BundesbahnPiStd-2.woff2"
         },
         {
           "name": "BundesbahnPiStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 6724
+          "fileSize": 6724,
+          "url": "fonts/Bundesbahn Pi Std/BundesbahnPiStd-3.woff2"
         }
       ]
     },
@@ -1785,28 +1954,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 113372
+          "fileSize": 113372,
+          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Light.woff2"
         },
         {
           "name": "CaflischScriptPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 144272
+          "fileSize": 144272,
+          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Regular.woff2"
         },
         {
           "name": "CaflischScriptPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 110460
+          "fileSize": 110460,
+          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Bold.woff2"
         },
         {
           "name": "CaflischScriptPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 144912
+          "fileSize": 144912,
+          "url": "fonts/Caflisch Script Pro/CaflischScriptPro-Semibold.woff2"
         }
       ]
     },
@@ -1825,21 +1998,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26632
+          "fileSize": 26632,
+          "url": "fonts/Calcite Pro/CalcitePro-Black.woff2"
         },
         {
           "name": "CalcitePro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26168
+          "fileSize": 26168,
+          "url": "fonts/Calcite Pro/CalcitePro-Regular.woff2"
         },
         {
           "name": "CalcitePro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28328
+          "fileSize": 28328,
+          "url": "fonts/Calcite Pro/CalcitePro-Bold.woff2"
         }
       ]
     },
@@ -1858,7 +2034,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25688
+          "fileSize": 25688,
+          "url": "fonts/Caliban Std/CalibanStd.woff2"
         }
       ]
     },
@@ -1877,21 +2054,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17940
+          "fileSize": 17940,
+          "url": "fonts/Calvert MT Std/CalvertMTStd-Light.woff2"
         },
         {
           "name": "CalvertMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17676
+          "fileSize": 17676,
+          "url": "fonts/Calvert MT Std/CalvertMTStd.woff2"
         },
         {
           "name": "CalvertMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17752
+          "fileSize": 17752,
+          "url": "fonts/Calvert MT Std/CalvertMTStd-Bold.woff2"
         }
       ]
     },
@@ -1910,21 +2090,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18656
+          "fileSize": 18656,
+          "url": "fonts/Candida Std/CandidaStd-Italic.woff2"
         },
         {
           "name": "CandidaStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16904
+          "fileSize": 16904,
+          "url": "fonts/Candida Std/CandidaStd-Roman.woff2"
         },
         {
           "name": "CandidaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16984
+          "fileSize": 16984,
+          "url": "fonts/Candida Std/CandidaStd-Bold.woff2"
         }
       ]
     },
@@ -1943,70 +2126,80 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21492
+          "fileSize": 21492,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-LightItalic.woff2"
         },
         {
           "name": "CantoriaMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19944
+          "fileSize": 19944,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-Light.woff2"
         },
         {
           "name": "CantoriaMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21320
+          "fileSize": 21320,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-Italic.woff2"
         },
         {
           "name": "CantoriaMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20224
+          "fileSize": 20224,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd.woff2"
         },
         {
           "name": "CantoriaMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21264
+          "fileSize": 21264,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-BoldItalic.woff2"
         },
         {
           "name": "CantoriaMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20120
+          "fileSize": 20120,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-Bold.woff2"
         },
         {
           "name": "CantoriaMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20428
+          "fileSize": 20428,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-ExtraBold.woff2"
         },
         {
           "name": "CantoriaMTStd-ExtraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21064
+          "fileSize": 21064,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-ExtraBoldIt.woff2"
         },
         {
           "name": "CantoriaMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20128
+          "fileSize": 20128,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-SemiBold.woff2"
         },
         {
           "name": "CantoriaMTStd-SemiBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21124
+          "fileSize": 21124,
+          "url": "fonts/Cantoria MT Std/CantoriaMTStd-SemiBoldIt.woff2"
         }
       ]
     },
@@ -2025,28 +2218,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25284
+          "fileSize": 25284,
+          "url": "fonts/Caravan LT Std/CaravanLTStd-1.woff2"
         },
         {
           "name": "CaravanLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18432
+          "fileSize": 18432,
+          "url": "fonts/Caravan LT Std/CaravanLTStd-2.woff2"
         },
         {
           "name": "CaravanLTStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19504
+          "fileSize": 19504,
+          "url": "fonts/Caravan LT Std/CaravanLTStd-3.woff2"
         },
         {
           "name": "CaravanLTStd-4",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19456
+          "fileSize": 19456,
+          "url": "fonts/Caravan LT Std/CaravanLTStd-4.woff2"
         }
       ]
     },
@@ -2065,7 +2262,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22964
+          "fileSize": 22964,
+          "url": "fonts/Carolina LT Std/CarolinaLTStd.woff2"
         }
       ]
     },
@@ -2084,7 +2282,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20432
+          "fileSize": 20432,
+          "url": "fonts/Carta Std/CartaStd.woff2"
         }
       ]
     },
@@ -2103,7 +2302,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19980
+          "fileSize": 19980,
+          "url": "fonts/Cascade Script LT Std/CascadeScriptLTStd.woff2"
         }
       ]
     },
@@ -2122,14 +2322,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21320
+          "fileSize": 21320,
+          "url": "fonts/Caslon 3 LT Std/Caslon3LTStd-Italic.woff2"
         },
         {
           "name": "Caslon3LTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25312
+          "fileSize": 25312,
+          "url": "fonts/Caslon 3 LT Std/Caslon3LTStd-Roman.woff2"
         }
       ]
     },
@@ -2148,14 +2350,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21528
+          "fileSize": 21528,
+          "url": "fonts/Caslon 540 LT Std/Caslon540LTStd-Italic.woff2"
         },
         {
           "name": "Caslon540LTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26840
+          "fileSize": 26840,
+          "url": "fonts/Caslon 540 LT Std/Caslon540LTStd-Roman.woff2"
         }
       ]
     },
@@ -2174,7 +2378,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29988
+          "fileSize": 29988,
+          "url": "fonts/Caslon Open Face LT Std/CaslonOpenFaceLTStd.woff2"
         }
       ]
     },
@@ -2193,7 +2398,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21680
+          "fileSize": 21680,
+          "url": "fonts/Castellar MT Std/CastellarMTStd.woff2"
         }
       ]
     },
@@ -2212,42 +2418,48 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25344
+          "fileSize": 25344,
+          "url": "fonts/Caxton Std/CaxtonStd-LightItalic.woff2"
         },
         {
           "name": "CaxtonStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24208
+          "fileSize": 24208,
+          "url": "fonts/Caxton Std/CaxtonStd-Light.woff2"
         },
         {
           "name": "CaxtonStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24800
+          "fileSize": 24800,
+          "url": "fonts/Caxton Std/CaxtonStd-BookItalic.woff2"
         },
         {
           "name": "CaxtonStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23928
+          "fileSize": 23928,
+          "url": "fonts/Caxton Std/CaxtonStd-Book.woff2"
         },
         {
           "name": "CaxtonStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24696
+          "fileSize": 24696,
+          "url": "fonts/Caxton Std/CaxtonStd-BoldItalic.woff2"
         },
         {
           "name": "CaxtonStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23616
+          "fileSize": 23616,
+          "url": "fonts/Caxton Std/CaxtonStd-Bold.woff2"
         }
       ]
     },
@@ -2266,28 +2478,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 46740
+          "fileSize": 46740,
+          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd-Italic.woff2"
         },
         {
           "name": "CelestiaAntiquaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 110476
+          "fileSize": 110476,
+          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd.woff2"
         },
         {
           "name": "CelestiaAntiquaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 51296
+          "fileSize": 51296,
+          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd-Bold.woff2"
         },
         {
           "name": "CelestiaAntiquaStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 49324
+          "fileSize": 49324,
+          "url": "fonts/Celestia Antiqua Std/CelestiaAntiquaStd-Semibold.woff2"
         }
       ]
     },
@@ -2306,28 +2522,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 43436
+          "fileSize": 43436,
+          "url": "fonts/Centaur MT Std/CentaurMTStd-Italic.woff2"
         },
         {
           "name": "CentaurMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45208
+          "fileSize": 45208,
+          "url": "fonts/Centaur MT Std/CentaurMTStd.woff2"
         },
         {
           "name": "CentaurMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32892
+          "fileSize": 32892,
+          "url": "fonts/Centaur MT Std/CentaurMTStd-BoldItalic.woff2"
         },
         {
           "name": "CentaurMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35744
+          "fileSize": 35744,
+          "url": "fonts/Centaur MT Std/CentaurMTStd-Bold.woff2"
         }
       ]
     },
@@ -2346,14 +2566,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20968
+          "fileSize": 20968,
+          "url": "fonts/Century Expanded LT Std/CenturyExpandedLTStd-Italic.woff2"
         },
         {
           "name": "CenturyExpandedLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19336
+          "fileSize": 19336,
+          "url": "fonts/Century Expanded LT Std/CenturyExpandedLTStd.woff2"
         }
       ]
     },
@@ -2372,21 +2594,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19724
+          "fileSize": 19724,
+          "url": "fonts/Century Old Style Std/CenturyOldStyleStd-Italic.woff2"
         },
         {
           "name": "CenturyOldStyleStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18464
+          "fileSize": 18464,
+          "url": "fonts/Century Old Style Std/CenturyOldStyleStd-Regular.woff2"
         },
         {
           "name": "CenturyOldStyleStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18312
+          "fileSize": 18312,
+          "url": "fonts/Century Old Style Std/CenturyOldStyleStd-Bold.woff2"
         }
       ]
     },
@@ -2405,14 +2630,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19728
+          "fileSize": 19728,
+          "url": "fonts/Charlemagne Std/CharlemagneStd-Regular.woff2"
         },
         {
           "name": "CharlemagneStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19916
+          "fileSize": 19916,
+          "url": "fonts/Charlemagne Std/CharlemagneStd-Bold.woff2"
         }
       ]
     },
@@ -2431,7 +2658,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23208
+          "fileSize": 23208,
+          "url": "fonts/Charme Std/CharmeStd.woff2"
         }
       ]
     },
@@ -2450,7 +2678,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7608
+          "fileSize": 7608,
+          "url": "fonts/Cheq Std/CheqStd.woff2"
         }
       ]
     },
@@ -2469,7 +2698,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20844
+          "fileSize": 20844,
+          "url": "fonts/Clairvaux LT Std/ClairvauxLTStd.woff2"
         }
       ]
     },
@@ -2488,21 +2718,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19008
+          "fileSize": 19008,
+          "url": "fonts/Clarendon LT Std/ClarendonLTStd-Light.woff2"
         },
         {
           "name": "ClarendonLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19784
+          "fileSize": 19784,
+          "url": "fonts/Clarendon LT Std/ClarendonLTStd.woff2"
         },
         {
           "name": "ClarendonLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19736
+          "fileSize": 19736,
+          "url": "fonts/Clarendon LT Std/ClarendonLTStd-Bold.woff2"
         }
       ]
     },
@@ -2521,35 +2754,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17488
+          "fileSize": 17488,
+          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Light.woff2"
         },
         {
           "name": "ClearfaceGothicLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17872
+          "fileSize": 17872,
+          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Black.woff2"
         },
         {
           "name": "ClearfaceGothicLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18104
+          "fileSize": 18104,
+          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Medium.woff2"
         },
         {
           "name": "ClearfaceGothicLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17912
+          "fileSize": 17912,
+          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Roman.woff2"
         },
         {
           "name": "ClearfaceGothicLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17824
+          "fileSize": 17824,
+          "url": "fonts/Clearface Gothic LT Std/ClearfaceGothicLTStd-Bold.woff2"
         }
       ]
     },
@@ -2568,7 +2806,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37220
+          "fileSize": 37220,
+          "url": "fonts/Cloister Std/CloisterStd-OpenFace.woff2"
         }
       ]
     },
@@ -2587,42 +2826,48 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23536
+          "fileSize": 23536,
+          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-LightItalic.woff2"
         },
         {
           "name": "CTMercuriusStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22652
+          "fileSize": 22652,
+          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-Light.woff2"
         },
         {
           "name": "CTMercuriusStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23860
+          "fileSize": 23860,
+          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-BlackItalic.woff2"
         },
         {
           "name": "CTMercuriusStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24100
+          "fileSize": 24100,
+          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-MediumItalic.woff2"
         },
         {
           "name": "CTMercuriusStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22800
+          "fileSize": 22800,
+          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-Black.woff2"
         },
         {
           "name": "CTMercuriusStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22692
+          "fileSize": 22692,
+          "url": "fonts/Club Type Mercurius Std/CTMercuriusStd-Medium.woff2"
         }
       ]
     },
@@ -2641,28 +2886,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20560
+          "fileSize": 20560,
+          "url": "fonts/Cochin LT Std/CochinLTStd-Italic.woff2"
         },
         {
           "name": "CochinLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19952
+          "fileSize": 19952,
+          "url": "fonts/Cochin LT Std/CochinLTStd.woff2"
         },
         {
           "name": "CochinLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20840
+          "fileSize": 20840,
+          "url": "fonts/Cochin LT Std/CochinLTStd-BoldItalic.woff2"
         },
         {
           "name": "CochinLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20180
+          "fileSize": 20180,
+          "url": "fonts/Cochin LT Std/CochinLTStd-Bold.woff2"
         }
       ]
     },
@@ -2681,35 +2930,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26476
+          "fileSize": 26476,
+          "url": "fonts/Conga Brava Std/CongaBravaStd-Light.woff2"
         },
         {
           "name": "CongaBravaStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26332
+          "fileSize": 26332,
+          "url": "fonts/Conga Brava Std/CongaBravaStd-Black.woff2"
         },
         {
           "name": "CongaBravaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27628
+          "fileSize": 27628,
+          "url": "fonts/Conga Brava Std/CongaBravaStd-Regular.woff2"
         },
         {
           "name": "CongaBravaStd-SmBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27464
+          "fileSize": 27464,
+          "url": "fonts/Conga Brava Std/CongaBravaStd-SmBd.woff2"
         },
         {
           "name": "CongaBravaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27356
+          "fileSize": 27356,
+          "url": "fonts/Conga Brava Std/CongaBravaStd-Bold.woff2"
         }
       ]
     },
@@ -2728,28 +2982,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27380
+          "fileSize": 27380,
+          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-Black.woff2"
         },
         {
           "name": "CongaBravaStencilStd-Reg",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28852
+          "fileSize": 28852,
+          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-Reg.woff2"
         },
         {
           "name": "CongaBravaStencilStd-SmBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29152
+          "fileSize": 29152,
+          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-SmBd.woff2"
         },
         {
           "name": "CongaBravaStencilStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29144
+          "fileSize": 29144,
+          "url": "fonts/Conga Brava Stencil Std/CongaBravaStencilStd-Bold.woff2"
         }
       ]
     },
@@ -2768,14 +3026,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24264
+          "fileSize": 24264,
+          "url": "fonts/Cooper Black Std/CooperBlackStd-Italic.woff2"
         },
         {
           "name": "CooperBlackStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22832
+          "fileSize": 22832,
+          "url": "fonts/Cooper Black Std/CooperBlackStd.woff2"
         }
       ]
     },
@@ -2794,21 +3054,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 98172
+          "fileSize": 98172,
+          "url": "fonts/Copal Std/CopalStd-Decorated.woff2"
         },
         {
           "name": "CopalStd-Outline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 57676
+          "fileSize": 57676,
+          "url": "fonts/Copal Std/CopalStd-Outline.woff2"
         },
         {
           "name": "CopalStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32396
+          "fileSize": 32396,
+          "url": "fonts/Copal Std/CopalStd-Solid.woff2"
         }
       ]
     },
@@ -2827,63 +3090,72 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18396
+          "fileSize": 18396,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-29AB.woff2"
         },
         {
           "name": "CopperplateGothicStd-29BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18640
+          "fileSize": 18640,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-29BC.woff2"
         },
         {
           "name": "CopperplateGothicStd-30AB",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18428
+          "fileSize": 18428,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-30AB.woff2"
         },
         {
           "name": "CopperplateGothicStd-30BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18588
+          "fileSize": 18588,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-30BC.woff2"
         },
         {
           "name": "CopperplateGothicStd-31AB",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19108
+          "fileSize": 19108,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-31AB.woff2"
         },
         {
           "name": "CopperplateGothicStd-31BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18720
+          "fileSize": 18720,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-31BC.woff2"
         },
         {
           "name": "CopperplateGothicStd-32AB",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18592
+          "fileSize": 18592,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-32AB.woff2"
         },
         {
           "name": "CopperplateGothicStd-32BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18720
+          "fileSize": 18720,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-32BC.woff2"
         },
         {
           "name": "CopperplateGothicStd-33BC",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18396
+          "fileSize": 18396,
+          "url": "fonts/Copperplate Gothic Std/CopperplateGothicStd-33BC.woff2"
         }
       ]
     },
@@ -2902,7 +3174,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36092
+          "fileSize": 36092,
+          "url": "fonts/Coriander Std/CorianderStd.woff2"
         }
       ]
     },
@@ -2921,21 +3194,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21248
+          "fileSize": 21248,
+          "url": "fonts/Corona LT Std/CoronaLTStd-Italic.woff2"
         },
         {
           "name": "CoronaLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19696
+          "fileSize": 19696,
+          "url": "fonts/Corona LT Std/CoronaLTStd.woff2"
         },
         {
           "name": "CoronaLTStd-BoldFaceNo2",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19760
+          "fileSize": 19760,
+          "url": "fonts/Corona LT Std/CoronaLTStd-BoldFaceNo2.woff2"
         }
       ]
     },
@@ -2954,14 +3230,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25448
+          "fileSize": 25448,
+          "url": "fonts/Coronet LT Std/CoronetLTStd-Regular.woff2"
         },
         {
           "name": "CoronetLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25636
+          "fileSize": 25636,
+          "url": "fonts/Coronet LT Std/CoronetLTStd-Bold.woff2"
         }
       ]
     },
@@ -2980,7 +3258,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23196
+          "fileSize": 23196,
+          "url": "fonts/Cottonwood Std/CottonwoodStd.woff2"
         }
       ]
     },
@@ -2999,28 +3278,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23320
+          "fileSize": 23320,
+          "url": "fonts/Courier Std/CourierStd.woff2"
         },
         {
           "name": "CourierStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 24460
+          "fileSize": 24460,
+          "url": "fonts/Courier Std/CourierStd-Oblique.woff2"
         },
         {
           "name": "CourierStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23016
+          "fileSize": 23016,
+          "url": "fonts/Courier Std/CourierStd-Bold.woff2"
         },
         {
           "name": "CourierStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 24016
+          "fileSize": 24016,
+          "url": "fonts/Courier Std/CourierStd-BoldOblique.woff2"
         }
       ]
     },
@@ -3039,7 +3322,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32156
+          "fileSize": 32156,
+          "url": "fonts/Critter Std/CritterStd.woff2"
         }
       ]
     },
@@ -3058,7 +3342,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20580
+          "fileSize": 20580,
+          "url": "fonts/Cutout Std/CutoutStd.woff2"
         }
       ]
     },
@@ -3077,42 +3362,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35700
+          "fileSize": 35700,
+          "url": "fonts/Dante MT Std/DanteMTStd-Italic.woff2"
         },
         {
           "name": "DanteMTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35212
+          "fileSize": 35212,
+          "url": "fonts/Dante MT Std/DanteMTStd-MediumItalic.woff2"
         },
         {
           "name": "DanteMTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32620
+          "fileSize": 32620,
+          "url": "fonts/Dante MT Std/DanteMTStd-Medium.woff2"
         },
         {
           "name": "DanteMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 53384
+          "fileSize": 53384,
+          "url": "fonts/Dante MT Std/DanteMTStd-Regular.woff2"
         },
         {
           "name": "DanteMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 35720
+          "fileSize": 35720,
+          "url": "fonts/Dante MT Std/DanteMTStd-BoldItalic.woff2"
         },
         {
           "name": "DanteMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33456
+          "fileSize": 33456,
+          "url": "fonts/Dante MT Std/DanteMTStd-Bold.woff2"
         }
       ]
     },
@@ -3131,14 +3422,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25096
+          "fileSize": 25096,
+          "url": "fonts/Delphin LT Std/DelphinLTStd-1.woff2"
         },
         {
           "name": "DelphinLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24056
+          "fileSize": 24056,
+          "url": "fonts/Delphin LT Std/DelphinLTStd-2.woff2"
         }
       ]
     },
@@ -3157,28 +3450,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15164
+          "fileSize": 15164,
+          "url": "fonts/DIN Std/DINNeuzeitGroteskStd-Light.woff2"
         },
         {
           "name": "DINEngschriftStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15464
+          "fileSize": 15464,
+          "url": "fonts/DIN Std/DINEngschriftStd.woff2"
         },
         {
           "name": "DINMittelschriftStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15316
+          "fileSize": 15316,
+          "url": "fonts/DIN Std/DINMittelschriftStd.woff2"
         },
         {
           "name": "DINNeuzeitGroteskStd-BdCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15348
+          "fileSize": 15348,
+          "url": "fonts/DIN Std/DINNeuzeitGroteskStd-BdCond.woff2"
         }
       ]
     },
@@ -3197,14 +3494,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25116
+          "fileSize": 25116,
+          "url": "fonts/Diotima LT Std/DiotimaLTStd-Italic.woff2"
         },
         {
           "name": "DiotimaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31440
+          "fileSize": 31440,
+          "url": "fonts/Diotima LT Std/DiotimaLTStd-Roman.woff2"
         }
       ]
     },
@@ -3223,14 +3522,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26308
+          "fileSize": 26308,
+          "url": "fonts/Diskus LT Std/DiskusLTStd.woff2"
         },
         {
           "name": "DiskusLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27388
+          "fileSize": 27388,
+          "url": "fonts/Diskus LT Std/DiskusLTStd-Bold.woff2"
         }
       ]
     },
@@ -3249,14 +3550,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20000
+          "fileSize": 20000,
+          "url": "fonts/Dom Casual Std/DomCasualStd.woff2"
         },
         {
           "name": "DomCasualStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22256
+          "fileSize": 22256,
+          "url": "fonts/Dom Casual Std/DomCasualStd-Bold.woff2"
         }
       ]
     },
@@ -3275,7 +3578,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26208
+          "fileSize": 26208,
+          "url": "fonts/Dorchester Script MT Std/DorchesterScriptMTStd.woff2"
         }
       ]
     },
@@ -3294,7 +3598,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15620
+          "fileSize": 15620,
+          "url": "fonts/Doric LT Std/DoricLTStd-Bold.woff2"
         }
       ]
     },
@@ -3313,7 +3618,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26856
+          "fileSize": 26856,
+          "url": "fonts/Duc De Berry LT Std/DucDeBerryLTStd.woff2"
         }
       ]
     },
@@ -3332,7 +3638,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15300
+          "fileSize": 15300,
+          "url": "fonts/Eccentric Std/EccentricStd.woff2"
         }
       ]
     },
@@ -3351,28 +3658,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19772
+          "fileSize": 19772,
+          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Italic.woff2"
         },
         {
           "name": "EgyptienneFLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18888
+          "fileSize": 18888,
+          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Black.woff2"
         },
         {
           "name": "EgyptienneFLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18476
+          "fileSize": 18476,
+          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Roman.woff2"
         },
         {
           "name": "EgyptienneFLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18348
+          "fileSize": 18348,
+          "url": "fonts/Egyptienne F LT Std/EgyptienneFLTStd-Bold.woff2"
         }
       ]
     },
@@ -3391,28 +3702,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22300
+          "fileSize": 22300,
+          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-Italic.woff2"
         },
         {
           "name": "EhrhardtMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19980
+          "fileSize": 19980,
+          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-Regular.woff2"
         },
         {
           "name": "EhrhardtMTStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19952
+          "fileSize": 19952,
+          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-Semibold.woff2"
         },
         {
           "name": "EhrhardtMTStd-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22088
+          "fileSize": 22088,
+          "url": "fonts/Ehrhardt MT Std/EhrhardtMTStd-SemiboldIt.woff2"
         }
       ]
     },
@@ -3431,56 +3746,64 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23648
+          "fileSize": 23648,
+          "url": "fonts/Electra LT Std/ElectraLTStd-Cursive.woff2"
         },
         {
           "name": "ElectraLTStd-CursiveDisplay",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22184
+          "fileSize": 22184,
+          "url": "fonts/Electra LT Std/ElectraLTStd-CursiveDisplay.woff2"
         },
         {
           "name": "ElectraLTStd-Display",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21384
+          "fileSize": 21384,
+          "url": "fonts/Electra LT Std/ElectraLTStd-Display.woff2"
         },
         {
           "name": "ElectraLTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28976
+          "fileSize": 28976,
+          "url": "fonts/Electra LT Std/ElectraLTStd-Regular.woff2"
         },
         {
           "name": "ElectraLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29196
+          "fileSize": 29196,
+          "url": "fonts/Electra LT Std/ElectraLTStd-Bold.woff2"
         },
         {
           "name": "ElectraLTStd-BoldCursive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23492
+          "fileSize": 23492,
+          "url": "fonts/Electra LT Std/ElectraLTStd-BoldCursive.woff2"
         },
         {
           "name": "ElectraLTStd-BoldCursiveDis",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22284
+          "fileSize": 22284,
+          "url": "fonts/Electra LT Std/ElectraLTStd-BoldCursiveDis.woff2"
         },
         {
           "name": "ElectraLTStd-BoldDisplay",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21412
+          "fileSize": 21412,
+          "url": "fonts/Electra LT Std/ElectraLTStd-BoldDisplay.woff2"
         }
       ]
     },
@@ -3499,56 +3822,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23372
+          "fileSize": 23372,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-LightItalic.woff2"
         },
         {
           "name": "EllingtonMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24424
+          "fileSize": 24424,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-Light.woff2"
         },
         {
           "name": "EllingtonMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24672
+          "fileSize": 24672,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-Italic.woff2"
         },
         {
           "name": "EllingtonMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24160
+          "fileSize": 24160,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd.woff2"
         },
         {
           "name": "EllingtonMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24960
+          "fileSize": 24960,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-BoldItalic.woff2"
         },
         {
           "name": "EllingtonMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24216
+          "fileSize": 24216,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-Bold.woff2"
         },
         {
           "name": "EllingtonMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25056
+          "fileSize": 25056,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-ExtraBold.woff2"
         },
         {
           "name": "EllingtonMTStd-ExtraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24828
+          "fileSize": 24828,
+          "url": "fonts/Ellington MT Std/EllingtonMTStd-ExtraBoldIt.woff2"
         }
       ]
     },
@@ -3567,28 +3898,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21448
+          "fileSize": 21448,
+          "url": "fonts/Else NPL Std/ElseNPLStd-Light.woff2"
         },
         {
           "name": "ElseNPLStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22072
+          "fileSize": 22072,
+          "url": "fonts/Else NPL Std/ElseNPLStd-Medium.woff2"
         },
         {
           "name": "ElseNPLStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21652
+          "fileSize": 21652,
+          "url": "fonts/Else NPL Std/ElseNPLStd-Bold.woff2"
         },
         {
           "name": "ElseNPLStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21792
+          "fileSize": 21792,
+          "url": "fonts/Else NPL Std/ElseNPLStd-SemiBold.woff2"
         }
       ]
     },
@@ -3607,7 +3942,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40188
+          "fileSize": 40188,
+          "url": "fonts/Emmascript MVB Std/EmmascriptMVBStd.woff2"
         }
       ]
     },
@@ -3626,7 +3962,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18632
+          "fileSize": 18632,
+          "url": "fonts/Engravers LT Std/EngraversLTStd-BoldFace.woff2"
         }
       ]
     },
@@ -3645,28 +3982,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1372
+          "fileSize": 1372,
+          "url": "fonts/Euro Mono Std/EuroMonoStd-Italic.woff2"
         },
         {
           "name": "EuroMonoStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1340
+          "fileSize": 1340,
+          "url": "fonts/Euro Mono Std/EuroMonoStd-Regular.woff2"
         },
         {
           "name": "EuroMonoStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1440
+          "fileSize": 1440,
+          "url": "fonts/Euro Mono Std/EuroMonoStd-BoldItalic.woff2"
         },
         {
           "name": "EuroMonoStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1368
+          "fileSize": 1368,
+          "url": "fonts/Euro Mono Std/EuroMonoStd-Bold.woff2"
         }
       ]
     },
@@ -3685,28 +4026,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1316
+          "fileSize": 1316,
+          "url": "fonts/Euro Sans Std/EuroSansStd-Italic.woff2"
         },
         {
           "name": "EuroSansStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1356
+          "fileSize": 1356,
+          "url": "fonts/Euro Sans Std/EuroSansStd-Regular.woff2"
         },
         {
           "name": "EuroSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1388
+          "fileSize": 1388,
+          "url": "fonts/Euro Sans Std/EuroSansStd-BoldItalic.woff2"
         },
         {
           "name": "EuroSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1424
+          "fileSize": 1424,
+          "url": "fonts/Euro Sans Std/EuroSansStd-Bold.woff2"
         }
       ]
     },
@@ -3725,28 +4070,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1404
+          "fileSize": 1404,
+          "url": "fonts/Euro Serif Std/EuroSerifStd-Italic.woff2"
         },
         {
           "name": "EuroSerifStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1408
+          "fileSize": 1408,
+          "url": "fonts/Euro Serif Std/EuroSerifStd-Regular.woff2"
         },
         {
           "name": "EuroSerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 1408
+          "fileSize": 1408,
+          "url": "fonts/Euro Serif Std/EuroSerifStd-BoldItalic.woff2"
         },
         {
           "name": "EuroSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1392
+          "fileSize": 1392,
+          "url": "fonts/Euro Serif Std/EuroSerifStd-Bold.woff2"
         }
       ]
     },
@@ -3765,28 +4114,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7080
+          "fileSize": 7080,
+          "url": "fonts/European Pi Std/EuropeanPiStd-1.woff2"
         },
         {
           "name": "EuropeanPiStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7224
+          "fileSize": 7224,
+          "url": "fonts/European Pi Std/EuropeanPiStd-2.woff2"
         },
         {
           "name": "EuropeanPiStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8420
+          "fileSize": 8420,
+          "url": "fonts/European Pi Std/EuropeanPiStd-3.woff2"
         },
         {
           "name": "EuropeanPiStd-4",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 6068
+          "fileSize": 6068,
+          "url": "fonts/European Pi Std/EuropeanPiStd-4.woff2"
         }
       ]
     },
@@ -3805,70 +4158,80 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15328
+          "fileSize": 15328,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd.woff2"
         },
         {
           "name": "EurostileLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15024
+          "fileSize": 15024,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-Cn.woff2"
         },
         {
           "name": "EurostileLTStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15364
+          "fileSize": 15364,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-Demi.woff2"
         },
         {
           "name": "EurostileLTStd-Ex2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15780
+          "fileSize": 15780,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-Ex2.woff2"
         },
         {
           "name": "EurostileLTStd-DemiOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16496
+          "fileSize": 16496,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-DemiOblique.woff2"
         },
         {
           "name": "EurostileLTStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16420
+          "fileSize": 16420,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-Oblique.woff2"
         },
         {
           "name": "EurostileLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15760
+          "fileSize": 15760,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-Bold.woff2"
         },
         {
           "name": "EurostileLTStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16008
+          "fileSize": 16008,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-BoldCn.woff2"
         },
         {
           "name": "EurostileLTStd-BoldEx2",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16060
+          "fileSize": 16060,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-BoldEx2.woff2"
         },
         {
           "name": "EurostileLTStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16800
+          "fileSize": 16800,
+          "url": "fonts/Eurostile LT Std/EurostileLTStd-BoldOblique.woff2"
         }
       ]
     },
@@ -3887,21 +4250,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 108784
+          "fileSize": 108784,
+          "url": "fonts/Ex Ponto Pro/ExPontoPro-Light.woff2"
         },
         {
           "name": "ExPontoPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 133840
+          "fileSize": 133840,
+          "url": "fonts/Ex Ponto Pro/ExPontoPro-Regular.woff2"
         },
         {
           "name": "ExPontoPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 111916
+          "fileSize": 111916,
+          "url": "fonts/Ex Ponto Pro/ExPontoPro-Bold.woff2"
         }
       ]
     },
@@ -3920,21 +4286,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28972
+          "fileSize": 28972,
+          "url": "fonts/Excelsior LT Std/ExcelsiorLTStd-Italic.woff2"
         },
         {
           "name": "ExcelsiorLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28716
+          "fileSize": 28716,
+          "url": "fonts/Excelsior LT Std/ExcelsiorLTStd.woff2"
         },
         {
           "name": "ExcelsiorLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28492
+          "fileSize": 28492,
+          "url": "fonts/Excelsior LT Std/ExcelsiorLTStd-Bold.woff2"
         }
       ]
     },
@@ -3953,84 +4322,96 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30512
+          "fileSize": 30512,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-LightItalic.woff2"
         },
         {
           "name": "FairfieldLTStd-CaptionLight",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22440
+          "fileSize": 22440,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionLight.woff2"
         },
         {
           "name": "FairfieldLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30060
+          "fileSize": 30060,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Light.woff2"
         },
         {
           "name": "FairfieldLTStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31436
+          "fileSize": 31436,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-HeavyItalic.woff2"
         },
         {
           "name": "FairfieldLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30924
+          "fileSize": 30924,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-MediumItalic.woff2"
         },
         {
           "name": "FairfieldLTStd-CaptionHeavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22696
+          "fileSize": 22696,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionHeavy.woff2"
         },
         {
           "name": "FairfieldLTStd-CaptionMed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22284
+          "fileSize": 22284,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionMed.woff2"
         },
         {
           "name": "FairfieldLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30740
+          "fileSize": 30740,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Heavy.woff2"
         },
         {
           "name": "FairfieldLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30388
+          "fileSize": 30388,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Medium.woff2"
         },
         {
           "name": "FairfieldLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31360
+          "fileSize": 31360,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-BoldItalic.woff2"
         },
         {
           "name": "FairfieldLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30808
+          "fileSize": 30808,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-Bold.woff2"
         },
         {
           "name": "FairfieldLTStd-CaptionBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23072
+          "fileSize": 23072,
+          "url": "fonts/Fairfield LT Std/FairfieldLTStd-CaptionBold.woff2"
         }
       ]
     },
@@ -4049,7 +4430,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22184
+          "fileSize": 22184,
+          "url": "fonts/Falstaff MT Std/FalstaffMTStd.woff2"
         }
       ]
     },
@@ -4068,7 +4450,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24900
+          "fileSize": 24900,
+          "url": "fonts/Fette Fraktur LT Std/FetteFrakturLTStd.woff2"
         }
       ]
     },
@@ -4087,7 +4470,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34028
+          "fileSize": 34028,
+          "url": "fonts/Flood Std/FloodStd.woff2"
         }
       ]
     },
@@ -4106,7 +4490,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42884
+          "fileSize": 42884,
+          "url": "fonts/Florens LP Std/FlorensLPStd.woff2"
         }
       ]
     },
@@ -4125,14 +4510,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15428
+          "fileSize": 15428,
+          "url": "fonts/Flyer LT Std/FlyerLTStd-BlackCondensed.woff2"
         },
         {
           "name": "FlyerLTStd-ExtraBlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15332
+          "fileSize": 15332,
+          "url": "fonts/Flyer LT Std/FlyerLTStd-ExtraBlackCond.woff2"
         }
       ]
     },
@@ -4151,35 +4538,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15048
+          "fileSize": 15048,
+          "url": "fonts/Folio Std/FolioStd-Light.woff2"
         },
         {
           "name": "FolioStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15752
+          "fileSize": 15752,
+          "url": "fonts/Folio Std/FolioStd-Medium.woff2"
         },
         {
           "name": "FolioStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15784
+          "fileSize": 15784,
+          "url": "fonts/Folio Std/FolioStd-Bold.woff2"
         },
         {
           "name": "FolioStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15336
+          "fileSize": 15336,
+          "url": "fonts/Folio Std/FolioStd-BoldCondensed.woff2"
         },
         {
           "name": "FolioStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16472
+          "fileSize": 16472,
+          "url": "fonts/Folio Std/FolioStd-ExtraBold.woff2"
         }
       ]
     },
@@ -4198,7 +4590,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23676
+          "fileSize": 23676,
+          "url": "fonts/Forte MT Std/ForteMTStd.woff2"
         }
       ]
     },
@@ -4217,14 +4610,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 44700
+          "fileSize": 44700,
+          "url": "fonts/Fournier MT Std/FournierMTStd-Italic.woff2"
         },
         {
           "name": "FournierMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58716
+          "fileSize": 58716,
+          "url": "fonts/Fournier MT Std/FournierMTStd-Regular.woff2"
         }
       ]
     },
@@ -4243,21 +4638,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15508
+          "fileSize": 15508,
+          "url": "fonts/Franklin Gothic Std/FranklinGothicStd-Condensed.woff2"
         },
         {
           "name": "FranklinGothicStd-ExtraCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15200
+          "fileSize": 15200,
+          "url": "fonts/Franklin Gothic Std/FranklinGothicStd-ExtraCond.woff2"
         },
         {
           "name": "FranklinGothicStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15308
+          "fileSize": 15308,
+          "url": "fonts/Franklin Gothic Std/FranklinGothicStd-Roman.woff2"
         }
       ]
     },
@@ -4276,7 +4674,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21580
+          "fileSize": 21580,
+          "url": "fonts/Freestyle Script Std/FreestyleScriptStd.woff2"
         }
       ]
     },
@@ -4295,14 +4694,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17924
+          "fileSize": 17924,
+          "url": "fonts/Friz Quadrata Std/FrizQuadrataStd.woff2"
         },
         {
           "name": "FrizQuadrataStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18268
+          "fileSize": 18268,
+          "url": "fonts/Friz Quadrata Std/FrizQuadrataStd-Bold.woff2"
         }
       ]
     },
@@ -4321,98 +4722,112 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15712
+          "fileSize": 15712,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-LightItalic.woff2"
         },
         {
           "name": "FrutigerLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15212
+          "fileSize": 15212,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Light.woff2"
         },
         {
           "name": "FrutigerLTStd-LightCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15344
+          "fileSize": 15344,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-LightCn.woff2"
         },
         {
           "name": "FrutigerLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16012
+          "fileSize": 16012,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BlackItalic.woff2"
         },
         {
           "name": "FrutigerLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15592
+          "fileSize": 15592,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Italic.woff2"
         },
         {
           "name": "FrutigerLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15352
+          "fileSize": 15352,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Black.woff2"
         },
         {
           "name": "FrutigerLTStd-BlackCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15520
+          "fileSize": 15520,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BlackCn.woff2"
         },
         {
           "name": "FrutigerLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15300
+          "fileSize": 15300,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Cn.woff2"
         },
         {
           "name": "FrutigerLTStd-ExtraBlackCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15936
+          "fileSize": 15936,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-ExtraBlackCn.woff2"
         },
         {
           "name": "FrutigerLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15188
+          "fileSize": 15188,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Roman.woff2"
         },
         {
           "name": "FrutigerLTStd-UltraBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15804
+          "fileSize": 15804,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-UltraBlack.woff2"
         },
         {
           "name": "FrutigerLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15940
+          "fileSize": 15940,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BoldItalic.woff2"
         },
         {
           "name": "FrutigerLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15596
+          "fileSize": 15596,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-Bold.woff2"
         },
         {
           "name": "FrutigerLTStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15772
+          "fileSize": 15772,
+          "url": "fonts/Frutiger LT Std/FrutigerLTStd-BoldCn.woff2"
         }
       ]
     },
@@ -4431,7 +4846,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17348
+          "fileSize": 17348,
+          "url": "fonts/Fusaka Std/FusakaStd.woff2"
         }
       ]
     },
@@ -4450,140 +4866,160 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15456
+          "fileSize": 15456,
+          "url": "fonts/Futura Std/FuturaStd-CondensedLight.woff2"
         },
         {
           "name": "FuturaStd-CondensedLightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16432
+          "fileSize": 16432,
+          "url": "fonts/Futura Std/FuturaStd-CondensedLightObl.woff2"
         },
         {
           "name": "FuturaStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14972
+          "fileSize": 14972,
+          "url": "fonts/Futura Std/FuturaStd-Light.woff2"
         },
         {
           "name": "FuturaStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16236
+          "fileSize": 16236,
+          "url": "fonts/Futura Std/FuturaStd-LightOblique.woff2"
         },
         {
           "name": "FuturaStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14588
+          "fileSize": 14588,
+          "url": "fonts/Futura Std/FuturaStd-Book.woff2"
         },
         {
           "name": "FuturaStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15080
+          "fileSize": 15080,
+          "url": "fonts/Futura Std/FuturaStd-Condensed.woff2"
         },
         {
           "name": "FuturaStd-CondensedExtraBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16148
+          "fileSize": 16148,
+          "url": "fonts/Futura Std/FuturaStd-CondensedExtraBd.woff2"
         },
         {
           "name": "FuturaStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14920
+          "fileSize": 14920,
+          "url": "fonts/Futura Std/FuturaStd-Heavy.woff2"
         },
         {
           "name": "FuturaStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14548
+          "fileSize": 14548,
+          "url": "fonts/Futura Std/FuturaStd-Medium.woff2"
         },
         {
           "name": "FuturaStd-BookOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15684
+          "fileSize": 15684,
+          "url": "fonts/Futura Std/FuturaStd-BookOblique.woff2"
         },
         {
           "name": "FuturaStd-CondensedOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16620
+          "fileSize": 16620,
+          "url": "fonts/Futura Std/FuturaStd-CondensedOblique.woff2"
         },
         {
           "name": "FuturaStd-HeavyOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15892
+          "fileSize": 15892,
+          "url": "fonts/Futura Std/FuturaStd-HeavyOblique.woff2"
         },
         {
           "name": "FuturaStd-MediumOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15644
+          "fileSize": 15644,
+          "url": "fonts/Futura Std/FuturaStd-MediumOblique.woff2"
         },
         {
           "name": "FuturaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15480
+          "fileSize": 15480,
+          "url": "fonts/Futura Std/FuturaStd-Bold.woff2"
         },
         {
           "name": "FuturaStd-CondensedBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15164
+          "fileSize": 15164,
+          "url": "fonts/Futura Std/FuturaStd-CondensedBold.woff2"
         },
         {
           "name": "FuturaStd-CondensedBoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16372
+          "fileSize": 16372,
+          "url": "fonts/Futura Std/FuturaStd-CondensedBoldObl.woff2"
         },
         {
           "name": "FuturaStd-CondExtraBoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17092
+          "fileSize": 17092,
+          "url": "fonts/Futura Std/FuturaStd-CondExtraBoldObl.woff2"
         },
         {
           "name": "FuturaStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15972
+          "fileSize": 15972,
+          "url": "fonts/Futura Std/FuturaStd-ExtraBold.woff2"
         },
         {
           "name": "FuturaStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16296
+          "fileSize": 16296,
+          "url": "fonts/Futura Std/FuturaStd-BoldOblique.woff2"
         },
         {
           "name": "FuturaStd-ExtraBoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 16896
+          "fileSize": 16896,
+          "url": "fonts/Futura Std/FuturaStd-ExtraBoldOblique.woff2"
         }
       ]
     },
@@ -4602,7 +5038,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 98928
+          "fileSize": 98928,
+          "url": "fonts/Galahad Std/GalahadStd-Regular.woff2"
         }
       ]
     },
@@ -4621,28 +5058,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24468
+          "fileSize": 24468,
+          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd-Italic.woff2"
         },
         {
           "name": "Garamond3LTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30960
+          "fileSize": 30960,
+          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd.woff2"
         },
         {
           "name": "Garamond3LTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24636
+          "fileSize": 24636,
+          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd-BoldItalic.woff2"
         },
         {
           "name": "Garamond3LTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31592
+          "fileSize": 31592,
+          "url": "fonts/Garamond 3 LT Std/Garamond3LTStd-Bold.woff2"
         }
       ]
     },
@@ -4661,21 +5102,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20768
+          "fileSize": 20768,
+          "url": "fonts/Gazette LT Std/GazetteLTStd-Italic.woff2"
         },
         {
           "name": "GazetteLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19840
+          "fileSize": 19840,
+          "url": "fonts/Gazette LT Std/GazetteLTStd-Roman.woff2"
         },
         {
           "name": "GazetteLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19852
+          "fileSize": 19852,
+          "url": "fonts/Gazette LT Std/GazetteLTStd-Bold.woff2"
         }
       ]
     },
@@ -4694,14 +5138,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460
+          "fileSize": 30460,
+          "url": "fonts/Giddyup Std/GiddyupStd.woff2"
         },
         {
           "name": "GiddyupStd-Thangs",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12228
+          "fileSize": 12228,
+          "url": "fonts/Giddyup Std/GiddyupStd-Thangs.woff2"
         }
       ]
     },
@@ -4720,7 +5166,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25704
+          "fileSize": 25704,
+          "url": "fonts/Gill Floriated Caps MT Std/GillFloriatedCapsMTStd.woff2"
         }
       ]
     },
@@ -4739,105 +5186,120 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15940
+          "fileSize": 15940,
+          "url": "fonts/Gill Sans Std/GillSansStd-LightItalic.woff2"
         },
         {
           "name": "GillSansStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15492
+          "fileSize": 15492,
+          "url": "fonts/Gill Sans Std/GillSansStd-Light.woff2"
         },
         {
           "name": "GillSansStd-LightShadowed",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21096
+          "fileSize": 21096,
+          "url": "fonts/Gill Sans Std/GillSansStd-LightShadowed.woff2"
         },
         {
           "name": "GillSansStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16184
+          "fileSize": 16184,
+          "url": "fonts/Gill Sans Std/GillSansStd-Italic.woff2"
         },
         {
           "name": "GillSansStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15868
+          "fileSize": 15868,
+          "url": "fonts/Gill Sans Std/GillSansStd.woff2"
         },
         {
           "name": "GillSansStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15180
+          "fileSize": 15180,
+          "url": "fonts/Gill Sans Std/GillSansStd-Condensed.woff2"
         },
         {
           "name": "GillSansStd-Shadowed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20668
+          "fileSize": 20668,
+          "url": "fonts/Gill Sans Std/GillSansStd-Shadowed.woff2"
         },
         {
           "name": "GillSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16392
+          "fileSize": 16392,
+          "url": "fonts/Gill Sans Std/GillSansStd-BoldItalic.woff2"
         },
         {
           "name": "GillSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16004
+          "fileSize": 16004,
+          "url": "fonts/Gill Sans Std/GillSansStd-Bold.woff2"
         },
         {
           "name": "GillSansStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15968
+          "fileSize": 15968,
+          "url": "fonts/Gill Sans Std/GillSansStd-BoldCondensed.woff2"
         },
         {
           "name": "GillSansStd-BoldExtraCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17084
+          "fileSize": 17084,
+          "url": "fonts/Gill Sans Std/GillSansStd-BoldExtraCond.woff2"
         },
         {
           "name": "GillSansStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16568
+          "fileSize": 16568,
+          "url": "fonts/Gill Sans Std/GillSansStd-ExtraBold.woff2"
         },
         {
           "name": "GillSansStd-ExtraBoldDisp",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17300
+          "fileSize": 17300,
+          "url": "fonts/Gill Sans Std/GillSansStd-ExtraBoldDisp.woff2"
         },
         {
           "name": "GillSansStd-UltraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16936
+          "fileSize": 16936,
+          "url": "fonts/Gill Sans Std/GillSansStd-UltraBold.woff2"
         },
         {
           "name": "GillSansStd-UltraBoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16728
+          "fileSize": 16728,
+          "url": "fonts/Gill Sans Std/GillSansStd-UltraBoldCond.woff2"
         }
       ]
     },
@@ -4856,70 +5318,80 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16876
+          "fileSize": 16876,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-Light.woff2"
         },
         {
           "name": "GlyphaLTStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17612
+          "fileSize": 17612,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-LightOblique.woff2"
         },
         {
           "name": "GlyphaLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18660
+          "fileSize": 18660,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd.woff2"
         },
         {
           "name": "GlyphaLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17184
+          "fileSize": 17184,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-Black.woff2"
         },
         {
           "name": "GlyphaLTStd-Thin",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16372
+          "fileSize": 16372,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-Thin.woff2"
         },
         {
           "name": "GlyphaLTStd-BlackOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 18024
+          "fileSize": 18024,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-BlackOblique.woff2"
         },
         {
           "name": "GlyphaLTStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 19152
+          "fileSize": 19152,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-Oblique.woff2"
         },
         {
           "name": "GlyphaLTStd-ThinOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17468
+          "fileSize": 17468,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-ThinOblique.woff2"
         },
         {
           "name": "GlyphaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18956
+          "fileSize": 18956,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-Bold.woff2"
         },
         {
           "name": "GlyphaLTStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 19636
+          "fileSize": 19636,
+          "url": "fonts/Glypha LT Std/GlyphaLTStd-BoldOblique.woff2"
         }
       ]
     },
@@ -4938,7 +5410,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15348
+          "fileSize": 15348,
+          "url": "fonts/Gothic Thirteen Std/GothicThirteenStd.woff2"
         }
       ]
     },
@@ -4957,21 +5430,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22756
+          "fileSize": 22756,
+          "url": "fonts/Goudy Heavyface Std/GoudyStd-HeavyfaceItalic.woff2"
         },
         {
           "name": "GoudyStd-Heavyface",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21636
+          "fileSize": 21636,
+          "url": "fonts/Goudy Heavyface Std/GoudyStd-Heavyface.woff2"
         },
         {
           "name": "GoudyStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21772
+          "fileSize": 21772,
+          "url": "fonts/Goudy Heavyface Std/GoudyStd-ExtraBold.woff2"
         }
       ]
     },
@@ -4990,14 +5466,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24908
+          "fileSize": 24908,
+          "url": "fonts/Goudy Modern MT Std/GoudyModernMTStd-Italic.woff2"
         },
         {
           "name": "GoudyModernMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24056
+          "fileSize": 24056,
+          "url": "fonts/Goudy Modern MT Std/GoudyModernMTStd.woff2"
         }
       ]
     },
@@ -5016,28 +5494,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22972
+          "fileSize": 22972,
+          "url": "fonts/Goudy Std/GoudyStd-Italic.woff2"
         },
         {
           "name": "GoudyStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28188
+          "fileSize": 28188,
+          "url": "fonts/Goudy Std/GoudyStd.woff2"
         },
         {
           "name": "GoudyStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22284
+          "fileSize": 22284,
+          "url": "fonts/Goudy Std/GoudyStd-BoldItalic.woff2"
         },
         {
           "name": "GoudyStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21512
+          "fileSize": 21512,
+          "url": "fonts/Goudy Std/GoudyStd-Bold.woff2"
         }
       ]
     },
@@ -5056,7 +5538,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45380
+          "fileSize": 45380,
+          "url": "fonts/Goudy Text MT Std/GoudyTextMTStd.woff2"
         }
       ]
     },
@@ -5075,21 +5558,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22124
+          "fileSize": 22124,
+          "url": "fonts/Granjon LT Std/GranjonLTStd-Italic.woff2"
         },
         {
           "name": "GranjonLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25648
+          "fileSize": 25648,
+          "url": "fonts/Granjon LT Std/GranjonLTStd.woff2"
         },
         {
           "name": "GranjonLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19608
+          "fileSize": 19608,
+          "url": "fonts/Granjon LT Std/GranjonLTStd-Bold.woff2"
         }
       ]
     },
@@ -5108,63 +5594,72 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17972
+          "fileSize": 17972,
+          "url": "fonts/Graphite Std/GraphiteStd-Light.woff2"
         },
         {
           "name": "GraphiteStd-LightNarrow",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17216
+          "fileSize": 17216,
+          "url": "fonts/Graphite Std/GraphiteStd-LightNarrow.woff2"
         },
         {
           "name": "GraphiteStd-LightWide",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17968
+          "fileSize": 17968,
+          "url": "fonts/Graphite Std/GraphiteStd-LightWide.woff2"
         },
         {
           "name": "GraphiteStd-Narrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18056
+          "fileSize": 18056,
+          "url": "fonts/Graphite Std/GraphiteStd-Narrow.woff2"
         },
         {
           "name": "GraphiteStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18440
+          "fileSize": 18440,
+          "url": "fonts/Graphite Std/GraphiteStd-Regular.woff2"
         },
         {
           "name": "GraphiteStd-Wide",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18516
+          "fileSize": 18516,
+          "url": "fonts/Graphite Std/GraphiteStd-Wide.woff2"
         },
         {
           "name": "GraphiteStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18100
+          "fileSize": 18100,
+          "url": "fonts/Graphite Std/GraphiteStd-Bold.woff2"
         },
         {
           "name": "GraphiteStd-BoldNarrow",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17368
+          "fileSize": 17368,
+          "url": "fonts/Graphite Std/GraphiteStd-BoldNarrow.woff2"
         },
         {
           "name": "GraphiteStd-BoldWide",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17928
+          "fileSize": 17928,
+          "url": "fonts/Graphite Std/GraphiteStd-BoldWide.woff2"
         }
       ]
     },
@@ -5183,14 +5678,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 118644
+          "fileSize": 118644,
+          "url": "fonts/Greymantle MVB Std/GreymantleMVBStd.woff2"
         },
         {
           "name": "GreymantleMVBStd-Ornaments",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31608
+          "fileSize": 31608,
+          "url": "fonts/Greymantle MVB Std/GreymantleMVBStd-Ornaments.woff2"
         }
       ]
     },
@@ -5209,70 +5706,80 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18004
+          "fileSize": 18004,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-LightItalic.woff2"
         },
         {
           "name": "GrotesqueMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17544
+          "fileSize": 17544,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Light.woff2"
         },
         {
           "name": "GrotesqueMTStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17304
+          "fileSize": 17304,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-LightCond.woff2"
         },
         {
           "name": "GrotesqueMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17228
+          "fileSize": 17228,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Italic.woff2"
         },
         {
           "name": "GrotesqueMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17540
+          "fileSize": 17540,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd.woff2"
         },
         {
           "name": "GrotesqueMTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17544
+          "fileSize": 17544,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Black.woff2"
         },
         {
           "name": "GrotesqueMTStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17248
+          "fileSize": 17248,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Condensed.woff2"
         },
         {
           "name": "GrotesqueMTStd-ExtraCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16052
+          "fileSize": 16052,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-ExtraCond.woff2"
         },
         {
           "name": "GrotesqueMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17424
+          "fileSize": 17424,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-Bold.woff2"
         },
         {
           "name": "GrotesqueMTStd-BoldExtended",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16912
+          "fileSize": 16912,
+          "url": "fonts/Grotesque MT Std/GrotesqueMTStd-BoldExtended.woff2"
         }
       ]
     },
@@ -5291,42 +5798,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21564
+          "fileSize": 21564,
+          "url": "fonts/Guardi LT Std/GuardiLTStd-BlackItalic.woff2"
         },
         {
           "name": "GuardiLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21248
+          "fileSize": 21248,
+          "url": "fonts/Guardi LT Std/GuardiLTStd-Italic.woff2"
         },
         {
           "name": "GuardiLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20728
+          "fileSize": 20728,
+          "url": "fonts/Guardi LT Std/GuardiLTStd-Black.woff2"
         },
         {
           "name": "GuardiLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20448
+          "fileSize": 20448,
+          "url": "fonts/Guardi LT Std/GuardiLTStd-Roman.woff2"
         },
         {
           "name": "GuardiLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20952
+          "fileSize": 20952,
+          "url": "fonts/Guardi LT Std/GuardiLTStd-BoldItalic.woff2"
         },
         {
           "name": "GuardiLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20948
+          "fileSize": 20948,
+          "url": "fonts/Guardi LT Std/GuardiLTStd-Bold.woff2"
         }
       ]
     },
@@ -5345,7 +5858,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16272
+          "fileSize": 16272,
+          "url": "fonts/Hardwood LP Std/HardwoodLPStd.woff2"
         }
       ]
     },
@@ -5364,7 +5878,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21932
+          "fileSize": 21932,
+          "url": "fonts/Helvetica Inserat LT Std/HelveticaInseratLTStd-Roman.woff2"
         }
       ]
     },
@@ -5383,147 +5898,168 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15676
+          "fileSize": 15676,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Light.woff2"
         },
         {
           "name": "HelveticaLTStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16168
+          "fileSize": 16168,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-LightCond.woff2"
         },
         {
           "name": "HelveticaLTStd-LightCondObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17316
+          "fileSize": 17316,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-LightCondObl.woff2"
         },
         {
           "name": "HelveticaLTStd-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16900
+          "fileSize": 16900,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-LightObl.woff2"
         },
         {
           "name": "HelveticaLTStd-Blk",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316
+          "fileSize": 16316,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Blk.woff2"
         },
         {
           "name": "HelveticaLTStd-BlkCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16836
+          "fileSize": 16836,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BlkCond.woff2"
         },
         {
           "name": "HelveticaLTStd-BlkCondObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17736
+          "fileSize": 17736,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BlkCondObl.woff2"
         },
         {
           "name": "HelveticaLTStd-BlkObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17280
+          "fileSize": 17280,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BlkObl.woff2"
         },
         {
           "name": "HelveticaLTStd-Comp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15356
+          "fileSize": 15356,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Comp.woff2"
         },
         {
           "name": "HelveticaLTStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16908
+          "fileSize": 16908,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Cond.woff2"
         },
         {
           "name": "HelveticaLTStd-CondObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17820
+          "fileSize": 17820,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-CondObl.woff2"
         },
         {
           "name": "HelveticaLTStd-ExtraComp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14928
+          "fileSize": 14928,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-ExtraComp.woff2"
         },
         {
           "name": "HelveticaLTStd-Fractions",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 7864
+          "fileSize": 7864,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Fractions.woff2"
         },
         {
           "name": "HelveticaLTStd-FractionsBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8040
+          "fileSize": 8040,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-FractionsBd.woff2"
         },
         {
           "name": "HelveticaLTStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25012
+          "fileSize": 25012,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Obl.woff2"
         },
         {
           "name": "HelveticaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24432
+          "fileSize": 24432,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Roman.woff2"
         },
         {
           "name": "HelveticaLTStd-UltraComp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15156
+          "fileSize": 15156,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-UltraComp.woff2"
         },
         {
           "name": "HelveticaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24132
+          "fileSize": 24132,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-Bold.woff2"
         },
         {
           "name": "HelveticaLTStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17192
+          "fileSize": 17192,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BoldCond.woff2"
         },
         {
           "name": "HelveticaLTStd-BoldCondObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18492
+          "fileSize": 18492,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BoldCondObl.woff2"
         },
         {
           "name": "HelveticaLTStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24864
+          "fileSize": 24864,
+          "url": "fonts/Helvetica LT Std/HelveticaLTStd-BoldObl.woff2"
         }
       ]
     },
@@ -5542,357 +6078,408 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15824
+          "fileSize": 15824,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Bd.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15976
+          "fileSize": 15976,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BdCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17076
+          "fileSize": 17076,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BdEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15648
+          "fileSize": 15648,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BdExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17028
+          "fileSize": 17028,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16484
+          "fileSize": 16484,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BdOu",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23848
+          "fileSize": 23848,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BdOu.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Blk",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16796
+          "fileSize": 16796,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Blk.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BlkCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16244
+          "fileSize": 16244,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BlkCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17060
+          "fileSize": 17060,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BlkEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552
+          "fileSize": 16552,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BlkExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17816
+          "fileSize": 17816,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-BlkIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17016
+          "fileSize": 17016,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-BlkIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15644
+          "fileSize": 15644,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Cn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-CnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16844
+          "fileSize": 16844,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-CnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Ex",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15628
+          "fileSize": 15628,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Ex.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-ExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16672
+          "fileSize": 16672,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Hv",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16432
+          "fileSize": 16432,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Hv.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-HvCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16340
+          "fileSize": 16340,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-HvCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17224
+          "fileSize": 17224,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-HvEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16180
+          "fileSize": 16180,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-HvExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17688
+          "fileSize": 17688,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-HvIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16944
+          "fileSize": 16944,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-HvIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16304
+          "fileSize": 16304,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-It.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Lt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15760
+          "fileSize": 15760,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Lt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-LtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15608
+          "fileSize": 15608,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-LtCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16696
+          "fileSize": 16696,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-LtEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15704
+          "fileSize": 15704,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-LtExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17064
+          "fileSize": 17064,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-LtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16512
+          "fileSize": 16512,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-LtIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Md",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15888
+          "fileSize": 15888,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Md.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-MdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16116
+          "fileSize": 16116,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-MdCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17120
+          "fileSize": 17120,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-MdEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15996
+          "fileSize": 15996,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-MdExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16852
+          "fileSize": 16852,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-MdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16624
+          "fileSize": 16624,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-MdIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15624
+          "fileSize": 15624,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Roman.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-Th",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15920
+          "fileSize": 15920,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-Th.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-ThCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15756
+          "fileSize": 15756,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-ThCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16924
+          "fileSize": 16924,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-ThEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15620
+          "fileSize": 15620,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-ThExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16904
+          "fileSize": 16904,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-ThIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16572
+          "fileSize": 16572,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-ThIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-UltLt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15488
+          "fileSize": 15488,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-UltLtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15588
+          "fileSize": 15588,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-UltLtCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16436
+          "fileSize": 16436,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtCnO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-UltLtEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15288
+          "fileSize": 15288,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtEx.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-UltLtExO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16560
+          "fileSize": 16560,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtExO.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-UltLtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16400
+          "fileSize": 16400,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-UltLtIt.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-XBlkCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16564
+          "fileSize": 16564,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-XBlkCn.woff2"
         },
         {
           "name": "HelveticaNeueLTStd-XBlkCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17252
+          "fileSize": 17252,
+          "url": "fonts/Helvetica Neue LT Std/HelveticaNeueLTStd-XBlkCnO.woff2"
         }
       ]
     },
@@ -5911,42 +6498,48 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17820
+          "fileSize": 17820,
+          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-Bd.woff2"
         },
         {
           "name": "HelveticaRoundedLTStd-BdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17888
+          "fileSize": 17888,
+          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BdCn.woff2"
         },
         {
           "name": "HelveticaRoundedLTStd-BdCnO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19364
+          "fileSize": 19364,
+          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BdCnO.woff2"
         },
         {
           "name": "HelveticaRoundedLTStd-BdO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19744
+          "fileSize": 19744,
+          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BdO.woff2"
         },
         {
           "name": "HelveticaRoundedLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18072
+          "fileSize": 18072,
+          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-Black.woff2"
         },
         {
           "name": "HelveticaRoundedLTStd-BlkO",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19488
+          "fileSize": 19488,
+          "url": "fonts/Helvetica Rounded LT Std/HelveticaRoundedLTStd-BlkO.woff2"
         }
       ]
     },
@@ -5965,7 +6558,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19808
+          "fileSize": 19808,
+          "url": "fonts/Herculanum LT Std/HerculanumLTStd.woff2"
         }
       ]
     },
@@ -5984,56 +6578,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21528
+          "fileSize": 21528,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-BlackItalic.woff2"
         },
         {
           "name": "HiroshigeStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21296
+          "fileSize": 21296,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-BookItalic.woff2"
         },
         {
           "name": "HiroshigeStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22228
+          "fileSize": 22228,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-MediumItalic.woff2"
         },
         {
           "name": "HiroshigeStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21972
+          "fileSize": 21972,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-Black.woff2"
         },
         {
           "name": "HiroshigeStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20972
+          "fileSize": 20972,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-Book.woff2"
         },
         {
           "name": "HiroshigeStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22268
+          "fileSize": 22268,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-Medium.woff2"
         },
         {
           "name": "HiroshigeStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20960
+          "fileSize": 20960,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-BoldItalic.woff2"
         },
         {
           "name": "HiroshigeStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22328
+          "fileSize": 22328,
+          "url": "fonts/Hiroshige Std/HiroshigeStd-Bold.woff2"
         }
       ]
     },
@@ -6052,7 +6654,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19396
+          "fileSize": 19396,
+          "url": "fonts/Hobo Std/HoboStd.woff2"
         }
       ]
     },
@@ -6071,56 +6674,64 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26024
+          "fileSize": 26024,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Light.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd-LightIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25668
+          "fileSize": 25668,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-LightIt.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 26552
+          "fileSize": 26552,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Italic.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26196
+          "fileSize": 26196,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd-Sb",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25972
+          "fileSize": 25972,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Sb.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd-SbIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26156
+          "fileSize": 26156,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-SbIt.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26796
+          "fileSize": 26796,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-Bold.woff2"
         },
         {
           "name": "HorleyOldStyleMTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26204
+          "fileSize": 26204,
+          "url": "fonts/Horley Old Style MT Std/HorleyOldStyleMTStd-BoldIt.woff2"
         }
       ]
     },
@@ -6139,7 +6750,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22328
+          "fileSize": 22328,
+          "url": "fonts/Immi Five O Five Std/ImmiFiveOFiveStd.woff2"
         }
       ]
     },
@@ -6158,7 +6770,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15348
+          "fileSize": 15348,
+          "url": "fonts/Impact LT Std/ImpactLTStd.woff2"
         }
       ]
     },
@@ -6177,21 +6790,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18900
+          "fileSize": 18900,
+          "url": "fonts/Impressum Std/ImpressumStd-Italic.woff2"
         },
         {
           "name": "ImpressumStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18468
+          "fileSize": 18468,
+          "url": "fonts/Impressum Std/ImpressumStd-Roman.woff2"
         },
         {
           "name": "ImpressumStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18540
+          "fileSize": 18540,
+          "url": "fonts/Impressum Std/ImpressumStd-Bold.woff2"
         }
       ]
     },
@@ -6210,14 +6826,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21136
+          "fileSize": 21136,
+          "url": "fonts/Industria LT Std/IndustriaLTStd-Inline.woff2"
         },
         {
           "name": "IndustriaLTStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13032
+          "fileSize": 13032,
+          "url": "fonts/Industria LT Std/IndustriaLTStd-Solid.woff2"
         }
       ]
     },
@@ -6236,7 +6854,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21792
+          "fileSize": 21792,
+          "url": "fonts/Inflex MT Std/InflexMTStd-Bold.woff2"
         }
       ]
     },
@@ -6255,7 +6874,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15716
+          "fileSize": 15716,
+          "url": "fonts/Insignia LT Std/InsigniaLTStd.woff2"
         }
       ]
     },
@@ -6274,7 +6894,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20644
+          "fileSize": 20644,
+          "url": "fonts/Ironwood Std/IronwoodStd.woff2"
         }
       ]
     },
@@ -6293,7 +6914,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20972
+          "fileSize": 20972,
+          "url": "fonts/Isabella Std/IsabellaStd.woff2"
         }
       ]
     },
@@ -6312,21 +6934,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19496
+          "fileSize": 19496,
+          "url": "fonts/Italia Std/ItaliaStd-Book.woff2"
         },
         {
           "name": "ItaliaStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19328
+          "fileSize": 19328,
+          "url": "fonts/Italia Std/ItaliaStd-Medium.woff2"
         },
         {
           "name": "ItaliaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19448
+          "fileSize": 19448,
+          "url": "fonts/Italia Std/ItaliaStd-Bold.woff2"
         }
       ]
     },
@@ -6345,28 +6970,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21752
+          "fileSize": 21752,
+          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd-Italic.woff2"
         },
         {
           "name": "ItalianOldStyleMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20172
+          "fileSize": 20172,
+          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd.woff2"
         },
         {
           "name": "ItalianOldStyleMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20652
+          "fileSize": 20652,
+          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd-Bold.woff2"
         },
         {
           "name": "ItalianOldStyleMTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22184
+          "fileSize": 22184,
+          "url": "fonts/Italian Old Style MT Std/ItalianOldStyleMTStd-BoldIt.woff2"
         }
       ]
     },
@@ -6385,42 +7014,48 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25740
+          "fileSize": 25740,
+          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Light.woff2"
         },
         {
           "name": "AmericanTypewriterStd-BdCnd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25072
+          "fileSize": 25072,
+          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-BdCnd.woff2"
         },
         {
           "name": "AmericanTypewriterStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25188
+          "fileSize": 25188,
+          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Cond.woff2"
         },
         {
           "name": "AmericanTypewriterStd-LtCnd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25260
+          "fileSize": 25260,
+          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-LtCnd.woff2"
         },
         {
           "name": "AmericanTypewriterStd-Med",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27020
+          "fileSize": 27020,
+          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Med.woff2"
         },
         {
           "name": "AmericanTypewriterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26768
+          "fileSize": 26768,
+          "url": "fonts/ITC American Typewriter Std/AmericanTypewriterStd-Bold.woff2"
         }
       ]
     },
@@ -6439,7 +7074,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12856
+          "fileSize": 12856,
+          "url": "fonts/ITC Anna Std/AnnaStd.woff2"
         }
       ]
     },
@@ -6458,140 +7094,160 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17060
+          "fileSize": 17060,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Bk.woff2"
         },
         {
           "name": "ITCAvantGardeStd-BkCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17028
+          "fileSize": 17028,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BkCn.woff2"
         },
         {
           "name": "ITCAvantGardeStd-BkCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18384
+          "fileSize": 18384,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BkCnObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-BkObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18252
+          "fileSize": 18252,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BkObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17456
+          "fileSize": 17456,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Demi.woff2"
         },
         {
           "name": "ITCAvantGardeStd-DemiCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16900
+          "fileSize": 16900,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-DemiCn.woff2"
         },
         {
           "name": "ITCAvantGardeStd-DemiCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18036
+          "fileSize": 18036,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-DemiCnObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-DemiObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18244
+          "fileSize": 18244,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-DemiObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-Md",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17116
+          "fileSize": 17116,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Md.woff2"
         },
         {
           "name": "ITCAvantGardeStd-MdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16892
+          "fileSize": 16892,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-MdCn.woff2"
         },
         {
           "name": "ITCAvantGardeStd-MdCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17968
+          "fileSize": 17968,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-MdCnObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-MdObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17968
+          "fileSize": 17968,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-MdObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-XLt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16372
+          "fileSize": 16372,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLt.woff2"
         },
         {
           "name": "ITCAvantGardeStd-XLtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15844
+          "fileSize": 15844,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLtCn.woff2"
         },
         {
           "name": "ITCAvantGardeStd-XLtCnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16812
+          "fileSize": 16812,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLtCnObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-XLtObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17492
+          "fileSize": 17492,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-XLtObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16764
+          "fileSize": 16764,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-Bold.woff2"
         },
         {
           "name": "ITCAvantGardeStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16060
+          "fileSize": 16060,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BoldCn.woff2"
         },
         {
           "name": "ITCAvantGardeStd-BoldCnObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17020
+          "fileSize": 17020,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BoldCnObl.woff2"
         },
         {
           "name": "ITCAvantGardeStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17540
+          "fileSize": 17540,
+          "url": "fonts/ITC Avant Garde Gothic Std/ITCAvantGardeStd-BoldObl.woff2"
         }
       ]
     },
@@ -6610,7 +7266,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18528
+          "fileSize": 18528,
+          "url": "fonts/ITC Beesknees Std/BeeskneesStd.woff2"
         }
       ]
     },
@@ -6629,56 +7286,64 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16876
+          "fileSize": 16876,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Book.woff2"
         },
         {
           "name": "BenguiatGothicStd-BookObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18480
+          "fileSize": 18480,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-BookObl.woff2"
         },
         {
           "name": "BenguiatGothicStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17016
+          "fileSize": 17016,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Heavy.woff2"
         },
         {
           "name": "BenguiatGothicStd-HeavyObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18636
+          "fileSize": 18636,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-HeavyObl.woff2"
         },
         {
           "name": "BenguiatGothicStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16680
+          "fileSize": 16680,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Medium.woff2"
         },
         {
           "name": "BenguiatGothicStd-MediumObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18392
+          "fileSize": 18392,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-MediumObl.woff2"
         },
         {
           "name": "BenguiatGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17308
+          "fileSize": 17308,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-Bold.woff2"
         },
         {
           "name": "BenguiatGothicStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18848
+          "fileSize": 18848,
+          "url": "fonts/ITC Benguiat Gothic Std/BenguiatGothicStd-BoldObl.woff2"
         }
       ]
     },
@@ -6697,42 +7362,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25848
+          "fileSize": 25848,
+          "url": "fonts/ITC Benguiat Std/BenguiatStd-BookItalic.woff2"
         },
         {
           "name": "BenguiatStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24972
+          "fileSize": 24972,
+          "url": "fonts/ITC Benguiat Std/BenguiatStd-MediumItalic.woff2"
         },
         {
           "name": "BenguiatStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22092
+          "fileSize": 22092,
+          "url": "fonts/ITC Benguiat Std/BenguiatStd-Book.woff2"
         },
         {
           "name": "BenguiatStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23912
+          "fileSize": 23912,
+          "url": "fonts/ITC Benguiat Std/BenguiatStd-Medium.woff2"
         },
         {
           "name": "BenguiatStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25756
+          "fileSize": 25756,
+          "url": "fonts/ITC Benguiat Std/BenguiatStd-BoldItalic.woff2"
         },
         {
           "name": "BenguiatStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23244
+          "fileSize": 23244,
+          "url": "fonts/ITC Benguiat Std/BenguiatStd-Bold.woff2"
         }
       ]
     },
@@ -6751,56 +7422,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20212
+          "fileSize": 20212,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-BlackItalic.woff2"
         },
         {
           "name": "BerkeleyStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20228
+          "fileSize": 20228,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-BookItalic.woff2"
         },
         {
           "name": "BerkeleyStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19728
+          "fileSize": 19728,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Italic.woff2"
         },
         {
           "name": "BerkeleyStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19288
+          "fileSize": 19288,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Black.woff2"
         },
         {
           "name": "BerkeleyStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18784
+          "fileSize": 18784,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Book.woff2"
         },
         {
           "name": "BerkeleyStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18824
+          "fileSize": 18824,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Medium.woff2"
         },
         {
           "name": "BerkeleyStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20492
+          "fileSize": 20492,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-BoldItalic.woff2"
         },
         {
           "name": "BerkeleyStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048
+          "fileSize": 19048,
+          "url": "fonts/ITC Berkeley Std/BerkeleyStd-Bold.woff2"
         }
       ]
     },
@@ -6819,56 +7498,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21976
+          "fileSize": 21976,
+          "url": "fonts/ITC Bookman Std/BookmanStd-LightItalic.woff2"
         },
         {
           "name": "BookmanStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21092
+          "fileSize": 21092,
+          "url": "fonts/ITC Bookman Std/BookmanStd-Light.woff2"
         },
         {
           "name": "BookmanStd-DemiItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21428
+          "fileSize": 21428,
+          "url": "fonts/ITC Bookman Std/BookmanStd-DemiItalic.woff2"
         },
         {
           "name": "BookmanStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20576
+          "fileSize": 20576,
+          "url": "fonts/ITC Bookman Std/BookmanStd-MediumItalic.woff2"
         },
         {
           "name": "BookmanStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20756
+          "fileSize": 20756,
+          "url": "fonts/ITC Bookman Std/BookmanStd-Demi.woff2"
         },
         {
           "name": "BookmanStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19196
+          "fileSize": 19196,
+          "url": "fonts/ITC Bookman Std/BookmanStd-Medium.woff2"
         },
         {
           "name": "BookmanStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20372
+          "fileSize": 20372,
+          "url": "fonts/ITC Bookman Std/BookmanStd-BoldItalic.woff2"
         },
         {
           "name": "BookmanStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19588
+          "fileSize": 19588,
+          "url": "fonts/ITC Bookman Std/BookmanStd-Bold.woff2"
         }
       ]
     },
@@ -6887,56 +7574,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22400
+          "fileSize": 22400,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-BlackItalic.woff2"
         },
         {
           "name": "Caslon224Std-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21892
+          "fileSize": 21892,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-BookItalic.woff2"
         },
         {
           "name": "Caslon224Std-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22600
+          "fileSize": 22600,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-MediumItalic.woff2"
         },
         {
           "name": "Caslon224Std-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19784
+          "fileSize": 19784,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Black.woff2"
         },
         {
           "name": "Caslon224Std-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20120
+          "fileSize": 20120,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Book.woff2"
         },
         {
           "name": "Caslon224Std-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20104
+          "fileSize": 20104,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Medium.woff2"
         },
         {
           "name": "Caslon224Std-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22280
+          "fileSize": 22280,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-BoldItalic.woff2"
         },
         {
           "name": "Caslon224Std-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20192
+          "fileSize": 20192,
+          "url": "fonts/ITC Caslon 224 Std/Caslon224Std-Bold.woff2"
         }
       ]
     },
@@ -6955,14 +7650,16 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34320
+          "fileSize": 34320,
+          "url": "fonts/ITC Century Handtooled Std/CenturyStd-HandtooledBold.woff2"
         },
         {
           "name": "CenturyStd-HandtooledBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36984
+          "fileSize": 36984,
+          "url": "fonts/ITC Century Handtooled Std/CenturyStd-HandtooledBoldIt.woff2"
         }
       ]
     },
@@ -6981,112 +7678,128 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20820
+          "fileSize": 20820,
+          "url": "fonts/ITC Century Std/CenturyStd-LightItalic.woff2"
         },
         {
           "name": "CenturyStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19120
+          "fileSize": 19120,
+          "url": "fonts/ITC Century Std/CenturyStd-Light.woff2"
         },
         {
           "name": "CenturyStd-LightCondensed",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19420
+          "fileSize": 19420,
+          "url": "fonts/ITC Century Std/CenturyStd-LightCondensed.woff2"
         },
         {
           "name": "CenturyStd-LightCondensedIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20592
+          "fileSize": 20592,
+          "url": "fonts/ITC Century Std/CenturyStd-LightCondensedIt.woff2"
         },
         {
           "name": "CenturyStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21048
+          "fileSize": 21048,
+          "url": "fonts/ITC Century Std/CenturyStd-BookItalic.woff2"
         },
         {
           "name": "CenturyStd-UltraItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20616
+          "fileSize": 20616,
+          "url": "fonts/ITC Century Std/CenturyStd-UltraItalic.woff2"
         },
         {
           "name": "CenturyStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19192
+          "fileSize": 19192,
+          "url": "fonts/ITC Century Std/CenturyStd-Book.woff2"
         },
         {
           "name": "CenturyStd-BookCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19664
+          "fileSize": 19664,
+          "url": "fonts/ITC Century Std/CenturyStd-BookCondensed.woff2"
         },
         {
           "name": "CenturyStd-BookCondensedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20668
+          "fileSize": 20668,
+          "url": "fonts/ITC Century Std/CenturyStd-BookCondensedIt.woff2"
         },
         {
           "name": "CenturyStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19528
+          "fileSize": 19528,
+          "url": "fonts/ITC Century Std/CenturyStd-Ultra.woff2"
         },
         {
           "name": "CenturyStd-UltraCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19652
+          "fileSize": 19652,
+          "url": "fonts/ITC Century Std/CenturyStd-UltraCondensed.woff2"
         },
         {
           "name": "CenturyStd-UltraCondensedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20504
+          "fileSize": 20504,
+          "url": "fonts/ITC Century Std/CenturyStd-UltraCondensedIt.woff2"
         },
         {
           "name": "CenturyStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20920
+          "fileSize": 20920,
+          "url": "fonts/ITC Century Std/CenturyStd-BoldItalic.woff2"
         },
         {
           "name": "CenturyStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19356
+          "fileSize": 19356,
+          "url": "fonts/ITC Century Std/CenturyStd-Bold.woff2"
         },
         {
           "name": "CenturyStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19152
+          "fileSize": 19152,
+          "url": "fonts/ITC Century Std/CenturyStd-BoldCondensed.woff2"
         },
         {
           "name": "CenturyStd-BoldCondensedIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20104
+          "fileSize": 20104,
+          "url": "fonts/ITC Century Std/CenturyStd-BoldCondensedIt.woff2"
         }
       ]
     },
@@ -7105,42 +7818,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30356
+          "fileSize": 30356,
+          "url": "fonts/ITC Cerigo Std/CerigoStd-BookItalic.woff2"
         },
         {
           "name": "CerigoStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30900
+          "fileSize": 30900,
+          "url": "fonts/ITC Cerigo Std/CerigoStd-MediumItalic.woff2"
         },
         {
           "name": "CerigoStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29984
+          "fileSize": 29984,
+          "url": "fonts/ITC Cerigo Std/CerigoStd-Book.woff2"
         },
         {
           "name": "CerigoStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460
+          "fileSize": 30460,
+          "url": "fonts/ITC Cerigo Std/CerigoStd-Medium.woff2"
         },
         {
           "name": "CerigoStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31372
+          "fileSize": 31372,
+          "url": "fonts/ITC Cerigo Std/CerigoStd-BoldItalic.woff2"
         },
         {
           "name": "CerigoStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30220
+          "fileSize": 30220,
+          "url": "fonts/ITC Cerigo Std/CerigoStd-Bold.woff2"
         }
       ]
     },
@@ -7159,14 +7878,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37412
+          "fileSize": 37412,
+          "url": "fonts/ITC Cheltenham Handtooled Std/CheltenhamStd-HdtooledBdIt.woff2"
         },
         {
           "name": "CheltenhamStd-HdtooledBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35976
+          "fileSize": 35976,
+          "url": "fonts/ITC Cheltenham Handtooled Std/CheltenhamStd-HdtooledBold.woff2"
         }
       ]
     },
@@ -7185,112 +7906,128 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20660
+          "fileSize": 20660,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-LightItalic.woff2"
         },
         {
           "name": "CheltenhamStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19408
+          "fileSize": 19408,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Light.woff2"
         },
         {
           "name": "CheltenhamStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17712
+          "fileSize": 17712,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-LightCond.woff2"
         },
         {
           "name": "CheltenhamStd-LightCondIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19136
+          "fileSize": 19136,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-LightCondIt.woff2"
         },
         {
           "name": "CheltenhamStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20424
+          "fileSize": 20424,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BookItalic.woff2"
         },
         {
           "name": "CheltenhamStd-UltraItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21252
+          "fileSize": 21252,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-UltraItalic.woff2"
         },
         {
           "name": "CheltenhamStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19344
+          "fileSize": 19344,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Book.woff2"
         },
         {
           "name": "CheltenhamStd-BookCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17904
+          "fileSize": 17904,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BookCond.woff2"
         },
         {
           "name": "CheltenhamStd-BookCondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19284
+          "fileSize": 19284,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BookCondIt.woff2"
         },
         {
           "name": "CheltenhamStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20128
+          "fileSize": 20128,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Ultra.woff2"
         },
         {
           "name": "CheltenhamStd-UltraCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18496
+          "fileSize": 18496,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-UltraCond.woff2"
         },
         {
           "name": "CheltenhamStd-UltraCondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20044
+          "fileSize": 20044,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-UltraCondIt.woff2"
         },
         {
           "name": "CheltenhamStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20804
+          "fileSize": 20804,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BoldItalic.woff2"
         },
         {
           "name": "CheltenhamStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19516
+          "fileSize": 19516,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-Bold.woff2"
         },
         {
           "name": "CheltenhamStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18096
+          "fileSize": 18096,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BoldCond.woff2"
         },
         {
           "name": "CheltenhamStd-BoldCondIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19604
+          "fileSize": 19604,
+          "url": "fonts/ITC Cheltenham Std/CheltenhamStd-BoldCondIt.woff2"
         }
       ]
     },
@@ -7309,56 +8046,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20108
+          "fileSize": 20108,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-BlackItalic.woff2"
         },
         {
           "name": "ClearfaceStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19824
+          "fileSize": 19824,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-HeavyItalic.woff2"
         },
         {
           "name": "ClearfaceStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20048
+          "fileSize": 20048,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-Italic.woff2"
         },
         {
           "name": "ClearfaceStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18580
+          "fileSize": 18580,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-Black.woff2"
         },
         {
           "name": "ClearfaceStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18996
+          "fileSize": 18996,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-Heavy.woff2"
         },
         {
           "name": "ClearfaceStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18796
+          "fileSize": 18796,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-Regular.woff2"
         },
         {
           "name": "ClearfaceStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20256
+          "fileSize": 20256,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-BoldItalic.woff2"
         },
         {
           "name": "ClearfaceStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18232
+          "fileSize": 18232,
+          "url": "fonts/ITC Clearface Std/ClearfaceStd-Bold.woff2"
         }
       ]
     },
@@ -7377,56 +8122,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19692
+          "fileSize": 19692,
+          "url": "fonts/ITC Cushing Std/CushingStd-BookItalic.woff2"
         },
         {
           "name": "CushingStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19308
+          "fileSize": 19308,
+          "url": "fonts/ITC Cushing Std/CushingStd-HeavyItalic.woff2"
         },
         {
           "name": "CushingStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19608
+          "fileSize": 19608,
+          "url": "fonts/ITC Cushing Std/CushingStd-MediumItalic.woff2"
         },
         {
           "name": "CushingStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18236
+          "fileSize": 18236,
+          "url": "fonts/ITC Cushing Std/CushingStd-Book.woff2"
         },
         {
           "name": "CushingStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18200
+          "fileSize": 18200,
+          "url": "fonts/ITC Cushing Std/CushingStd-Heavy.woff2"
         },
         {
           "name": "CushingStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17884
+          "fileSize": 17884,
+          "url": "fonts/ITC Cushing Std/CushingStd-Medium.woff2"
         },
         {
           "name": "CushingStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19108
+          "fileSize": 19108,
+          "url": "fonts/ITC Cushing Std/CushingStd-BoldItalic.woff2"
         },
         {
           "name": "CushingStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18756
+          "fileSize": 18756,
+          "url": "fonts/ITC Cushing Std/CushingStd-Bold.woff2"
         }
       ]
     },
@@ -7445,42 +8198,48 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17636
+          "fileSize": 17636,
+          "url": "fonts/ITC Eras Std/ITCErasStd-Light.woff2"
         },
         {
           "name": "ITCErasStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17288
+          "fileSize": 17288,
+          "url": "fonts/ITC Eras Std/ITCErasStd-Book.woff2"
         },
         {
           "name": "ITCErasStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17064
+          "fileSize": 17064,
+          "url": "fonts/ITC Eras Std/ITCErasStd-Demi.woff2"
         },
         {
           "name": "ITCErasStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17100
+          "fileSize": 17100,
+          "url": "fonts/ITC Eras Std/ITCErasStd-Medium.woff2"
         },
         {
           "name": "ITCErasStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17428
+          "fileSize": 17428,
+          "url": "fonts/ITC Eras Std/ITCErasStd-Ultra.woff2"
         },
         {
           "name": "ITCErasStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17200
+          "fileSize": 17200,
+          "url": "fonts/ITC Eras Std/ITCErasStd-Bold.woff2"
         }
       ]
     },
@@ -7499,56 +8258,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20668
+          "fileSize": 20668,
+          "url": "fonts/ITC Esprit Std/EspritStd-BlackItalic.woff2"
         },
         {
           "name": "EspritStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21388
+          "fileSize": 21388,
+          "url": "fonts/ITC Esprit Std/EspritStd-BookItalic.woff2"
         },
         {
           "name": "EspritStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21240
+          "fileSize": 21240,
+          "url": "fonts/ITC Esprit Std/EspritStd-MediumItalic.woff2"
         },
         {
           "name": "EspritStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20984
+          "fileSize": 20984,
+          "url": "fonts/ITC Esprit Std/EspritStd-Black.woff2"
         },
         {
           "name": "EspritStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20812
+          "fileSize": 20812,
+          "url": "fonts/ITC Esprit Std/EspritStd-Book.woff2"
         },
         {
           "name": "EspritStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20844
+          "fileSize": 20844,
+          "url": "fonts/ITC Esprit Std/EspritStd-Medium.woff2"
         },
         {
           "name": "EspritStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20832
+          "fileSize": 20832,
+          "url": "fonts/ITC Esprit Std/EspritStd-BoldItalic.woff2"
         },
         {
           "name": "EspritStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20892
+          "fileSize": 20892,
+          "url": "fonts/ITC Esprit Std/EspritStd-Bold.woff2"
         }
       ]
     },
@@ -7567,56 +8334,64 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16728
+          "fileSize": 16728,
+          "url": "fonts/ITC Fenice Std/FeniceStd-Light.woff2"
         },
         {
           "name": "FeniceStd-LightOblique",
           "weight": 300,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17380
+          "fileSize": 17380,
+          "url": "fonts/ITC Fenice Std/FeniceStd-LightOblique.woff2"
         },
         {
           "name": "FeniceStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16876
+          "fileSize": 16876,
+          "url": "fonts/ITC Fenice Std/FeniceStd-Regular.woff2"
         },
         {
           "name": "FeniceStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17308
+          "fileSize": 17308,
+          "url": "fonts/ITC Fenice Std/FeniceStd-Ultra.woff2"
         },
         {
           "name": "FeniceStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17632
+          "fileSize": 17632,
+          "url": "fonts/ITC Fenice Std/FeniceStd-Oblique.woff2"
         },
         {
           "name": "FeniceStd-UltraOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 18180
+          "fileSize": 18180,
+          "url": "fonts/ITC Fenice Std/FeniceStd-UltraOblique.woff2"
         },
         {
           "name": "FeniceStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16760
+          "fileSize": 16760,
+          "url": "fonts/ITC Fenice Std/FeniceStd-Bold.woff2"
         },
         {
           "name": "FeniceStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17660
+          "fileSize": 17660,
+          "url": "fonts/ITC Fenice Std/FeniceStd-BoldOblique.woff2"
         }
       ]
     },
@@ -7635,14 +8410,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19404
+          "fileSize": 19404,
+          "url": "fonts/ITC Flora Std/FloraStd-Medium.woff2"
         },
         {
           "name": "FloraStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19292
+          "fileSize": 19292,
+          "url": "fonts/ITC Flora Std/FloraStd-Bold.woff2"
         }
       ]
     },
@@ -7661,140 +8438,160 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16408
+          "fileSize": 16408,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCd.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-BkCdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16928
+          "fileSize": 16928,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCdIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-BkCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15976
+          "fileSize": 15976,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCp.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-BkCpIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16940
+          "fileSize": 16940,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkCpIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-BkXCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16424
+          "fileSize": 16424,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BkXCp.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16296
+          "fileSize": 16296,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Book.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-BookIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17656
+          "fileSize": 17656,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-BookIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552
+          "fileSize": 16552,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Demi.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-DemiIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17584
+          "fileSize": 17584,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DemiIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-DmCd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16500
+          "fileSize": 16500,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCd.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-DmCdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17204
+          "fileSize": 17204,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCdIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-DmCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16908
+          "fileSize": 16908,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCp.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-DmCpIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17724
+          "fileSize": 17724,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmCpIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-DmXCp",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16772
+          "fileSize": 16772,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-DmXCp.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-Hvy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552
+          "fileSize": 16552,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Hvy.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-HvyIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18052
+          "fileSize": 18052,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-HvyIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-MdCd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16444
+          "fileSize": 16444,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-MdCd.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-MdCdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17052
+          "fileSize": 17052,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-MdCdIt.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-Med",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16684
+          "fileSize": 16684,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-Med.woff2"
         },
         {
           "name": "ITCFranklinGothicStd-MedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17736
+          "fileSize": 17736,
+          "url": "fonts/ITC Franklin Gothic Std/ITCFranklinGothicStd-MedIt.woff2"
         }
       ]
     },
@@ -7813,56 +8610,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20520
+          "fileSize": 20520,
+          "url": "fonts/ITC Galliard Std/GalliardStd-BlackItalic.woff2"
         },
         {
           "name": "GalliardStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19188
+          "fileSize": 19188,
+          "url": "fonts/ITC Galliard Std/GalliardStd-Italic.woff2"
         },
         {
           "name": "GalliardStd-UltraItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20272
+          "fileSize": 20272,
+          "url": "fonts/ITC Galliard Std/GalliardStd-UltraItalic.woff2"
         },
         {
           "name": "GalliardStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19600
+          "fileSize": 19600,
+          "url": "fonts/ITC Galliard Std/GalliardStd-Black.woff2"
         },
         {
           "name": "GalliardStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18004
+          "fileSize": 18004,
+          "url": "fonts/ITC Galliard Std/GalliardStd-Roman.woff2"
         },
         {
           "name": "GalliardStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19336
+          "fileSize": 19336,
+          "url": "fonts/ITC Galliard Std/GalliardStd-Ultra.woff2"
         },
         {
           "name": "GalliardStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19412
+          "fileSize": 19412,
+          "url": "fonts/ITC Galliard Std/GalliardStd-BoldItalic.woff2"
         },
         {
           "name": "GalliardStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18192
+          "fileSize": 18192,
+          "url": "fonts/ITC Galliard Std/GalliardStd-Bold.woff2"
         }
       ]
     },
@@ -7881,14 +8686,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45540
+          "fileSize": 45540,
+          "url": "fonts/ITC Garamond Handtooled Std/GaramondStd-HandtooledBdIt.woff2"
         },
         {
           "name": "GaramondStd-HandtooledBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42784
+          "fileSize": 42784,
+          "url": "fonts/ITC Garamond Handtooled Std/GaramondStd-HandtooledBold.woff2"
         }
       ]
     },
@@ -7907,168 +8714,192 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27232
+          "fileSize": 27232,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Bd.woff2"
         },
         {
           "name": "ITCGaramondStd-BdCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26688
+          "fileSize": 26688,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdCond.woff2"
         },
         {
           "name": "ITCGaramondStd-BdCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27668
+          "fileSize": 27668,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdCondIta.woff2"
         },
         {
           "name": "ITCGaramondStd-BdIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28208
+          "fileSize": 28208,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdIta.woff2"
         },
         {
           "name": "ITCGaramondStd-BdNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27320
+          "fileSize": 27320,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdNarrow.woff2"
         },
         {
           "name": "ITCGaramondStd-BdNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28672
+          "fileSize": 28672,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BdNarrowIta.woff2"
         },
         {
           "name": "ITCGaramondStd-Bk",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27204
+          "fileSize": 27204,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Bk.woff2"
         },
         {
           "name": "ITCGaramondStd-BkCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26096
+          "fileSize": 26096,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkCond.woff2"
         },
         {
           "name": "ITCGaramondStd-BkCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27508
+          "fileSize": 27508,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkCondIta.woff2"
         },
         {
           "name": "ITCGaramondStd-BkIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28448
+          "fileSize": 28448,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkIta.woff2"
         },
         {
           "name": "ITCGaramondStd-BkNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27080
+          "fileSize": 27080,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkNarrow.woff2"
         },
         {
           "name": "ITCGaramondStd-BkNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28268
+          "fileSize": 28268,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-BkNarrowIta.woff2"
         },
         {
           "name": "ITCGaramondStd-Lt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23776
+          "fileSize": 23776,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Lt.woff2"
         },
         {
           "name": "ITCGaramondStd-LtCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24300
+          "fileSize": 24300,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtCond.woff2"
         },
         {
           "name": "ITCGaramondStd-LtCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25592
+          "fileSize": 25592,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtCondIta.woff2"
         },
         {
           "name": "ITCGaramondStd-LtIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26000
+          "fileSize": 26000,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtIta.woff2"
         },
         {
           "name": "ITCGaramondStd-LtNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25988
+          "fileSize": 25988,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtNarrow.woff2"
         },
         {
           "name": "ITCGaramondStd-LtNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27728
+          "fileSize": 27728,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-LtNarrowIta.woff2"
         },
         {
           "name": "ITCGaramondStd-Ult",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25636
+          "fileSize": 25636,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-Ult.woff2"
         },
         {
           "name": "ITCGaramondStd-UltCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24724
+          "fileSize": 24724,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltCond.woff2"
         },
         {
           "name": "ITCGaramondStd-UltCondIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25488
+          "fileSize": 25488,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltCondIta.woff2"
         },
         {
           "name": "ITCGaramondStd-UltIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26436
+          "fileSize": 26436,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltIta.woff2"
         },
         {
           "name": "ITCGaramondStd-UltNarrow",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26576
+          "fileSize": 26576,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltNarrow.woff2"
         },
         {
           "name": "ITCGaramondStd-UltNarrowIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28064
+          "fileSize": 28064,
+          "url": "fonts/ITC Garamond Std/ITCGaramondStd-UltNarrowIta.woff2"
         }
       ]
     },
@@ -8087,42 +8918,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21012
+          "fileSize": 21012,
+          "url": "fonts/ITC Giovanni Std/GiovanniStd-BlackItalic.woff2"
         },
         {
           "name": "GiovanniStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20384
+          "fileSize": 20384,
+          "url": "fonts/ITC Giovanni Std/GiovanniStd-BookItalic.woff2"
         },
         {
           "name": "GiovanniStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19424
+          "fileSize": 19424,
+          "url": "fonts/ITC Giovanni Std/GiovanniStd-Black.woff2"
         },
         {
           "name": "GiovanniStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19416
+          "fileSize": 19416,
+          "url": "fonts/ITC Giovanni Std/GiovanniStd-Book.woff2"
         },
         {
           "name": "GiovanniStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20752
+          "fileSize": 20752,
+          "url": "fonts/ITC Giovanni Std/GiovanniStd-BoldItalic.woff2"
         },
         {
           "name": "GiovanniStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19800
+          "fileSize": 19800,
+          "url": "fonts/ITC Giovanni Std/GiovanniStd-Bold.woff2"
         }
       ]
     },
@@ -8141,56 +8978,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22492
+          "fileSize": 22492,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-BlackItalic.woff2"
         },
         {
           "name": "GoudySansStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22228
+          "fileSize": 22228,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-BookItalic.woff2"
         },
         {
           "name": "GoudySansStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22156
+          "fileSize": 22156,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-MediumItalic.woff2"
         },
         {
           "name": "GoudySansStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20172
+          "fileSize": 20172,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Black.woff2"
         },
         {
           "name": "GoudySansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19828
+          "fileSize": 19828,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Book.woff2"
         },
         {
           "name": "GoudySansStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19912
+          "fileSize": 19912,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Medium.woff2"
         },
         {
           "name": "GoudySansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22552
+          "fileSize": 22552,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-BoldItalic.woff2"
         },
         {
           "name": "GoudySansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20112
+          "fileSize": 20112,
+          "url": "fonts/ITC Goudy Sans Std/GoudySansStd-Bold.woff2"
         }
       ]
     },
@@ -8209,42 +9054,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27828
+          "fileSize": 27828,
+          "url": "fonts/ITC Highlander Std/HighlanderStd-BookItalic.woff2"
         },
         {
           "name": "HighlanderStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28048
+          "fileSize": 28048,
+          "url": "fonts/ITC Highlander Std/HighlanderStd-MediumItalic.woff2"
         },
         {
           "name": "HighlanderStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28272
+          "fileSize": 28272,
+          "url": "fonts/ITC Highlander Std/HighlanderStd-Book.woff2"
         },
         {
           "name": "HighlanderStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28776
+          "fileSize": 28776,
+          "url": "fonts/ITC Highlander Std/HighlanderStd-Medium.woff2"
         },
         {
           "name": "HighlanderStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28252
+          "fileSize": 28252,
+          "url": "fonts/ITC Highlander Std/HighlanderStd-BoldItalic.woff2"
         },
         {
           "name": "HighlanderStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29504
+          "fileSize": 29504,
+          "url": "fonts/ITC Highlander Std/HighlanderStd-Bold.woff2"
         }
       ]
     },
@@ -8263,14 +9114,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21232
+          "fileSize": 21232,
+          "url": "fonts/ITC Isadora Std/IsadoraStd-Regular.woff2"
         },
         {
           "name": "IsadoraStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20672
+          "fileSize": 20672,
+          "url": "fonts/ITC Isadora Std/IsadoraStd-Bold.woff2"
         }
       ]
     },
@@ -8289,35 +9142,40 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15332
+          "fileSize": 15332,
+          "url": "fonts/ITC Kabel Std/ITCKabelStd-Book.woff2"
         },
         {
           "name": "ITCKabelStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15596
+          "fileSize": 15596,
+          "url": "fonts/ITC Kabel Std/ITCKabelStd-Demi.woff2"
         },
         {
           "name": "ITCKabelStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15292
+          "fileSize": 15292,
+          "url": "fonts/ITC Kabel Std/ITCKabelStd-Medium.woff2"
         },
         {
           "name": "ITCKabelStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15320
+          "fileSize": 15320,
+          "url": "fonts/ITC Kabel Std/ITCKabelStd-Ultra.woff2"
         },
         {
           "name": "ITCKabelStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15064
+          "fileSize": 15064,
+          "url": "fonts/ITC Kabel Std/ITCKabelStd-Bold.woff2"
         }
       ]
     },
@@ -8336,28 +9194,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19044
+          "fileSize": 19044,
+          "url": "fonts/ITC Korinna Std/KorinnaStd-Kursiv.woff2"
         },
         {
           "name": "KorinnaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17956
+          "fileSize": 17956,
+          "url": "fonts/ITC Korinna Std/KorinnaStd-Regular.woff2"
         },
         {
           "name": "KorinnaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17680
+          "fileSize": 17680,
+          "url": "fonts/ITC Korinna Std/KorinnaStd-Bold.woff2"
         },
         {
           "name": "KorinnaStd-BoldKursiv",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18648
+          "fileSize": 18648,
+          "url": "fonts/ITC Korinna Std/KorinnaStd-BoldKursiv.woff2"
         }
       ]
     },
@@ -8376,56 +9238,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21288
+          "fileSize": 21288,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-BlackItalic.woff2"
         },
         {
           "name": "LeawoodStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20140
+          "fileSize": 20140,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-BookItalic.woff2"
         },
         {
           "name": "LeawoodStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20988
+          "fileSize": 20988,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-MediumItalic.woff2"
         },
         {
           "name": "LeawoodStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20980
+          "fileSize": 20980,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-Black.woff2"
         },
         {
           "name": "LeawoodStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20420
+          "fileSize": 20420,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-Book.woff2"
         },
         {
           "name": "LeawoodStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20712
+          "fileSize": 20712,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-Medium.woff2"
         },
         {
           "name": "LeawoodStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21176
+          "fileSize": 21176,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-BoldItalic.woff2"
         },
         {
           "name": "LeawoodStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21340
+          "fileSize": 21340,
+          "url": "fonts/ITC Leawood Std/LeawoodStd-Bold.woff2"
         }
       ]
     },
@@ -8444,49 +9314,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20228
+          "fileSize": 20228,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-BookItalic.woff2"
         },
         {
           "name": "LegacySansStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20656
+          "fileSize": 20656,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-MediumItalic.woff2"
         },
         {
           "name": "LegacySansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19516
+          "fileSize": 19516,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Book.woff2"
         },
         {
           "name": "LegacySansStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19240
+          "fileSize": 19240,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Medium.woff2"
         },
         {
           "name": "LegacySansStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20240
+          "fileSize": 20240,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Ultra.woff2"
         },
         {
           "name": "LegacySansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20348
+          "fileSize": 20348,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-BoldItalic.woff2"
         },
         {
           "name": "LegacySansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19264
+          "fileSize": 19264,
+          "url": "fonts/ITC Legacy Sans Std/LegacySansStd-Bold.woff2"
         }
       ]
     },
@@ -8505,49 +9382,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29428
+          "fileSize": 29428,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-BookItalic.woff2"
         },
         {
           "name": "LegacySerifStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29624
+          "fileSize": 29624,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-MediumItalic.woff2"
         },
         {
           "name": "LegacySerifStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30164
+          "fileSize": 30164,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Book.woff2"
         },
         {
           "name": "LegacySerifStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30240
+          "fileSize": 30240,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Medium.woff2"
         },
         {
           "name": "LegacySerifStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30460
+          "fileSize": 30460,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Ultra.woff2"
         },
         {
           "name": "LegacySerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30436
+          "fileSize": 30436,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-BoldItalic.woff2"
         },
         {
           "name": "LegacySerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30400
+          "fileSize": 30400,
+          "url": "fonts/ITC Legacy Serif Std/LegacySerifStd-Bold.woff2"
         }
       ]
     },
@@ -8566,28 +9450,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16496
+          "fileSize": 16496,
+          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-Book.woff2"
         },
         {
           "name": "LubalinGraphStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17120
+          "fileSize": 17120,
+          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-Demi.woff2"
         },
         {
           "name": "LubalinGraphStd-BookOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17364
+          "fileSize": 17364,
+          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-BookOblique.woff2"
         },
         {
           "name": "LubalinGraphStd-DemiOblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 17808
+          "fileSize": 17808,
+          "url": "fonts/ITC Lubalin Graph Std/LubalinGraphStd-DemiOblique.woff2"
         }
       ]
     },
@@ -8606,14 +9494,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11112
+          "fileSize": 11112,
+          "url": "fonts/ITC Machine Std/MachineStd.woff2"
         },
         {
           "name": "MachineStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11252
+          "fileSize": 11252,
+          "url": "fonts/ITC Machine Std/MachineStd-Bold.woff2"
         }
       ]
     },
@@ -8632,42 +9522,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31300
+          "fileSize": 31300,
+          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-BookItalic.woff2"
         },
         {
           "name": "MendozaRomanStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30620
+          "fileSize": 30620,
+          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-Book.woff2"
         },
         {
           "name": "MendozaRomanStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31340
+          "fileSize": 31340,
+          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-Medium.woff2"
         },
         {
           "name": "MendozaRomanStd-MediumIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31620
+          "fileSize": 31620,
+          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-MediumIt.woff2"
         },
         {
           "name": "MendozaRomanStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31612
+          "fileSize": 31612,
+          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-BoldItalic.woff2"
         },
         {
           "name": "MendozaRomanStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31360
+          "fileSize": 31360,
+          "url": "fonts/ITC Mendoza Roman Std/MendozaRomanStd-Bold.woff2"
         }
       ]
     },
@@ -8686,14 +9582,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25480
+          "fileSize": 25480,
+          "url": "fonts/ITC Mona Lisa Std/MonaLisaStd-Recut.woff2"
         },
         {
           "name": "MonaLisaStd-Solid",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20204
+          "fileSize": 20204,
+          "url": "fonts/ITC Mona Lisa Std/MonaLisaStd-Solid.woff2"
         }
       ]
     },
@@ -8712,28 +9610,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22864
+          "fileSize": 22864,
+          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-Italic.woff2"
         },
         {
           "name": "NewBaskervilleStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27632
+          "fileSize": 27632,
+          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-Roman.woff2"
         },
         {
           "name": "NewBaskervilleStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28240
+          "fileSize": 28240,
+          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-Bold.woff2"
         },
         {
           "name": "NewBaskervilleStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23712
+          "fileSize": 23712,
+          "url": "fonts/ITC New Baskerville Std/NewBaskervilleStd-BoldIt.woff2"
         }
       ]
     },
@@ -8752,49 +9654,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19220
+          "fileSize": 19220,
+          "url": "fonts/ITC Novarese Std/NovareseStd-BookItalic.woff2"
         },
         {
           "name": "NovareseStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18408
+          "fileSize": 18408,
+          "url": "fonts/ITC Novarese Std/NovareseStd-MediumItalic.woff2"
         },
         {
           "name": "NovareseStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18328
+          "fileSize": 18328,
+          "url": "fonts/ITC Novarese Std/NovareseStd-Book.woff2"
         },
         {
           "name": "NovareseStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17992
+          "fileSize": 17992,
+          "url": "fonts/ITC Novarese Std/NovareseStd-Medium.woff2"
         },
         {
           "name": "NovareseStd-Ultra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18600
+          "fileSize": 18600,
+          "url": "fonts/ITC Novarese Std/NovareseStd-Ultra.woff2"
         },
         {
           "name": "NovareseStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18440
+          "fileSize": 18440,
+          "url": "fonts/ITC Novarese Std/NovareseStd-BoldItalic.woff2"
         },
         {
           "name": "NovareseStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18060
+          "fileSize": 18060,
+          "url": "fonts/ITC Novarese Std/NovareseStd-Bold.woff2"
         }
       ]
     },
@@ -8813,28 +9722,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20844
+          "fileSize": 20844,
+          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-BookItalic.woff2"
         },
         {
           "name": "OfficinaSansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20012
+          "fileSize": 20012,
+          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-Book.woff2"
         },
         {
           "name": "OfficinaSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20608
+          "fileSize": 20608,
+          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-BoldItalic.woff2"
         },
         {
           "name": "OfficinaSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19392
+          "fileSize": 19392,
+          "url": "fonts/ITC Officina Sans Std/OfficinaSansStd-Bold.woff2"
         }
       ]
     },
@@ -8853,28 +9766,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21616
+          "fileSize": 21616,
+          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-BookItalic.woff2"
         },
         {
           "name": "OfficinaSerifStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20604
+          "fileSize": 20604,
+          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-Book.woff2"
         },
         {
           "name": "OfficinaSerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21208
+          "fileSize": 21208,
+          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-BoldItalic.woff2"
         },
         {
           "name": "OfficinaSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20092
+          "fileSize": 20092,
+          "url": "fonts/ITC Officina Serif Std/OfficinaSerifStd-Bold.woff2"
         }
       ]
     },
@@ -8893,7 +9810,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35160
+          "fileSize": 35160,
+          "url": "fonts/ITC Ozwald Std/OzwaldStd.woff2"
         }
       ]
     },
@@ -8912,35 +9830,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18512
+          "fileSize": 18512,
+          "url": "fonts/ITC Quorum Std/QuorumStd-Light.woff2"
         },
         {
           "name": "QuorumStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18756
+          "fileSize": 18756,
+          "url": "fonts/ITC Quorum Std/QuorumStd-Black.woff2"
         },
         {
           "name": "QuorumStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18580
+          "fileSize": 18580,
+          "url": "fonts/ITC Quorum Std/QuorumStd-Book.woff2"
         },
         {
           "name": "QuorumStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18496
+          "fileSize": 18496,
+          "url": "fonts/ITC Quorum Std/QuorumStd-Medium.woff2"
         },
         {
           "name": "QuorumStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18772
+          "fileSize": 18772,
+          "url": "fonts/ITC Quorum Std/QuorumStd-Bold.woff2"
         }
       ]
     },
@@ -8959,42 +9882,48 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16644
+          "fileSize": 16644,
+          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Light.woff2"
         },
         {
           "name": "SerifGothicStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17228
+          "fileSize": 17228,
+          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd.woff2"
         },
         {
           "name": "SerifGothicStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17704
+          "fileSize": 17704,
+          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Black.woff2"
         },
         {
           "name": "SerifGothicStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17440
+          "fileSize": 17440,
+          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Heavy.woff2"
         },
         {
           "name": "SerifGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17432
+          "fileSize": 17432,
+          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-Bold.woff2"
         },
         {
           "name": "SerifGothicStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17392
+          "fileSize": 17392,
+          "url": "fonts/ITC Serif Gothic Std/SerifGothicStd-ExtraBold.woff2"
         }
       ]
     },
@@ -9013,56 +9942,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21748
+          "fileSize": 21748,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-BlackItalic.woff2"
         },
         {
           "name": "SlimbachStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22480
+          "fileSize": 22480,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-BookItalic.woff2"
         },
         {
           "name": "SlimbachStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21744
+          "fileSize": 21744,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-MediumItalic.woff2"
         },
         {
           "name": "SlimbachStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20396
+          "fileSize": 20396,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-Black.woff2"
         },
         {
           "name": "SlimbachStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21420
+          "fileSize": 21420,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-Book.woff2"
         },
         {
           "name": "SlimbachStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21804
+          "fileSize": 21804,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-Medium.woff2"
         },
         {
           "name": "SlimbachStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21488
+          "fileSize": 21488,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-BoldItalic.woff2"
         },
         {
           "name": "SlimbachStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20192
+          "fileSize": 20192,
+          "url": "fonts/ITC Slimbach Std/SlimbachStd-Bold.woff2"
         }
       ]
     },
@@ -9081,56 +10018,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23352
+          "fileSize": 23352,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-LightItalic.woff2"
         },
         {
           "name": "SouvenirStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21560
+          "fileSize": 21560,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-Light.woff2"
         },
         {
           "name": "SouvenirStd-DemiItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22548
+          "fileSize": 22548,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-DemiItalic.woff2"
         },
         {
           "name": "SouvenirStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20652
+          "fileSize": 20652,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-MediumItalic.woff2"
         },
         {
           "name": "SouvenirStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21336
+          "fileSize": 21336,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-Demi.woff2"
         },
         {
           "name": "SouvenirStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19556
+          "fileSize": 19556,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-Medium.woff2"
         },
         {
           "name": "SouvenirStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20536
+          "fileSize": 20536,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-BoldItalic.woff2"
         },
         {
           "name": "SouvenirStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19412
+          "fileSize": 19412,
+          "url": "fonts/ITC Souvenir Std/SouvenirStd-Bold.woff2"
         }
       ]
     },
@@ -9149,42 +10094,48 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19540
+          "fileSize": 19540,
+          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-Medium.woff2"
         },
         {
           "name": "StoneInformalStd-MediumItal",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20140
+          "fileSize": 20140,
+          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-MediumItal.woff2"
         },
         {
           "name": "StoneInformalStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19988
+          "fileSize": 19988,
+          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-BoldItalic.woff2"
         },
         {
           "name": "StoneInformalStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19792
+          "fileSize": 19792,
+          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-Bold.woff2"
         },
         {
           "name": "StoneInformalStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19680
+          "fileSize": 19680,
+          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-Semibold.woff2"
         },
         {
           "name": "StoneInformalStd-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19652
+          "fileSize": 19652,
+          "url": "fonts/ITC Stone Informal Std/StoneInformalStd-SemiboldIt.woff2"
         }
       ]
     },
@@ -9203,49 +10154,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16016
+          "fileSize": 16016,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-MediumItalic.woff2"
         },
         {
           "name": "StoneSansStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15316
+          "fileSize": 15316,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Medium.woff2"
         },
         {
           "name": "StoneSansStd-Phonetic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47660
+          "fileSize": 47660,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Phonetic.woff2"
         },
         {
           "name": "StoneSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16348
+          "fileSize": 16348,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-BoldItalic.woff2"
         },
         {
           "name": "StoneSansStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16064
+          "fileSize": 16064,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-SemiboldItalic.woff2"
         },
         {
           "name": "StoneSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15804
+          "fileSize": 15804,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Bold.woff2"
         },
         {
           "name": "StoneSansStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15416
+          "fileSize": 15416,
+          "url": "fonts/ITC Stone Sans Std/StoneSansStd-Semibold.woff2"
         }
       ]
     },
@@ -9264,49 +10222,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19600
+          "fileSize": 19600,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-MediumItalic.woff2"
         },
         {
           "name": "StoneSerifStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18588
+          "fileSize": 18588,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Medium.woff2"
         },
         {
           "name": "StoneSerifStd-Phonetic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 53996
+          "fileSize": 53996,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Phonetic.woff2"
         },
         {
           "name": "StoneSerifStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19096
+          "fileSize": 19096,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-BoldItalic.woff2"
         },
         {
           "name": "StoneSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048
+          "fileSize": 19048,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Bold.woff2"
         },
         {
           "name": "StoneSerifStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19152
+          "fileSize": 19152,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-Semibold.woff2"
         },
         {
           "name": "StoneSerifStd-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19316
+          "fileSize": 19316,
+          "url": "fonts/ITC Stone Serif Std/StoneSerifStd-SemiboldIt.woff2"
         }
       ]
     },
@@ -9325,56 +10290,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17684
+          "fileSize": 17684,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-BlackItalic.woff2"
         },
         {
           "name": "ITCSymbolStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17892
+          "fileSize": 17892,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-BookItalic.woff2"
         },
         {
           "name": "ITCSymbolStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17704
+          "fileSize": 17704,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-MediumItalic.woff2"
         },
         {
           "name": "ITCSymbolStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17348
+          "fileSize": 17348,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Black.woff2"
         },
         {
           "name": "ITCSymbolStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16808
+          "fileSize": 16808,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Book.woff2"
         },
         {
           "name": "ITCSymbolStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17024
+          "fileSize": 17024,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Medium.woff2"
         },
         {
           "name": "ITCSymbolStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17972
+          "fileSize": 17972,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-BoldItalic.woff2"
         },
         {
           "name": "ITCSymbolStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17316
+          "fileSize": 17316,
+          "url": "fonts/ITC Symbol Std/ITCSymbolStd-Bold.woff2"
         }
       ]
     },
@@ -9393,42 +10366,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 26412
+          "fileSize": 26412,
+          "url": "fonts/ITC Tiepolo Std/TiepoloStd-BlackItalic.woff2"
         },
         {
           "name": "TiepoloStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25880
+          "fileSize": 25880,
+          "url": "fonts/ITC Tiepolo Std/TiepoloStd-BookItalic.woff2"
         },
         {
           "name": "TiepoloStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23772
+          "fileSize": 23772,
+          "url": "fonts/ITC Tiepolo Std/TiepoloStd-Black.woff2"
         },
         {
           "name": "TiepoloStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25332
+          "fileSize": 25332,
+          "url": "fonts/ITC Tiepolo Std/TiepoloStd-Book.woff2"
         },
         {
           "name": "TiepoloStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24440
+          "fileSize": 24440,
+          "url": "fonts/ITC Tiepolo Std/TiepoloStd-BoldItalic.woff2"
         },
         {
           "name": "TiepoloStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23792
+          "fileSize": 23792,
+          "url": "fonts/ITC Tiepolo Std/TiepoloStd-Bold.woff2"
         }
       ]
     },
@@ -9447,42 +10426,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23560
+          "fileSize": 23560,
+          "url": "fonts/ITC Tiffany Std/TiffanyStd-DemiItalic.woff2"
         },
         {
           "name": "TiffanyStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24052
+          "fileSize": 24052,
+          "url": "fonts/ITC Tiffany Std/TiffanyStd-HeavyItalic.woff2"
         },
         {
           "name": "TiffanyStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23492
+          "fileSize": 23492,
+          "url": "fonts/ITC Tiffany Std/TiffanyStd-Italic.woff2"
         },
         {
           "name": "TiffanyStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22360
+          "fileSize": 22360,
+          "url": "fonts/ITC Tiffany Std/TiffanyStd.woff2"
         },
         {
           "name": "TiffanyStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21900
+          "fileSize": 21900,
+          "url": "fonts/ITC Tiffany Std/TiffanyStd-Demi.woff2"
         },
         {
           "name": "TiffanyStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22120
+          "fileSize": 22120,
+          "url": "fonts/ITC Tiffany Std/TiffanyStd-Heavy.woff2"
         }
       ]
     },
@@ -9501,56 +10486,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21648
+          "fileSize": 21648,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-BlackItalic.woff2"
         },
         {
           "name": "UsherwoodStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22184
+          "fileSize": 22184,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-BookItalic.woff2"
         },
         {
           "name": "UsherwoodStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21540
+          "fileSize": 21540,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-MediumItalic.woff2"
         },
         {
           "name": "UsherwoodStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20684
+          "fileSize": 20684,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Black.woff2"
         },
         {
           "name": "UsherwoodStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22040
+          "fileSize": 22040,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Book.woff2"
         },
         {
           "name": "UsherwoodStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20804
+          "fileSize": 20804,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Medium.woff2"
         },
         {
           "name": "UsherwoodStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21120
+          "fileSize": 21120,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-BoldItalic.woff2"
         },
         {
           "name": "UsherwoodStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20748
+          "fileSize": 20748,
+          "url": "fonts/ITC Usherwood Std/UsherwoodStd-Bold.woff2"
         }
       ]
     },
@@ -9569,56 +10562,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18300
+          "fileSize": 18300,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-BlackItalic.woff2"
         },
         {
           "name": "VeljovicStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17972
+          "fileSize": 17972,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-BookItalic.woff2"
         },
         {
           "name": "VeljovicStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18140
+          "fileSize": 18140,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-MediumItalic.woff2"
         },
         {
           "name": "VeljovicStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17672
+          "fileSize": 17672,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-Black.woff2"
         },
         {
           "name": "VeljovicStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17056
+          "fileSize": 17056,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-Book.woff2"
         },
         {
           "name": "VeljovicStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16924
+          "fileSize": 16924,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-Medium.woff2"
         },
         {
           "name": "VeljovicStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17992
+          "fileSize": 17992,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-BoldItalic.woff2"
         },
         {
           "name": "VeljovicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17396
+          "fileSize": 17396,
+          "url": "fonts/ITC Veljovic Std/VeljovicStd-Bold.woff2"
         }
       ]
     },
@@ -9637,42 +10638,48 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20280
+          "fileSize": 20280,
+          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-LightItalic.woff2"
         },
         {
           "name": "ZapfChanceryStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20696
+          "fileSize": 20696,
+          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Light.woff2"
         },
         {
           "name": "ZapfChanceryStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21908
+          "fileSize": 21908,
+          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Italic.woff2"
         },
         {
           "name": "ZapfChanceryStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21124
+          "fileSize": 21124,
+          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Demi.woff2"
         },
         {
           "name": "ZapfChanceryStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20628
+          "fileSize": 20628,
+          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Roman.woff2"
         },
         {
           "name": "ZapfChanceryStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21388
+          "fileSize": 21388,
+          "url": "fonts/ITC Zapf Chancery Std/ZapfChanceryStd-Bold.woff2"
         }
       ]
     },
@@ -9691,7 +10698,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25488
+          "fileSize": 25488,
+          "url": "fonts/ITC Zapf Dingbats Std/ZapfDingbatsStd.woff2"
         }
       ]
     },
@@ -9710,28 +10718,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24632
+          "fileSize": 24632,
+          "url": "fonts/Janson Text LT Std/JansonTextLTStd-Italic.woff2"
         },
         {
           "name": "JansonTextLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29660
+          "fileSize": 29660,
+          "url": "fonts/Janson Text LT Std/JansonTextLTStd-Roman.woff2"
         },
         {
           "name": "JansonTextLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24528
+          "fileSize": 24528,
+          "url": "fonts/Janson Text LT Std/JansonTextLTStd-BoldItalic.woff2"
         },
         {
           "name": "JansonTextLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22772
+          "fileSize": 22772,
+          "url": "fonts/Janson Text LT Std/JansonTextLTStd-Bold.woff2"
         }
       ]
     },
@@ -9750,63 +10762,72 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27632
+          "fileSize": 27632,
+          "url": "fonts/Jimbo Std/JimboStd-Black.woff2"
         },
         {
           "name": "JimboStd-BlackCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26248
+          "fileSize": 26248,
+          "url": "fonts/Jimbo Std/JimboStd-BlackCondensed.woff2"
         },
         {
           "name": "JimboStd-BlackExpanded",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26672
+          "fileSize": 26672,
+          "url": "fonts/Jimbo Std/JimboStd-BlackExpanded.woff2"
         },
         {
           "name": "JimboStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25364
+          "fileSize": 25364,
+          "url": "fonts/Jimbo Std/JimboStd-Condensed.woff2"
         },
         {
           "name": "JimboStd-Expanded",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26560
+          "fileSize": 26560,
+          "url": "fonts/Jimbo Std/JimboStd-Expanded.woff2"
         },
         {
           "name": "JimboStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27084
+          "fileSize": 27084,
+          "url": "fonts/Jimbo Std/JimboStd-Regular.woff2"
         },
         {
           "name": "JimboStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27744
+          "fileSize": 27744,
+          "url": "fonts/Jimbo Std/JimboStd-Bold.woff2"
         },
         {
           "name": "JimboStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27356
+          "fileSize": 27356,
+          "url": "fonts/Jimbo Std/JimboStd-BoldCondensed.woff2"
         },
         {
           "name": "JimboStd-BoldExpanded",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28564
+          "fileSize": 28564,
+          "url": "fonts/Jimbo Std/JimboStd-BoldExpanded.woff2"
         }
       ]
     },
@@ -9825,49 +10846,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18304
+          "fileSize": 18304,
+          "url": "fonts/Joanna MT Std/JoannaMTStd-Italic.woff2"
         },
         {
           "name": "JoannaMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17200
+          "fileSize": 17200,
+          "url": "fonts/Joanna MT Std/JoannaMTStd.woff2"
         },
         {
           "name": "JoannaMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18580
+          "fileSize": 18580,
+          "url": "fonts/Joanna MT Std/JoannaMTStd-BoldItalic.woff2"
         },
         {
           "name": "JoannaMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18620
+          "fileSize": 18620,
+          "url": "fonts/Joanna MT Std/JoannaMTStd-SemiBoldItalic.woff2"
         },
         {
           "name": "JoannaMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17468
+          "fileSize": 17468,
+          "url": "fonts/Joanna MT Std/JoannaMTStd-Bold.woff2"
         },
         {
           "name": "JoannaMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17664
+          "fileSize": 17664,
+          "url": "fonts/Joanna MT Std/JoannaMTStd-ExtraBold.woff2"
         },
         {
           "name": "JoannaMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17644
+          "fileSize": 17644,
+          "url": "fonts/Joanna MT Std/JoannaMTStd-SemiBold.woff2"
         }
       ]
     },
@@ -9886,7 +10914,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17332
+          "fileSize": 17332,
+          "url": "fonts/Juniper Std/JuniperStd.woff2"
         }
       ]
     },
@@ -9905,28 +10934,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14216
+          "fileSize": 14216,
+          "url": "fonts/Kabel LT Std/KabelLTStd-Light.woff2"
         },
         {
           "name": "KabelLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15168
+          "fileSize": 15168,
+          "url": "fonts/Kabel LT Std/KabelLTStd-Black.woff2"
         },
         {
           "name": "KabelLTStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14284
+          "fileSize": 14284,
+          "url": "fonts/Kabel LT Std/KabelLTStd-Book.woff2"
         },
         {
           "name": "KabelLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14744
+          "fileSize": 14744,
+          "url": "fonts/Kabel LT Std/KabelLTStd-Heavy.woff2"
         }
       ]
     },
@@ -9945,14 +10978,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21700
+          "fileSize": 21700,
+          "url": "fonts/Kaufmann Std/KaufmannStd.woff2"
         },
         {
           "name": "KaufmannStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21816
+          "fileSize": 21816,
+          "url": "fonts/Kaufmann Std/KaufmannStd-Bold.woff2"
         }
       ]
     },
@@ -9971,14 +11006,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27176
+          "fileSize": 27176,
+          "url": "fonts/Khaki Std/KhakiStd-1.woff2"
         },
         {
           "name": "KhakiStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33500
+          "fileSize": 33500,
+          "url": "fonts/Khaki Std/KhakiStd-2.woff2"
         }
       ]
     },
@@ -9997,21 +11034,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 49140
+          "fileSize": 49140,
+          "url": "fonts/Kigali Std/KigaliStd-Italic.woff2"
         },
         {
           "name": "KigaliStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47692
+          "fileSize": 47692,
+          "url": "fonts/Kigali Std/KigaliStd-Roman.woff2"
         },
         {
           "name": "KigaliStd-ZigZag",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67044
+          "fileSize": 67044,
+          "url": "fonts/Kigali Std/KigaliStd-ZigZag.woff2"
         }
       ]
     },
@@ -10030,70 +11070,80 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 39892
+          "fileSize": 39892,
+          "url": "fonts/Kinesis Std/KinesisStd-LightItalic.woff2"
         },
         {
           "name": "KinesisStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 38448
+          "fileSize": 38448,
+          "url": "fonts/Kinesis Std/KinesisStd-Light.woff2"
         },
         {
           "name": "KinesisStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 39060
+          "fileSize": 39060,
+          "url": "fonts/Kinesis Std/KinesisStd-BlackItalic.woff2"
         },
         {
           "name": "KinesisStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 41268
+          "fileSize": 41268,
+          "url": "fonts/Kinesis Std/KinesisStd-Italic.woff2"
         },
         {
           "name": "KinesisStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39184
+          "fileSize": 39184,
+          "url": "fonts/Kinesis Std/KinesisStd-Black.woff2"
         },
         {
           "name": "KinesisStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40320
+          "fileSize": 40320,
+          "url": "fonts/Kinesis Std/KinesisStd-Regular.woff2"
         },
         {
           "name": "KinesisStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 41464
+          "fileSize": 41464,
+          "url": "fonts/Kinesis Std/KinesisStd-BoldItalic.woff2"
         },
         {
           "name": "KinesisStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 42072
+          "fileSize": 42072,
+          "url": "fonts/Kinesis Std/KinesisStd-SemiboldItalic.woff2"
         },
         {
           "name": "KinesisStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40880
+          "fileSize": 40880,
+          "url": "fonts/Kinesis Std/KinesisStd-Bold.woff2"
         },
         {
           "name": "KinesisStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41224
+          "fileSize": 41224,
+          "url": "fonts/Kinesis Std/KinesisStd-Semibold.woff2"
         }
       ]
     },
@@ -10112,7 +11162,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15888
+          "fileSize": 15888,
+          "url": "fonts/Kino MT Std/KinoMTStd.woff2"
         }
       ]
     },
@@ -10131,7 +11182,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22780
+          "fileSize": 22780,
+          "url": "fonts/Klang MT Std/KlangMTStd.woff2"
         }
       ]
     },
@@ -10150,7 +11202,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22840
+          "fileSize": 22840,
+          "url": "fonts/Koch Antiqua LT Std/KochAntiquaLTStd.woff2"
         }
       ]
     },
@@ -10169,21 +11222,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20188
+          "fileSize": 20188,
+          "url": "fonts/Kolo LP Std/KoloLPStd-Narrow.woff2"
         },
         {
           "name": "KoloLPStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25940
+          "fileSize": 25940,
+          "url": "fonts/Kolo LP Std/KoloLPStd-Regular.woff2"
         },
         {
           "name": "KoloLPStd-Wide",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21496
+          "fileSize": 21496,
+          "url": "fonts/Kolo LP Std/KoloLPStd-Wide.woff2"
         }
       ]
     },
@@ -10202,7 +11258,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28296
+          "fileSize": 28296,
+          "url": "fonts/Kompakt LT Std/KompaktLTStd.woff2"
         }
       ]
     },
@@ -10221,21 +11278,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24808
+          "fileSize": 24808,
+          "url": "fonts/Kuenstler Script LT Std/KuenstlerScriptLTStd-Black.woff2"
         },
         {
           "name": "KuenstlerScriptLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24676
+          "fileSize": 24676,
+          "url": "fonts/Kuenstler Script LT Std/KuenstlerScriptLTStd-Medium.woff2"
         },
         {
           "name": "KuenstlerScriptLTStd-2Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25168
+          "fileSize": 25168,
+          "url": "fonts/Kuenstler Script LT Std/KuenstlerScriptLTStd-2Bold.woff2"
         }
       ]
     },
@@ -10254,7 +11314,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18884
+          "fileSize": 18884,
+          "url": "fonts/Latin MT Std/LatinMTStd-Condensed.woff2"
         }
       ]
     },
@@ -10273,14 +11334,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 52664
+          "fileSize": 52664,
+          "url": "fonts/Legault Std/LegaultStd.woff2"
         },
         {
           "name": "LegaultStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 51536
+          "fileSize": 51536,
+          "url": "fonts/Legault Std/LegaultStd-Bold.woff2"
         }
       ]
     },
@@ -10299,28 +11362,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21048
+          "fileSize": 21048,
+          "url": "fonts/Letter Gothic Std/LetterGothicStd.woff2"
         },
         {
           "name": "LetterGothicStd-Slanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22312
+          "fileSize": 22312,
+          "url": "fonts/Letter Gothic Std/LetterGothicStd-Slanted.woff2"
         },
         {
           "name": "LetterGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20744
+          "fileSize": 20744,
+          "url": "fonts/Letter Gothic Std/LetterGothicStd-Bold.woff2"
         },
         {
           "name": "LetterGothicStd-BoldSlanted",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22220
+          "fileSize": 22220,
+          "url": "fonts/Letter Gothic Std/LetterGothicStd-BoldSlanted.woff2"
         }
       ]
     },
@@ -10339,21 +11406,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20892
+          "fileSize": 20892,
+          "url": "fonts/Life LT Std/LifeLTStd-Italic.woff2"
         },
         {
           "name": "LifeLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19500
+          "fileSize": 19500,
+          "url": "fonts/Life LT Std/LifeLTStd-Roman.woff2"
         },
         {
           "name": "LifeLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19172
+          "fileSize": 19172,
+          "url": "fonts/Life LT Std/LifeLTStd-Bold.woff2"
         }
       ]
     },
@@ -10372,56 +11442,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24692
+          "fileSize": 24692,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-Italic.woff2"
         },
         {
           "name": "LinoLetterStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24668
+          "fileSize": 24668,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-MediumItalic.woff2"
         },
         {
           "name": "LinoLetterStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30052
+          "fileSize": 30052,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-Black.woff2"
         },
         {
           "name": "LinoLetterStd-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24680
+          "fileSize": 24680,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-BlackIt.woff2"
         },
         {
           "name": "LinoLetterStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29808
+          "fileSize": 29808,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-Medium.woff2"
         },
         {
           "name": "LinoLetterStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29500
+          "fileSize": 29500,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-Roman.woff2"
         },
         {
           "name": "LinoLetterStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24740
+          "fileSize": 24740,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-BoldItalic.woff2"
         },
         {
           "name": "LinoLetterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29880
+          "fileSize": 29880,
+          "url": "fonts/LinoLetter Std/LinoLetterStd-Bold.woff2"
         }
       ]
     },
@@ -10440,7 +11518,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23920
+          "fileSize": 23920,
+          "url": "fonts/Linoscript Std/LinoscriptStd.woff2"
         }
       ]
     },
@@ -10459,7 +11538,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27636
+          "fileSize": 27636,
+          "url": "fonts/Linotext Std/LinotextStd.woff2"
         }
       ]
     },
@@ -10478,14 +11558,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 12932
+          "fileSize": 12932,
+          "url": "fonts/Linotype Astrology Pi Std/AstrologyPiLTStd-1.woff2"
         },
         {
           "name": "AstrologyPiLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40556
+          "fileSize": 40556,
+          "url": "fonts/Linotype Astrology Pi Std/AstrologyPiLTStd-2.woff2"
         }
       ]
     },
@@ -10504,7 +11586,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20088
+          "fileSize": 20088,
+          "url": "fonts/Linotype Audio Pi Std/AudioPiLTStd.woff2"
         }
       ]
     },
@@ -10523,56 +11606,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21692
+          "fileSize": 21692,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-LightItalic.woff2"
         },
         {
           "name": "CentennialLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25828
+          "fileSize": 25828,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Light.woff2"
         },
         {
           "name": "CentennialLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22060
+          "fileSize": 22060,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-BlackItalic.woff2"
         },
         {
           "name": "CentennialLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21292
+          "fileSize": 21292,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Italic.woff2"
         },
         {
           "name": "CentennialLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21268
+          "fileSize": 21268,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Black.woff2"
         },
         {
           "name": "CentennialLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26348
+          "fileSize": 26348,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Roman.woff2"
         },
         {
           "name": "CentennialLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20812
+          "fileSize": 20812,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-BoldItalic.woff2"
         },
         {
           "name": "CentennialLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20552
+          "fileSize": 20552,
+          "url": "fonts/Linotype Centennial Std/CentennialLTStd-Bold.woff2"
         }
       ]
     },
@@ -10591,14 +11682,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18548
+          "fileSize": 18548,
+          "url": "fonts/Linotype Decoration Pi Std/DecorationPiLTStd-1.woff2"
         },
         {
           "name": "DecorationPiLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21388
+          "fileSize": 21388,
+          "url": "fonts/Linotype Decoration Pi Std/DecorationPiLTStd-2.woff2"
         }
       ]
     },
@@ -10617,35 +11710,40 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20912
+          "fileSize": 20912,
+          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Italic.woff2"
         },
         {
           "name": "DidotLTStd-Headline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24372
+          "fileSize": 24372,
+          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Headline.woff2"
         },
         {
           "name": "DidotLTStd-Ornaments",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 9340
+          "fileSize": 9340,
+          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Ornaments.woff2"
         },
         {
           "name": "DidotLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25000
+          "fileSize": 25000,
+          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Roman.woff2"
         },
         {
           "name": "DidotLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20140
+          "fileSize": 20140,
+          "url": "fonts/Linotype Didot LT Std/DidotLTStd-Bold.woff2"
         }
       ]
     },
@@ -10664,28 +11762,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 13752
+          "fileSize": 13752,
+          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-ChessDraughts.woff2"
         },
         {
           "name": "GamePiLTStd-DiceDominoes",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 5840
+          "fileSize": 5840,
+          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-DiceDominoes.woff2"
         },
         {
           "name": "GamePiLTStd-EnglishCards",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11060
+          "fileSize": 11060,
+          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-EnglishCards.woff2"
         },
         {
           "name": "GamePiLTStd-FrenchCards",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19152
+          "fileSize": 19152,
+          "url": "fonts/Linotype Game Pi Std/GamePiLTStd-FrenchCards.woff2"
         }
       ]
     },
@@ -10704,21 +11806,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23428
+          "fileSize": 23428,
+          "url": "fonts/Linotype Holiday Pi Std/HolidayPiLTStd-1.woff2"
         },
         {
           "name": "HolidayPiLTStd-2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18176
+          "fileSize": 18176,
+          "url": "fonts/Linotype Holiday Pi Std/HolidayPiLTStd-2.woff2"
         },
         {
           "name": "HolidayPiLTStd-3",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20112
+          "fileSize": 20112,
+          "url": "fonts/Linotype Holiday Pi Std/HolidayPiLTStd-3.woff2"
         }
       ]
     },
@@ -10737,7 +11842,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23944
+          "fileSize": 23944,
+          "url": "fonts/Linotype Warning Pi Std/WarningPiLTStd.woff2"
         }
       ]
     },
@@ -10756,35 +11862,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31044
+          "fileSize": 31044,
+          "url": "fonts/Lithos Pro/LithosPro-ExtraLight.woff2"
         },
         {
           "name": "LithosPro-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32004
+          "fileSize": 32004,
+          "url": "fonts/Lithos Pro/LithosPro-Light.woff2"
         },
         {
           "name": "LithosPro-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31912
+          "fileSize": 31912,
+          "url": "fonts/Lithos Pro/LithosPro-Black.woff2"
         },
         {
           "name": "LithosPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31488
+          "fileSize": 31488,
+          "url": "fonts/Lithos Pro/LithosPro-Regular.woff2"
         },
         {
           "name": "LithosPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31824
+          "fileSize": 31824,
+          "url": "fonts/Lithos Pro/LithosPro-Bold.woff2"
         }
       ]
     },
@@ -10803,21 +11914,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 12028
+          "fileSize": 12028,
+          "url": "fonts/Lucida Math Std/LucidaMathStd-Italic.woff2"
         },
         {
           "name": "LucidaMathStd-Extension",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8524
+          "fileSize": 8524,
+          "url": "fonts/Lucida Math Std/LucidaMathStd-Extension.woff2"
         },
         {
           "name": "LucidaMathStd-Symbol",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 11444
+          "fileSize": 11444,
+          "url": "fonts/Lucida Math Std/LucidaMathStd-Symbol.woff2"
         }
       ]
     },
@@ -10836,28 +11950,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15940
+          "fileSize": 15940,
+          "url": "fonts/Lucida Sans Std/LucidaSansStd-Italic.woff2"
         },
         {
           "name": "LucidaSansStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15776
+          "fileSize": 15776,
+          "url": "fonts/Lucida Sans Std/LucidaSansStd.woff2"
         },
         {
           "name": "LucidaSansStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16344
+          "fileSize": 16344,
+          "url": "fonts/Lucida Sans Std/LucidaSansStd-BoldItalic.woff2"
         },
         {
           "name": "LucidaSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15876
+          "fileSize": 15876,
+          "url": "fonts/Lucida Sans Std/LucidaSansStd-Bold.woff2"
         }
       ]
     },
@@ -10876,28 +11994,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15620
+          "fileSize": 15620,
+          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd.woff2"
         },
         {
           "name": "LucidaSansTypewriterStd-Bd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16032
+          "fileSize": 16032,
+          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd-Bd.woff2"
         },
         {
           "name": "LucidaSansTypewriterStd-BOb",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16744
+          "fileSize": 16744,
+          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd-BOb.woff2"
         },
         {
           "name": "LucidaSansTypewriterStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16440
+          "fileSize": 16440,
+          "url": "fonts/Lucida Sans Typewriter Std/LucidaSansTypewriterStd-Obl.woff2"
         }
       ]
     },
@@ -10916,28 +12038,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18484
+          "fileSize": 18484,
+          "url": "fonts/Lucida Std/LucidaStd-Italic.woff2"
         },
         {
           "name": "LucidaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18008
+          "fileSize": 18008,
+          "url": "fonts/Lucida Std/LucidaStd.woff2"
         },
         {
           "name": "LucidaStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 18776
+          "fileSize": 18776,
+          "url": "fonts/Lucida Std/LucidaStd-BoldItalic.woff2"
         },
         {
           "name": "LucidaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18592
+          "fileSize": 18592,
+          "url": "fonts/Lucida Std/LucidaStd-Bold.woff2"
         }
       ]
     },
@@ -10956,28 +12082,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17284
+          "fileSize": 17284,
+          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd.woff2"
         },
         {
           "name": "LucidaTypewriterStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17836
+          "fileSize": 17836,
+          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd-Obl.woff2"
         },
         {
           "name": "LucidaTypewriterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17296
+          "fileSize": 17296,
+          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd-Bold.woff2"
         },
         {
           "name": "LucidaTypewriterStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17992
+          "fileSize": 17992,
+          "url": "fonts/Lucida Typewriter Std/LucidaTypewriterStd-BoldObl.woff2"
         }
       ]
     },
@@ -10996,7 +12126,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23116
+          "fileSize": 23116,
+          "url": "fonts/Madrone Std/MadroneStd.woff2"
         }
       ]
     },
@@ -11015,14 +12146,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14540
+          "fileSize": 14540,
+          "url": "fonts/Magnesium MVB Std/MagnesiumMVBStd.woff2"
         },
         {
           "name": "MagnesiumMVBStd-Grime",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 112300
+          "fileSize": 112300,
+          "url": "fonts/Magnesium MVB Std/MagnesiumMVBStd-Grime.woff2"
         }
       ]
     },
@@ -11041,7 +12174,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17884
+          "fileSize": 17884,
+          "url": "fonts/Magnolia MVB Std/MagnoliaMVBStd.woff2"
         }
       ]
     },
@@ -11060,7 +12194,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23396
+          "fileSize": 23396,
+          "url": "fonts/Manito LP Std/ManitoLPStd.woff2"
         }
       ]
     },
@@ -11079,7 +12214,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58680
+          "fileSize": 58680,
+          "url": "fonts/Mathematical Pi LT Std/MathematicalPiLTStd.woff2"
         }
       ]
     },
@@ -11098,7 +12234,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29544
+          "fileSize": 29544,
+          "url": "fonts/Matura MT Std/MaturaMTStd.woff2"
         }
       ]
     },
@@ -11117,7 +12254,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18460
+          "fileSize": 18460,
+          "url": "fonts/Maximus LT Std/MaximusLTStd.woff2"
         }
       ]
     },
@@ -11136,7 +12274,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21876
+          "fileSize": 21876,
+          "url": "fonts/Medici Script LT Std/MediciScriptLTStd.woff2"
         }
       ]
     },
@@ -11155,28 +12294,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21528
+          "fileSize": 21528,
+          "url": "fonts/Melior LT Std/MeliorLTStd-Italic.woff2"
         },
         {
           "name": "MeliorLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19284
+          "fileSize": 19284,
+          "url": "fonts/Melior LT Std/MeliorLTStd.woff2"
         },
         {
           "name": "MeliorLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20972
+          "fileSize": 20972,
+          "url": "fonts/Melior LT Std/MeliorLTStd-BoldItalic.woff2"
         },
         {
           "name": "MeliorLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19872
+          "fileSize": 19872,
+          "url": "fonts/Melior LT Std/MeliorLTStd-Bold.woff2"
         }
       ]
     },
@@ -11195,49 +12338,56 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17240
+          "fileSize": 17240,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-LightItalic.woff2"
         },
         {
           "name": "MemphisLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16512
+          "fileSize": 16512,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-Light.woff2"
         },
         {
           "name": "MemphisLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17256
+          "fileSize": 17256,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-MediumItalic.woff2"
         },
         {
           "name": "MemphisLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16628
+          "fileSize": 16628,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-Medium.woff2"
         },
         {
           "name": "MemphisLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17328
+          "fileSize": 17328,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-BoldItalic.woff2"
         },
         {
           "name": "MemphisLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16668
+          "fileSize": 16668,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-Bold.woff2"
         },
         {
           "name": "MemphisLTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17376
+          "fileSize": 17376,
+          "url": "fonts/Memphis LT Std/MemphisLTStd-ExtraBold.woff2"
         }
       ]
     },
@@ -11256,7 +12406,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20128
+          "fileSize": 20128,
+          "url": "fonts/Mercurius MT Std/MercuriusMTStd-BoldScript.woff2"
         }
       ]
     },
@@ -11275,42 +12426,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20904
+          "fileSize": 20904,
+          "url": "fonts/Meridien LT Std/MeridienLTStd-Italic.woff2"
         },
         {
           "name": "MeridienLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21056
+          "fileSize": 21056,
+          "url": "fonts/Meridien LT Std/MeridienLTStd-MediumItalic.woff2"
         },
         {
           "name": "MeridienLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20292
+          "fileSize": 20292,
+          "url": "fonts/Meridien LT Std/MeridienLTStd-Medium.woff2"
         },
         {
           "name": "MeridienLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20664
+          "fileSize": 20664,
+          "url": "fonts/Meridien LT Std/MeridienLTStd-Roman.woff2"
         },
         {
           "name": "MeridienLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21088
+          "fileSize": 21088,
+          "url": "fonts/Meridien LT Std/MeridienLTStd-BoldItalic.woff2"
         },
         {
           "name": "MeridienLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20688
+          "fileSize": 20688,
+          "url": "fonts/Meridien LT Std/MeridienLTStd-Bold.woff2"
         }
       ]
     },
@@ -11329,7 +12486,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26964
+          "fileSize": 26964,
+          "url": "fonts/Mesquite Std/MesquiteStd.woff2"
         }
       ]
     },
@@ -11348,35 +12506,40 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25720
+          "fileSize": 25720,
+          "url": "fonts/Mezz Std/MezzStd-Light.woff2"
         },
         {
           "name": "MezzStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25868
+          "fileSize": 25868,
+          "url": "fonts/Mezz Std/MezzStd-Black.woff2"
         },
         {
           "name": "MezzStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27440
+          "fileSize": 27440,
+          "url": "fonts/Mezz Std/MezzStd-Regular.woff2"
         },
         {
           "name": "MezzStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27260
+          "fileSize": 27260,
+          "url": "fonts/Mezz Std/MezzStd-Bold.woff2"
         },
         {
           "name": "MezzStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27128
+          "fileSize": 27128,
+          "url": "fonts/Mezz Std/MezzStd-Semibold.woff2"
         }
       ]
     },
@@ -11395,7 +12558,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 1940
+          "fileSize": 1940,
+          "url": "fonts/MICR Std/MICRStd.woff2"
         }
       ]
     },
@@ -11414,7 +12578,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28972
+          "fileSize": 28972,
+          "url": "fonts/Minion Std/MinionStd-Black.woff2"
         }
       ]
     },
@@ -11433,56 +12598,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21360
+          "fileSize": 21360,
+          "url": "fonts/Minister Std/MinisterStd-LightItalic.woff2"
         },
         {
           "name": "MinisterStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20168
+          "fileSize": 20168,
+          "url": "fonts/Minister Std/MinisterStd-Light.woff2"
         },
         {
           "name": "MinisterStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21560
+          "fileSize": 21560,
+          "url": "fonts/Minister Std/MinisterStd-BlackItalic.woff2"
         },
         {
           "name": "MinisterStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21508
+          "fileSize": 21508,
+          "url": "fonts/Minister Std/MinisterStd-BookItalic.woff2"
         },
         {
           "name": "MinisterStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20660
+          "fileSize": 20660,
+          "url": "fonts/Minister Std/MinisterStd-Black.woff2"
         },
         {
           "name": "MinisterStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20276
+          "fileSize": 20276,
+          "url": "fonts/Minister Std/MinisterStd-Book.woff2"
         },
         {
           "name": "MinisterStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21560
+          "fileSize": 21560,
+          "url": "fonts/Minister Std/MinisterStd-BoldItalic.woff2"
         },
         {
           "name": "MinisterStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20760
+          "fileSize": 20760,
+          "url": "fonts/Minister Std/MinisterStd-Bold.woff2"
         }
       ]
     },
@@ -11501,7 +12674,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31124
+          "fileSize": 31124,
+          "url": "fonts/Mistral Std/MistralStd.woff2"
         }
       ]
     },
@@ -11520,7 +12694,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17532
+          "fileSize": 17532,
+          "url": "fonts/Mojo Std/MojoStd.woff2"
         }
       ]
     },
@@ -11539,7 +12714,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29196
+          "fileSize": 29196,
+          "url": "fonts/Monoline Script MT Std/MonolineScriptMTStd.woff2"
         }
       ]
     },
@@ -11558,56 +12734,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22156
+          "fileSize": 22156,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-CondensedItalic.woff2"
         },
         {
           "name": "ModernMTStd-ExtendedItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23100
+          "fileSize": 23100,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-ExtendedItalic.woff2"
         },
         {
           "name": "ModernMTStd-WideItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22204
+          "fileSize": 22204,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-WideItalic.woff2"
         },
         {
           "name": "ModernMTStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20588
+          "fileSize": 20588,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-Condensed.woff2"
         },
         {
           "name": "ModernMTStd-Extended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22024
+          "fileSize": 22024,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-Extended.woff2"
         },
         {
           "name": "ModernMTStd-Wide",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20720
+          "fileSize": 20720,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-Wide.woff2"
         },
         {
           "name": "ModernMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23480
+          "fileSize": 23480,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-BoldItalic.woff2"
         },
         {
           "name": "ModernMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21808
+          "fileSize": 21808,
+          "url": "fonts/Monotype Modern Std/ModernMTStd-Bold.woff2"
         }
       ]
     },
@@ -11626,7 +12810,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33892
+          "fileSize": 33892,
+          "url": "fonts/Monotype Old Style MT Std/MonotypeOldStyleMTStd-BdOut.woff2"
         }
       ]
     },
@@ -11645,35 +12830,40 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 26352
+          "fileSize": 26352,
+          "url": "fonts/Montara Std/Montara-Italic.woff2"
         },
         {
           "name": "Montara-Gothic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26788
+          "fileSize": 26788,
+          "url": "fonts/Montara Std/Montara-Gothic.woff2"
         },
         {
           "name": "Montara-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25780
+          "fileSize": 25780,
+          "url": "fonts/Montara Std/Montara-BoldItalic.woff2"
         },
         {
           "name": "Montara-BoldGothic",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26012
+          "fileSize": 26012,
+          "url": "fonts/Montara Std/Montara-BoldGothic.woff2"
         },
         {
           "name": "Montara-BoldInitials",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44264
+          "fileSize": 44264,
+          "url": "fonts/Montara Std/Montara-BoldInitials.woff2"
         }
       ]
     },
@@ -11692,84 +12882,96 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32008
+          "fileSize": 32008,
+          "url": "fonts/Moonglow Std/Moonglow-Light.woff2"
         },
         {
           "name": "Moonglow-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31428
+          "fileSize": 31428,
+          "url": "fonts/Moonglow Std/Moonglow-LightCond.woff2"
         },
         {
           "name": "Moonglow-LightExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31184
+          "fileSize": 31184,
+          "url": "fonts/Moonglow Std/Moonglow-LightExt.woff2"
         },
         {
           "name": "Moonglow-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32428
+          "fileSize": 32428,
+          "url": "fonts/Moonglow Std/Moonglow-Cond.woff2"
         },
         {
           "name": "Moonglow-Ext",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32684
+          "fileSize": 32684,
+          "url": "fonts/Moonglow Std/Moonglow-Ext.woff2"
         },
         {
           "name": "Moonglow-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32404
+          "fileSize": 32404,
+          "url": "fonts/Moonglow Std/Moonglow-Regular.woff2"
         },
         {
           "name": "Moonglow-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32572
+          "fileSize": 32572,
+          "url": "fonts/Moonglow Std/Moonglow-Bold.woff2"
         },
         {
           "name": "Moonglow-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31956
+          "fileSize": 31956,
+          "url": "fonts/Moonglow Std/Moonglow-BoldCond.woff2"
         },
         {
           "name": "Moonglow-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31020
+          "fileSize": 31020,
+          "url": "fonts/Moonglow Std/Moonglow-BoldExt.woff2"
         },
         {
           "name": "Moonglow-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33028
+          "fileSize": 33028,
+          "url": "fonts/Moonglow Std/Moonglow-Semibold.woff2"
         },
         {
           "name": "Moonglow-SemiboldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32584
+          "fileSize": 32584,
+          "url": "fonts/Moonglow Std/Moonglow-SemiboldCond.woff2"
         },
         {
           "name": "Moonglow-SemiboldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32492
+          "fileSize": 32492,
+          "url": "fonts/Moonglow Std/Moonglow-SemiboldExt.woff2"
         }
       ]
     },
@@ -11788,21 +12990,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29568
+          "fileSize": 29568,
+          "url": "fonts/Motter Corpus Std/MotterCorpusStd-Condensed.woff2"
         },
         {
           "name": "MotterCorpusStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30420
+          "fileSize": 30420,
+          "url": "fonts/Motter Corpus Std/MotterCorpusStd-Regular.woff2"
         },
         {
           "name": "MotterCorpusStd-SemiCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31304
+          "fileSize": 31304,
+          "url": "fonts/Motter Corpus Std/MotterCorpusStd-SemiCond.woff2"
         }
       ]
     },
@@ -11821,280 +13026,320 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41736
+          "fileSize": 41736,
+          "url": "fonts/Myriad Pro/MyriadPro-Light.woff2"
         },
         {
           "name": "MyriadPro-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39684
+          "fileSize": 39684,
+          "url": "fonts/Myriad Pro/MyriadPro-LightCond.woff2"
         },
         {
           "name": "MyriadPro-LightCondIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42136
+          "fileSize": 42136,
+          "url": "fonts/Myriad Pro/MyriadPro-LightCondIt.woff2"
         },
         {
           "name": "MyriadPro-LightIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44372
+          "fileSize": 44372,
+          "url": "fonts/Myriad Pro/MyriadPro-LightIt.woff2"
         },
         {
           "name": "MyriadPro-LightSemiCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43612
+          "fileSize": 43612,
+          "url": "fonts/Myriad Pro/MyriadPro-LightSemiCn.woff2"
         },
         {
           "name": "MyriadPro-LightSemiCnIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46292
+          "fileSize": 46292,
+          "url": "fonts/Myriad Pro/MyriadPro-LightSemiCnIt.woff2"
         },
         {
           "name": "MyriadPro-LightSemiExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 40668
+          "fileSize": 40668,
+          "url": "fonts/Myriad Pro/MyriadPro-LightSemiExt.woff2"
         },
         {
           "name": "MyriadPro-LightSemiExtIt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43420
+          "fileSize": 43420,
+          "url": "fonts/Myriad Pro/MyriadPro-LightSemiExtIt.woff2"
         },
         {
           "name": "MyriadPro-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43096
+          "fileSize": 43096,
+          "url": "fonts/Myriad Pro/MyriadPro-Black.woff2"
         },
         {
           "name": "MyriadPro-BlackCond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41856
+          "fileSize": 41856,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackCond.woff2"
         },
         {
           "name": "MyriadPro-BlackCondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44112
+          "fileSize": 44112,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackCondIt.woff2"
         },
         {
           "name": "MyriadPro-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45860
+          "fileSize": 45860,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackIt.woff2"
         },
         {
           "name": "MyriadPro-BlackSemiCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45284
+          "fileSize": 45284,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiCn.woff2"
         },
         {
           "name": "MyriadPro-BlackSemiCnIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47640
+          "fileSize": 47640,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiCnIt.woff2"
         },
         {
           "name": "MyriadPro-BlackSemiExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42368
+          "fileSize": 42368,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiExt.woff2"
         },
         {
           "name": "MyriadPro-BlackSemiExtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44260
+          "fileSize": 44260,
+          "url": "fonts/Myriad Pro/MyriadPro-BlackSemiExtIt.woff2"
         },
         {
           "name": "MyriadPro-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41712
+          "fileSize": 41712,
+          "url": "fonts/Myriad Pro/MyriadPro-Cond.woff2"
         },
         {
           "name": "MyriadPro-CondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44508
+          "fileSize": 44508,
+          "url": "fonts/Myriad Pro/MyriadPro-CondIt.woff2"
         },
         {
           "name": "MyriadPro-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45008
+          "fileSize": 45008,
+          "url": "fonts/Myriad Pro/MyriadPro-It.woff2"
         },
         {
           "name": "MyriadPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42548
+          "fileSize": 42548,
+          "url": "fonts/Myriad Pro/MyriadPro-Regular.woff2"
         },
         {
           "name": "MyriadPro-SemiCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44464
+          "fileSize": 44464,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiCn.woff2"
         },
         {
           "name": "MyriadPro-SemiCnIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47112
+          "fileSize": 47112,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiCnIt.woff2"
         },
         {
           "name": "MyriadPro-SemiExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42780
+          "fileSize": 42780,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiExt.woff2"
         },
         {
           "name": "MyriadPro-SemiExtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45012
+          "fileSize": 45012,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiExtIt.woff2"
         },
         {
           "name": "MyriadPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43112
+          "fileSize": 43112,
+          "url": "fonts/Myriad Pro/MyriadPro-Bold.woff2"
         },
         {
           "name": "MyriadPro-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42332
+          "fileSize": 42332,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldCond.woff2"
         },
         {
           "name": "MyriadPro-BoldCondIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45360
+          "fileSize": 45360,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldCondIt.woff2"
         },
         {
           "name": "MyriadPro-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45404
+          "fileSize": 45404,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldIt.woff2"
         },
         {
           "name": "MyriadPro-BoldSemiCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44852
+          "fileSize": 44852,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiCn.woff2"
         },
         {
           "name": "MyriadPro-BoldSemiCnIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 48004
+          "fileSize": 48004,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiCnIt.woff2"
         },
         {
           "name": "MyriadPro-BoldSemiExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43040
+          "fileSize": 43040,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiExt.woff2"
         },
         {
           "name": "MyriadPro-BoldSemiExtIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45368
+          "fileSize": 45368,
+          "url": "fonts/Myriad Pro/MyriadPro-BoldSemiExtIt.woff2"
         },
         {
           "name": "MyriadPro-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43016
+          "fileSize": 43016,
+          "url": "fonts/Myriad Pro/MyriadPro-Semibold.woff2"
         },
         {
           "name": "MyriadPro-SemiboldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41960
+          "fileSize": 41960,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldCond.woff2"
         },
         {
           "name": "MyriadPro-SemiboldCondIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45072
+          "fileSize": 45072,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldCondIt.woff2"
         },
         {
           "name": "MyriadPro-SemiboldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45428
+          "fileSize": 45428,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldIt.woff2"
         },
         {
           "name": "MyriadPro-SemiboldSemiCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44664
+          "fileSize": 44664,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiCn.woff2"
         },
         {
           "name": "MyriadPro-SemiboldSemiCnIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 47652
+          "fileSize": 47652,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiCnIt.woff2"
         },
         {
           "name": "MyriadPro-SemiboldSemiExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 42936
+          "fileSize": 42936,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiExt.woff2"
         },
         {
           "name": "MyriadPro-SemiboldSemiExtIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45544
+          "fileSize": 45544,
+          "url": "fonts/Myriad Pro/MyriadPro-SemiboldSemiExtIt.woff2"
         }
       ]
     },
@@ -12113,14 +13358,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 49964
+          "fileSize": 49964,
+          "url": "fonts/Myriad Std/MyriadStd-Sketch.woff2"
         },
         {
           "name": "MyriadStd-Tilt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20096
+          "fileSize": 20096,
+          "url": "fonts/Myriad Std/MyriadStd-Tilt.woff2"
         }
       ]
     },
@@ -12139,7 +13386,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 41024
+          "fileSize": 41024,
+          "url": "fonts/Mythos Std/MythosStd.woff2"
         }
       ]
     },
@@ -12158,7 +13406,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21528
+          "fileSize": 21528,
+          "url": "fonts/National Code Pi Std/NationalCodePiStd-Universal.woff2"
         }
       ]
     },
@@ -12177,7 +13426,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39312
+          "fileSize": 39312,
+          "url": "fonts/Neue Hammer Unziale LT Std/NeueHammerUnzialeLTStd.woff2"
         }
       ]
     },
@@ -12196,7 +13446,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17500
+          "fileSize": 17500,
+          "url": "fonts/Neuland LT Std/NeulandLTStd.woff2"
         }
       ]
     },
@@ -12215,14 +13466,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15584
+          "fileSize": 15584,
+          "url": "fonts/Neuzeit S LT Std/NeuzeitSLTStd-Book.woff2"
         },
         {
           "name": "NeuzeitSLTStd-BookHeavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15872
+          "fileSize": 15872,
+          "url": "fonts/Neuzeit S LT Std/NeuzeitSLTStd-BookHeavy.woff2"
         }
       ]
     },
@@ -12241,56 +13494,64 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20344
+          "fileSize": 20344,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd.woff2"
         },
         {
           "name": "NewAsterLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20112
+          "fileSize": 20112,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-Black.woff2"
         },
         {
           "name": "NewAsterLTStd-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20732
+          "fileSize": 20732,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-BlackIt.woff2"
         },
         {
           "name": "NewAsterLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21060
+          "fileSize": 21060,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-It.woff2"
         },
         {
           "name": "NewAsterLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20212
+          "fileSize": 20212,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-Bold.woff2"
         },
         {
           "name": "NewAsterLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20948
+          "fileSize": 20948,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-BoldIt.woff2"
         },
         {
           "name": "NewAsterLTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20252
+          "fileSize": 20252,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-SemiBold.woff2"
         },
         {
           "name": "NewAsterLTStd-SemiBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20696
+          "fileSize": 20696,
+          "url": "fonts/New Aster LT Std/NewAsterLTStd-SemiBoldIt.woff2"
         }
       ]
     },
@@ -12309,7 +13570,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25872
+          "fileSize": 25872,
+          "url": "fonts/New Berolina MT Std/NewBerolinaMTStd.woff2"
         }
       ]
     },
@@ -12328,56 +13590,64 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28456
+          "fileSize": 28456,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21636
+          "fileSize": 21636,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-Black.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-BlackIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23484
+          "fileSize": 23484,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-BlackIt.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24752
+          "fileSize": 24752,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-It.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-SemiBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22068
+          "fileSize": 22068,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-SemiBd.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-SemiBdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22800
+          "fileSize": 22800,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-SemiBdIt.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28848
+          "fileSize": 28848,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-Bold.woff2"
         },
         {
           "name": "NewCaledoniaLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25164
+          "fileSize": 25164,
+          "url": "fonts/New Caledonia LT Std/NewCaledoniaLTStd-BoldIt.woff2"
         }
       ]
     },
@@ -12396,42 +13666,48 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19736
+          "fileSize": 19736,
+          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-Bd.woff2"
         },
         {
           "name": "NewCenturySchlbkLTStd-BdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20764
+          "fileSize": 20764,
+          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-BdIt.woff2"
         },
         {
           "name": "NewCenturySchlbkLTStd-Fra",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8768
+          "fileSize": 8768,
+          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-Fra.woff2"
         },
         {
           "name": "NewCenturySchlbkLTStd-FraBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 8900
+          "fileSize": 8900,
+          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-FraBd.woff2"
         },
         {
           "name": "NewCenturySchlbkLTStd-It",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20888
+          "fileSize": 20888,
+          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-It.woff2"
         },
         {
           "name": "NewCenturySchlbkLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19904
+          "fileSize": 19904,
+          "url": "fonts/New Century Schoolbook LT Std/NewCenturySchlbkLTStd-Roman.woff2"
         }
       ]
     },
@@ -12450,28 +13726,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14452
+          "fileSize": 14452,
+          "url": "fonts/News Gothic Std/NewsGothicStd.woff2"
         },
         {
           "name": "NewsGothicStd-Oblique",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15988
+          "fileSize": 15988,
+          "url": "fonts/News Gothic Std/NewsGothicStd-Oblique.woff2"
         },
         {
           "name": "NewsGothicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14728
+          "fileSize": 14728,
+          "url": "fonts/News Gothic Std/NewsGothicStd-Bold.woff2"
         },
         {
           "name": "NewsGothicStd-BoldOblique",
           "weight": 700,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 15872
+          "fileSize": 15872,
+          "url": "fonts/News Gothic Std/NewsGothicStd-BoldOblique.woff2"
         }
       ]
     },
@@ -12490,14 +13770,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 3544
+          "fileSize": 3544,
+          "url": "fonts/Notre Dame LT Std/NotreDameLTStd-Ornaments.woff2"
         },
         {
           "name": "NotreDameLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27008
+          "fileSize": 27008,
+          "url": "fonts/Notre Dame LT Std/NotreDameLTStd-Roman.woff2"
         }
       ]
     },
@@ -12516,126 +13798,144 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30648
+          "fileSize": 30648,
+          "url": "fonts/Nueva Std/NuevaStd-LightCondItalic.woff2"
         },
         {
           "name": "NuevaStd-LightItalic",
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32184
+          "fileSize": 32184,
+          "url": "fonts/Nueva Std/NuevaStd-LightItalic.woff2"
         },
         {
           "name": "NuevaStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32308
+          "fileSize": 32308,
+          "url": "fonts/Nueva Std/NuevaStd-Light.woff2"
         },
         {
           "name": "NuevaStd-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30800
+          "fileSize": 30800,
+          "url": "fonts/Nueva Std/NuevaStd-LightCond.woff2"
         },
         {
           "name": "NuevaStd-LightExtended",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32096
+          "fileSize": 32096,
+          "url": "fonts/Nueva Std/NuevaStd-LightExtended.woff2"
         },
         {
           "name": "NuevaStd-LightExtendedItal",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32200
+          "fileSize": 32200,
+          "url": "fonts/Nueva Std/NuevaStd-LightExtendedItal.woff2"
         },
         {
           "name": "NuevaStd-CondItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31132
+          "fileSize": 31132,
+          "url": "fonts/Nueva Std/NuevaStd-CondItalic.woff2"
         },
         {
           "name": "NuevaStd-ExtendedItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32796
+          "fileSize": 32796,
+          "url": "fonts/Nueva Std/NuevaStd-ExtendedItalic.woff2"
         },
         {
           "name": "NuevaStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32472
+          "fileSize": 32472,
+          "url": "fonts/Nueva Std/NuevaStd-Italic.woff2"
         },
         {
           "name": "NuevaStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31500
+          "fileSize": 31500,
+          "url": "fonts/Nueva Std/NuevaStd-Cond.woff2"
         },
         {
           "name": "NuevaStd-Extended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32384
+          "fileSize": 32384,
+          "url": "fonts/Nueva Std/NuevaStd-Extended.woff2"
         },
         {
           "name": "NuevaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32328
+          "fileSize": 32328,
+          "url": "fonts/Nueva Std/NuevaStd-Regular.woff2"
         },
         {
           "name": "NuevaStd-BoldCondItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30984
+          "fileSize": 30984,
+          "url": "fonts/Nueva Std/NuevaStd-BoldCondItalic.woff2"
         },
         {
           "name": "NuevaStd-BoldExtendedItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32052
+          "fileSize": 32052,
+          "url": "fonts/Nueva Std/NuevaStd-BoldExtendedItalic.woff2"
         },
         {
           "name": "NuevaStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 32280
+          "fileSize": 32280,
+          "url": "fonts/Nueva Std/NuevaStd-BoldItalic.woff2"
         },
         {
           "name": "NuevaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32092
+          "fileSize": 32092,
+          "url": "fonts/Nueva Std/NuevaStd-Bold.woff2"
         },
         {
           "name": "NuevaStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30756
+          "fileSize": 30756,
+          "url": "fonts/Nueva Std/NuevaStd-BoldCond.woff2"
         },
         {
           "name": "NuevaStd-BoldExtended",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32140
+          "fileSize": 32140,
+          "url": "fonts/Nueva Std/NuevaStd-BoldExtended.woff2"
         }
       ]
     },
@@ -12654,7 +13954,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23000
+          "fileSize": 23000,
+          "url": "fonts/Nuptial Script LT Std/NuptialScriptLTStd.woff2"
         }
       ]
     },
@@ -12673,7 +13974,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20644
+          "fileSize": 20644,
+          "url": "fonts/Nyx Std/NyxStd.woff2"
         }
       ]
     },
@@ -12692,168 +13994,192 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16160
+          "fileSize": 16160,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-Light.woff2"
         },
         {
           "name": "OceanSansStd-LightExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16560
+          "fileSize": 16560,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-LightExt.woff2"
         },
         {
           "name": "OceanSansStd-LightExtIta",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17232
+          "fileSize": 17232,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-LightExtIta.woff2"
         },
         {
           "name": "OceanSansStd-LightIta",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17308
+          "fileSize": 17308,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-LightIta.woff2"
         },
         {
           "name": "OceanSansStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17028
+          "fileSize": 17028,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-Book.woff2"
         },
         {
           "name": "OceanSansStd-BookExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17204
+          "fileSize": 17204,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BookExt.woff2"
         },
         {
           "name": "OceanSansStd-BookExtIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18208
+          "fileSize": 18208,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BookExtIta.woff2"
         },
         {
           "name": "OceanSansStd-BookIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18156
+          "fileSize": 18156,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BookIta.woff2"
         },
         {
           "name": "OceanSansStd-BookSemiExt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17456
+          "fileSize": 17456,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BookSemiExt.woff2"
         },
         {
           "name": "OceanSansStd-BookSemiExtIta",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18604
+          "fileSize": 18604,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BookSemiExtIta.woff2"
         },
         {
           "name": "OceanSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17080
+          "fileSize": 17080,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-Bold.woff2"
         },
         {
           "name": "OceanSansStd-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17336
+          "fileSize": 17336,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldExt.woff2"
         },
         {
           "name": "OceanSansStd-BoldExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18548
+          "fileSize": 18548,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldExtIta.woff2"
         },
         {
           "name": "OceanSansStd-BoldIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18036
+          "fileSize": 18036,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldIta.woff2"
         },
         {
           "name": "OceanSansStd-BoldSemiExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17280
+          "fileSize": 17280,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldSemiExt.woff2"
         },
         {
           "name": "OceanSansStd-BoldSemiExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18476
+          "fileSize": 18476,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-BoldSemiExtIta.woff2"
         },
         {
           "name": "OceanSansStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17300
+          "fileSize": 17300,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-Semibold.woff2"
         },
         {
           "name": "OceanSansStd-SemiboldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17240
+          "fileSize": 17240,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-SemiboldExt.woff2"
         },
         {
           "name": "OceanSansStd-SemiboldExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18352
+          "fileSize": 18352,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-SemiboldExtIta.woff2"
         },
         {
           "name": "OceanSansStd-SemiboldIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18452
+          "fileSize": 18452,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-SemiboldIta.woff2"
         },
         {
           "name": "OceanSansStd-XBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16364
+          "fileSize": 16364,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-XBold.woff2"
         },
         {
           "name": "OceanSansStd-XBoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16516
+          "fileSize": 16516,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-XBoldExt.woff2"
         },
         {
           "name": "OceanSansStd-XBoldExtIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17416
+          "fileSize": 17416,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-XBoldExtIta.woff2"
         },
         {
           "name": "OceanSansStd-XBoldIta",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17288
+          "fileSize": 17288,
+          "url": "fonts/Ocean Sans Std/OceanSansStd-XBoldIta.woff2"
         }
       ]
     },
@@ -12872,7 +14198,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14644
+          "fileSize": 14644,
+          "url": "fonts/OCRA Std/OCRAStd.woff2"
         }
       ]
     },
@@ -12891,7 +14218,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14992
+          "fileSize": 14992,
+          "url": "fonts/OCRB Std/OCRBStd.woff2"
         }
       ]
     },
@@ -12910,14 +14238,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30520
+          "fileSize": 30520,
+          "url": "fonts/Octavian MT Std/OctavianMTStd-Italic.woff2"
         },
         {
           "name": "OctavianMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34852
+          "fileSize": 34852,
+          "url": "fonts/Octavian MT Std/OctavianMTStd.woff2"
         }
       ]
     },
@@ -12936,7 +14266,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 74084
+          "fileSize": 74084,
+          "url": "fonts/Old Claude LP Std/OldClaudeLPStd.woff2"
         }
       ]
     },
@@ -12955,14 +14286,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22128
+          "fileSize": 22128,
+          "url": "fonts/Old Style 7 Std/OldStyle7Std-Italic.woff2"
         },
         {
           "name": "OldStyle7Std",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25476
+          "fileSize": 25476,
+          "url": "fonts/Old Style 7 Std/OldStyle7Std.woff2"
         }
       ]
     },
@@ -12981,28 +14314,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20628
+          "fileSize": 20628,
+          "url": "fonts/Olympian LT Std/OlympianLTStd-Italic.woff2"
         },
         {
           "name": "OlympianLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19840
+          "fileSize": 19840,
+          "url": "fonts/Olympian LT Std/OlympianLTStd.woff2"
         },
         {
           "name": "OlympianLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20528
+          "fileSize": 20528,
+          "url": "fonts/Olympian LT Std/OlympianLTStd-BoldItalic.woff2"
         },
         {
           "name": "OlympianLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19988
+          "fileSize": 19988,
+          "url": "fonts/Olympian LT Std/OlympianLTStd-Bold.woff2"
         }
       ]
     },
@@ -13021,7 +14358,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16540
+          "fileSize": 16540,
+          "url": "fonts/Omnia LT Std/OmniaLTStd.woff2"
         }
       ]
     },
@@ -13040,7 +14378,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23648
+          "fileSize": 23648,
+          "url": "fonts/Ondine LT Std/OndineLTStd.woff2"
         }
       ]
     },
@@ -13059,7 +14398,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21444
+          "fileSize": 21444,
+          "url": "fonts/Onyx MT Std/OnyxMTStd.woff2"
         }
       ]
     },
@@ -13078,84 +14418,96 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21928
+          "fileSize": 21928,
+          "url": "fonts/Optima LT Std/OptimaLTStd-BlackItalic.woff2"
         },
         {
           "name": "OptimaLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21372
+          "fileSize": 21372,
+          "url": "fonts/Optima LT Std/OptimaLTStd-Italic.woff2"
         },
         {
           "name": "OptimaLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22948
+          "fileSize": 22948,
+          "url": "fonts/Optima LT Std/OptimaLTStd-MediumItalic.woff2"
         },
         {
           "name": "OptimaLTStd-XBlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22240
+          "fileSize": 22240,
+          "url": "fonts/Optima LT Std/OptimaLTStd-XBlackItalic.woff2"
         },
         {
           "name": "OptimaLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20008
+          "fileSize": 20008,
+          "url": "fonts/Optima LT Std/OptimaLTStd.woff2"
         },
         {
           "name": "OptimaLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22412
+          "fileSize": 22412,
+          "url": "fonts/Optima LT Std/OptimaLTStd-Black.woff2"
         },
         {
           "name": "OptimaLTStd-ExtraBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22088
+          "fileSize": 22088,
+          "url": "fonts/Optima LT Std/OptimaLTStd-ExtraBlack.woff2"
         },
         {
           "name": "OptimaLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22884
+          "fileSize": 22884,
+          "url": "fonts/Optima LT Std/OptimaLTStd-Medium.woff2"
         },
         {
           "name": "OptimaLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22076
+          "fileSize": 22076,
+          "url": "fonts/Optima LT Std/OptimaLTStd-BoldItalic.woff2"
         },
         {
           "name": "OptimaLTStd-DemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22456
+          "fileSize": 22456,
+          "url": "fonts/Optima LT Std/OptimaLTStd-DemiBoldItalic.woff2"
         },
         {
           "name": "OptimaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19976
+          "fileSize": 19976,
+          "url": "fonts/Optima LT Std/OptimaLTStd-Bold.woff2"
         },
         {
           "name": "OptimaLTStd-DemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22416
+          "fileSize": 22416,
+          "url": "fonts/Optima LT Std/OptimaLTStd-DemiBold.woff2"
         }
       ]
     },
@@ -13174,14 +14526,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20364
+          "fileSize": 20364,
+          "url": "fonts/Orator Std/OratorStd.woff2"
         },
         {
           "name": "OratorStd-Slanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21536
+          "fileSize": 21536,
+          "url": "fonts/Orator Std/OratorStd-Slanted.woff2"
         }
       ]
     },
@@ -13200,7 +14554,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17984
+          "fileSize": 17984,
+          "url": "fonts/Organica GMM Std/OrganicaGMMStd-SmSerifRoman.woff2"
         }
       ]
     },
@@ -13219,56 +14574,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29568
+          "fileSize": 29568,
+          "url": "fonts/Origami Std/OrigamiStd-Italic.woff2"
         },
         {
           "name": "OrigamiStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30200
+          "fileSize": 30200,
+          "url": "fonts/Origami Std/OrigamiStd-MediumItalic.woff2"
         },
         {
           "name": "OrigamiStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29568
+          "fileSize": 29568,
+          "url": "fonts/Origami Std/OrigamiStd-Medium.woff2"
         },
         {
           "name": "OrigamiStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28908
+          "fileSize": 28908,
+          "url": "fonts/Origami Std/OrigamiStd-Regular.woff2"
         },
         {
           "name": "OrigamiStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 29012
+          "fileSize": 29012,
+          "url": "fonts/Origami Std/OrigamiStd-BoldItalic.woff2"
         },
         {
           "name": "OrigamiStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30316
+          "fileSize": 30316,
+          "url": "fonts/Origami Std/OrigamiStd-SemiBoldItalic.woff2"
         },
         {
           "name": "OrigamiStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28992
+          "fileSize": 28992,
+          "url": "fonts/Origami Std/OrigamiStd-Bold.woff2"
         },
         {
           "name": "OrigamiStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30016
+          "fileSize": 30016,
+          "url": "fonts/Origami Std/OrigamiStd-SemiBold.woff2"
         }
       ]
     },
@@ -13287,7 +14650,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30668
+          "fileSize": 30668,
+          "url": "fonts/Ouch Std/OuchStd.woff2"
         }
       ]
     },
@@ -13306,14 +14670,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26036
+          "fileSize": 26036,
+          "url": "fonts/Palace Script MT Std/PalaceScriptMTStd.woff2"
         },
         {
           "name": "PalaceScriptMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25356
+          "fileSize": 25356,
+          "url": "fonts/Palace Script MT Std/PalaceScriptMTStd-SemiBold.woff2"
         }
       ]
     },
@@ -13332,70 +14698,80 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24180
+          "fileSize": 24180,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-LightItalic.woff2"
         },
         {
           "name": "PalatinoLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22584
+          "fileSize": 22584,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-Light.woff2"
         },
         {
           "name": "PalatinoLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23304
+          "fileSize": 23304,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-BlackItalic.woff2"
         },
         {
           "name": "PalatinoLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24412
+          "fileSize": 24412,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-Italic.woff2"
         },
         {
           "name": "PalatinoLTStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23300
+          "fileSize": 23300,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-MediumItalic.woff2"
         },
         {
           "name": "PalatinoLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22984
+          "fileSize": 22984,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-Black.woff2"
         },
         {
           "name": "PalatinoLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22532
+          "fileSize": 22532,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-Medium.woff2"
         },
         {
           "name": "PalatinoLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29256
+          "fileSize": 29256,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-Roman.woff2"
         },
         {
           "name": "PalatinoLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24688
+          "fileSize": 24688,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-BoldItalic.woff2"
         },
         {
           "name": "PalatinoLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22428
+          "fileSize": 22428,
+          "url": "fonts/Palatino LT Std/PalatinoLTStd-Bold.woff2"
         }
       ]
     },
@@ -13414,7 +14790,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18228
+          "fileSize": 18228,
+          "url": "fonts/Parisian Std/ParisianStd.woff2"
         }
       ]
     },
@@ -13433,7 +14810,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22704
+          "fileSize": 22704,
+          "url": "fonts/Park Avenue Std/ParkAvenueStd.woff2"
         }
       ]
     },
@@ -13452,21 +14830,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15172
+          "fileSize": 15172,
+          "url": "fonts/Peignot LT Std/PeignotLTStd-Light.woff2"
         },
         {
           "name": "PeignotLTStd-Demi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15432
+          "fileSize": 15432,
+          "url": "fonts/Peignot LT Std/PeignotLTStd-Demi.woff2"
         },
         {
           "name": "PeignotLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14916
+          "fileSize": 14916,
+          "url": "fonts/Peignot LT Std/PeignotLTStd-Bold.woff2"
         }
       ]
     },
@@ -13485,28 +14866,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18212
+          "fileSize": 18212,
+          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Light.woff2"
         },
         {
           "name": "PenumbraFlareStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19360
+          "fileSize": 19360,
+          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Regular.woff2"
         },
         {
           "name": "PenumbraFlareStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18964
+          "fileSize": 18964,
+          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Bold.woff2"
         },
         {
           "name": "PenumbraFlareStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19192
+          "fileSize": 19192,
+          "url": "fonts/Penumbra Flare Std/PenumbraFlareStd-Semibold.woff2"
         }
       ]
     },
@@ -13525,28 +14910,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19404
+          "fileSize": 19404,
+          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-Light.woff2"
         },
         {
           "name": "PenumbraHalfSerifStd-Reg",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20308
+          "fileSize": 20308,
+          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-Reg.woff2"
         },
         {
           "name": "PenumbraHalfSerifStd-SeBd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20292
+          "fileSize": 20292,
+          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-SeBd.woff2"
         },
         {
           "name": "PenumbraHalfSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19812
+          "fileSize": 19812,
+          "url": "fonts/Penumbra Half Serif Std/PenumbraHalfSerifStd-Bold.woff2"
         }
       ]
     },
@@ -13565,28 +14954,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16800
+          "fileSize": 16800,
+          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Light.woff2"
         },
         {
           "name": "PenumbraSansStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18116
+          "fileSize": 18116,
+          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Regular.woff2"
         },
         {
           "name": "PenumbraSansStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17544
+          "fileSize": 17544,
+          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Bold.woff2"
         },
         {
           "name": "PenumbraSansStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18256
+          "fileSize": 18256,
+          "url": "fonts/Penumbra Sans Std/PenumbraSansStd-Semibold.woff2"
         }
       ]
     },
@@ -13605,28 +14998,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18812
+          "fileSize": 18812,
+          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Light.woff2"
         },
         {
           "name": "PenumbraSerifStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20396
+          "fileSize": 20396,
+          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Regular.woff2"
         },
         {
           "name": "PenumbraSerifStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19144
+          "fileSize": 19144,
+          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Bold.woff2"
         },
         {
           "name": "PenumbraSerifStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20348
+          "fileSize": 20348,
+          "url": "fonts/Penumbra Serif Std/PenumbraSerifStd-Semibold.woff2"
         }
       ]
     },
@@ -13645,7 +15042,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25048
+          "fileSize": 25048,
+          "url": "fonts/Pepita MT Std/PepitaMTStd.woff2"
         }
       ]
     },
@@ -13664,21 +15062,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21604
+          "fileSize": 21604,
+          "url": "fonts/Pepperwood Std/PepperwoodStd-Fill.woff2"
         },
         {
           "name": "PepperwoodStd-Outline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28980
+          "fileSize": 28980,
+          "url": "fonts/Pepperwood Std/PepperwoodStd-Outline.woff2"
         },
         {
           "name": "PepperwoodStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 39372
+          "fileSize": 39372,
+          "url": "fonts/Pepperwood Std/PepperwoodStd-Regular.woff2"
         }
       ]
     },
@@ -13697,28 +15098,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 28068
+          "fileSize": 28068,
+          "url": "fonts/Perpetua Std/PerpetuaStd-Italic.woff2"
         },
         {
           "name": "PerpetuaStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33248
+          "fileSize": 33248,
+          "url": "fonts/Perpetua Std/PerpetuaStd.woff2"
         },
         {
           "name": "PerpetuaStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27948
+          "fileSize": 27948,
+          "url": "fonts/Perpetua Std/PerpetuaStd-BoldItalic.woff2"
         },
         {
           "name": "PerpetuaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27336
+          "fileSize": 27336,
+          "url": "fonts/Perpetua Std/PerpetuaStd-Bold.woff2"
         }
       ]
     },
@@ -13737,56 +15142,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23568
+          "fileSize": 23568,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-Italic.woff2"
         },
         {
           "name": "PhotinaMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23040
+          "fileSize": 23040,
+          "url": "fonts/Photina MT Std/PhotinaMTStd.woff2"
         },
         {
           "name": "PhotinaMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24188
+          "fileSize": 24188,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-BoldItalic.woff2"
         },
         {
           "name": "PhotinaMTStd-SemiBoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22576
+          "fileSize": 22576,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-SemiBoldItalic.woff2"
         },
         {
           "name": "PhotinaMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23188
+          "fileSize": 23188,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-Bold.woff2"
         },
         {
           "name": "PhotinaMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22636
+          "fileSize": 22636,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-SemiBold.woff2"
         },
         {
           "name": "PhotinaMTStd-UltraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22432
+          "fileSize": 22432,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-UltraBold.woff2"
         },
         {
           "name": "PhotinaMTStd-UltraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22884
+          "fileSize": 22884,
+          "url": "fonts/Photina MT Std/PhotinaMTStd-UltraBoldIt.woff2"
         }
       ]
     },
@@ -13805,63 +15218,72 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21216
+          "fileSize": 21216,
+          "url": "fonts/Plantin Std/PlantinStd-LightItalic.woff2"
         },
         {
           "name": "PlantinStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19564
+          "fileSize": 19564,
+          "url": "fonts/Plantin Std/PlantinStd-Light.woff2"
         },
         {
           "name": "PlantinStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20416
+          "fileSize": 20416,
+          "url": "fonts/Plantin Std/PlantinStd-Italic.woff2"
         },
         {
           "name": "PlantinStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19168
+          "fileSize": 19168,
+          "url": "fonts/Plantin Std/PlantinStd.woff2"
         },
         {
           "name": "PlantinStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20720
+          "fileSize": 20720,
+          "url": "fonts/Plantin Std/PlantinStd-BoldItalic.woff2"
         },
         {
           "name": "PlantinStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21108
+          "fileSize": 21108,
+          "url": "fonts/Plantin Std/PlantinStd-SemiboldItalic.woff2"
         },
         {
           "name": "PlantinStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19652
+          "fileSize": 19652,
+          "url": "fonts/Plantin Std/PlantinStd-Bold.woff2"
         },
         {
           "name": "PlantinStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20032
+          "fileSize": 20032,
+          "url": "fonts/Plantin Std/PlantinStd-BoldCondensed.woff2"
         },
         {
           "name": "PlantinStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19320
+          "fileSize": 19320,
+          "url": "fonts/Plantin Std/PlantinStd-Semibold.woff2"
         }
       ]
     },
@@ -13880,56 +15302,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23888
+          "fileSize": 23888,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-LightItalic.woff2"
         },
         {
           "name": "CaeciliaLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23836
+          "fileSize": 23836,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Light.woff2"
         },
         {
           "name": "CaeciliaLTStd-HeavyItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23204
+          "fileSize": 23204,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-HeavyItalic.woff2"
         },
         {
           "name": "CaeciliaLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23684
+          "fileSize": 23684,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Italic.woff2"
         },
         {
           "name": "CaeciliaLTStd-Heavy",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23332
+          "fileSize": 23332,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Heavy.woff2"
         },
         {
           "name": "CaeciliaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23900
+          "fileSize": 23900,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Roman.woff2"
         },
         {
           "name": "CaeciliaLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24264
+          "fileSize": 24264,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-BoldItalic.woff2"
         },
         {
           "name": "CaeciliaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23704
+          "fileSize": 23704,
+          "url": "fonts/PMN Caecilia LT Std/CaeciliaLTStd-Bold.woff2"
         }
       ]
     },
@@ -13948,7 +15378,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 251704
+          "fileSize": 251704,
+          "url": "fonts/Poetica Std/PoeticaStd.woff2"
         }
       ]
     },
@@ -13967,14 +15398,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27504
+          "fileSize": 27504,
+          "url": "fonts/Pompeia Std/PompeiaStd-InlineItalic.woff2"
         },
         {
           "name": "PompeiaStd-Inline",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28852
+          "fileSize": 28852,
+          "url": "fonts/Pompeia Std/PompeiaStd-Inline.woff2"
         }
       ]
     },
@@ -13993,14 +15426,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 4796
+          "fileSize": 4796,
+          "url": "fonts/Pompeijana LT Std/PompeijanaLTStd-Borders.woff2"
         },
         {
           "name": "PompeijanaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19064
+          "fileSize": 19064,
+          "url": "fonts/Pompeijana LT Std/PompeijanaLTStd-Roman.woff2"
         }
       ]
     },
@@ -14019,7 +15454,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14972
+          "fileSize": 14972,
+          "url": "fonts/Ponderosa Std/PonderosaStd.woff2"
         }
       ]
     },
@@ -14038,7 +15474,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20392
+          "fileSize": 20392,
+          "url": "fonts/Poplar Std/PoplarStd.woff2"
         }
       ]
     },
@@ -14057,14 +15494,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21524
+          "fileSize": 21524,
+          "url": "fonts/Postino Std/PostinoStd-Italic.woff2"
         },
         {
           "name": "PostinoStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21332
+          "fileSize": 21332,
+          "url": "fonts/Postino Std/PostinoStd.woff2"
         }
       ]
     },
@@ -14083,42 +15522,48 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20896
+          "fileSize": 20896,
+          "url": "fonts/Present LT Std/PresentLTStd.woff2"
         },
         {
           "name": "PresentLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26568
+          "fileSize": 26568,
+          "url": "fonts/Present LT Std/PresentLTStd-Black.woff2"
         },
         {
           "name": "PresentLTStd-BlackCondensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26492
+          "fileSize": 26492,
+          "url": "fonts/Present LT Std/PresentLTStd-BlackCondensed.woff2"
         },
         {
           "name": "PresentLTStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23364
+          "fileSize": 23364,
+          "url": "fonts/Present LT Std/PresentLTStd-Condensed.woff2"
         },
         {
           "name": "PresentLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26088
+          "fileSize": 26088,
+          "url": "fonts/Present LT Std/PresentLTStd-Bold.woff2"
         },
         {
           "name": "PresentLTStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25200
+          "fileSize": 25200,
+          "url": "fonts/Present LT Std/PresentLTStd-BoldCondensed.woff2"
         }
       ]
     },
@@ -14137,28 +15582,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22524
+          "fileSize": 22524,
+          "url": "fonts/Prestige Elite Std/PrestigeEliteStd.woff2"
         },
         {
           "name": "PrestigeEliteStd-Bd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22376
+          "fileSize": 22376,
+          "url": "fonts/Prestige Elite Std/PrestigeEliteStd-Bd.woff2"
         },
         {
           "name": "PrestigeEliteStd-BdSlanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23760
+          "fileSize": 23760,
+          "url": "fonts/Prestige Elite Std/PrestigeEliteStd-BdSlanted.woff2"
         },
         {
           "name": "PrestigeEliteStd-Slanted",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23516
+          "fileSize": 23516,
+          "url": "fonts/Prestige Elite Std/PrestigeEliteStd-Slanted.woff2"
         }
       ]
     },
@@ -14177,7 +15626,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 25188
+          "fileSize": 25188,
+          "url": "fonts/Quake Std/QuakeStd.woff2"
         }
       ]
     },
@@ -14196,7 +15646,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 70884
+          "fileSize": 70884,
+          "url": "fonts/Rad Std/RadStd.woff2"
         }
       ]
     },
@@ -14215,28 +15666,32 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18608
+          "fileSize": 18608,
+          "url": "fonts/Raleigh LT Std/RaleighLTStd.woff2"
         },
         {
           "name": "RaleighLTStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18448
+          "fileSize": 18448,
+          "url": "fonts/Raleigh LT Std/RaleighLTStd-Medium.woff2"
         },
         {
           "name": "RaleighLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18612
+          "fileSize": 18612,
+          "url": "fonts/Raleigh LT Std/RaleighLTStd-Bold.woff2"
         },
         {
           "name": "RaleighLTStd-DemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18448
+          "fileSize": 18448,
+          "url": "fonts/Raleigh LT Std/RaleighLTStd-DemiBold.woff2"
         }
       ]
     },
@@ -14255,7 +15710,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21256
+          "fileSize": 21256,
+          "url": "fonts/Raphael Std/RaphaelStd.woff2"
         }
       ]
     },
@@ -14274,84 +15730,96 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30848
+          "fileSize": 30848,
+          "url": "fonts/Reliq Std/ReliqStd-LightActive.woff2"
         },
         {
           "name": "ReliqStd-LightCalm",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28420
+          "fileSize": 28420,
+          "url": "fonts/Reliq Std/ReliqStd-LightCalm.woff2"
         },
         {
           "name": "ReliqStd-LightExtraActive",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29828
+          "fileSize": 29828,
+          "url": "fonts/Reliq Std/ReliqStd-LightExtraActive.woff2"
         },
         {
           "name": "ReliqStd-Active",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32476
+          "fileSize": 32476,
+          "url": "fonts/Reliq Std/ReliqStd-Active.woff2"
         },
         {
           "name": "ReliqStd-Calm",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32048
+          "fileSize": 32048,
+          "url": "fonts/Reliq Std/ReliqStd-Calm.woff2"
         },
         {
           "name": "ReliqStd-ExtraActive",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32288
+          "fileSize": 32288,
+          "url": "fonts/Reliq Std/ReliqStd-ExtraActive.woff2"
         },
         {
           "name": "ReliqStd-BoldActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32272
+          "fileSize": 32272,
+          "url": "fonts/Reliq Std/ReliqStd-BoldActive.woff2"
         },
         {
           "name": "ReliqStd-BoldCalm",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30748
+          "fileSize": 30748,
+          "url": "fonts/Reliq Std/ReliqStd-BoldCalm.woff2"
         },
         {
           "name": "ReliqStd-BoldExtraActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30224
+          "fileSize": 30224,
+          "url": "fonts/Reliq Std/ReliqStd-BoldExtraActive.woff2"
         },
         {
           "name": "ReliqStd-SemiboldActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32652
+          "fileSize": 32652,
+          "url": "fonts/Reliq Std/ReliqStd-SemiboldActive.woff2"
         },
         {
           "name": "ReliqStd-SemiboldCalm",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32204
+          "fileSize": 32204,
+          "url": "fonts/Reliq Std/ReliqStd-SemiboldCalm.woff2"
         },
         {
           "name": "ReliqStd-SemiboldExtActive",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32300
+          "fileSize": 32300,
+          "url": "fonts/Reliq Std/ReliqStd-SemiboldExtActive.woff2"
         }
       ]
     },
@@ -14370,7 +15838,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32684
+          "fileSize": 32684,
+          "url": "fonts/Reporter LT Std/ReporterLTStd-2.woff2"
         }
       ]
     },
@@ -14389,7 +15858,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14736
+          "fileSize": 14736,
+          "url": "fonts/Revue Std/RevueStd.woff2"
         }
       ]
     },
@@ -14408,63 +15878,72 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17492
+          "fileSize": 17492,
+          "url": "fonts/Rockwell Std/RockwellStd-LightItalic.woff2"
         },
         {
           "name": "RockwellStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17256
+          "fileSize": 17256,
+          "url": "fonts/Rockwell Std/RockwellStd-Light.woff2"
         },
         {
           "name": "RockwellStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17532
+          "fileSize": 17532,
+          "url": "fonts/Rockwell Std/RockwellStd-Italic.woff2"
         },
         {
           "name": "RockwellStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17260
+          "fileSize": 17260,
+          "url": "fonts/Rockwell Std/RockwellStd.woff2"
         },
         {
           "name": "RockwellStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17068
+          "fileSize": 17068,
+          "url": "fonts/Rockwell Std/RockwellStd-Condensed.woff2"
         },
         {
           "name": "RockwellStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 17580
+          "fileSize": 17580,
+          "url": "fonts/Rockwell Std/RockwellStd-BoldItalic.woff2"
         },
         {
           "name": "RockwellStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17284
+          "fileSize": 17284,
+          "url": "fonts/Rockwell Std/RockwellStd-Bold.woff2"
         },
         {
           "name": "RockwellStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17400
+          "fileSize": 17400,
+          "url": "fonts/Rockwell Std/RockwellStd-BoldCondensed.woff2"
         },
         {
           "name": "RockwellStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17676
+          "fileSize": 17676,
+          "url": "fonts/Rockwell Std/RockwellStd-ExtraBold.woff2"
         }
       ]
     },
@@ -14483,35 +15962,40 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22148
+          "fileSize": 22148,
+          "url": "fonts/Romic Std/RomicStd-LightItalic.woff2"
         },
         {
           "name": "RomicStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22076
+          "fileSize": 22076,
+          "url": "fonts/Romic Std/RomicStd-Light.woff2"
         },
         {
           "name": "RomicStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21332
+          "fileSize": 21332,
+          "url": "fonts/Romic Std/RomicStd-Medium.woff2"
         },
         {
           "name": "RomicStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21668
+          "fileSize": 21668,
+          "url": "fonts/Romic Std/RomicStd-Bold.woff2"
         },
         {
           "name": "RomicStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21248
+          "fileSize": 21248,
+          "url": "fonts/Romic Std/RomicStd-ExtraBold.woff2"
         }
       ]
     },
@@ -14530,14 +16014,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17516
+          "fileSize": 17516,
+          "url": "fonts/Rosewood Std/RosewoodStd-Fill.woff2"
         },
         {
           "name": "RosewoodStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36996
+          "fileSize": 36996,
+          "url": "fonts/Rosewood Std/RosewoodStd-Regular.woff2"
         }
       ]
     },
@@ -14556,21 +16042,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21728
+          "fileSize": 21728,
+          "url": "fonts/Rotation LT Std/RotationLTStd-Italic.woff2"
         },
         {
           "name": "RotationLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19820
+          "fileSize": 19820,
+          "url": "fonts/Rotation LT Std/RotationLTStd-Roman.woff2"
         },
         {
           "name": "RotationLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19620
+          "fileSize": 19620,
+          "url": "fonts/Rotation LT Std/RotationLTStd-Bold.woff2"
         }
       ]
     },
@@ -14589,7 +16078,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 65428
+          "fileSize": 65428,
+          "url": "fonts/Ruling Script LT Std/RulingScriptLTStd-2.woff2"
         }
       ]
     },
@@ -14608,7 +16098,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18996
+          "fileSize": 18996,
+          "url": "fonts/Runic MT Std/RunicMTStd-Condensed.woff2"
         }
       ]
     },
@@ -14627,14 +16118,16 @@
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 26344
+          "fileSize": 26344,
+          "url": "fonts/Russell Oblique Std/RussellObliqueStd.woff2"
         },
         {
           "name": "RussellObliqueStd-Informal",
           "weight": 400,
           "style": "oblique",
           "format": "woff2",
-          "fileSize": 40756
+          "fileSize": 40756,
+          "url": "fonts/Russell Oblique Std/RussellObliqueStd-Informal.woff2"
         }
       ]
     },
@@ -14653,14 +16146,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 3884
+          "fileSize": 3884,
+          "url": "fonts/Rusticana LT Std/RusticanaLTStd-Borders.woff2"
         },
         {
           "name": "RusticanaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16180
+          "fileSize": 16180,
+          "url": "fonts/Rusticana LT Std/RusticanaLTStd-Roman.woff2"
         }
       ]
     },
@@ -14679,14 +16174,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30092
+          "fileSize": 30092,
+          "url": "fonts/Ruzicka Freehand LT Std/RuzickaFreehandLTStd-Roman.woff2"
         },
         {
           "name": "RuzickaFreehandLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30788
+          "fileSize": 30788,
+          "url": "fonts/Ruzicka Freehand LT Std/RuzickaFreehandLTStd-Bold.woff2"
         }
       ]
     },
@@ -14705,28 +16202,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22780
+          "fileSize": 22780,
+          "url": "fonts/Sabon LT Std/SabonLTStd-Italic.woff2"
         },
         {
           "name": "SabonLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26472
+          "fileSize": 26472,
+          "url": "fonts/Sabon LT Std/SabonLTStd-Roman.woff2"
         },
         {
           "name": "SabonLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21848
+          "fileSize": 21848,
+          "url": "fonts/Sabon LT Std/SabonLTStd-BoldItalic.woff2"
         },
         {
           "name": "SabonLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21668
+          "fileSize": 21668,
+          "url": "fonts/Sabon LT Std/SabonLTStd-Bold.woff2"
         }
       ]
     },
@@ -14745,7 +16246,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21236
+          "fileSize": 21236,
+          "url": "fonts/San Marco LT Std/SanMarcoLTStd.woff2"
         }
       ]
     },
@@ -14764,14 +16266,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 37892
+          "fileSize": 37892,
+          "url": "fonts/Sassafras Std/SassafrasStd-Italic.woff2"
         },
         {
           "name": "SassafrasStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37152
+          "fileSize": 37152,
+          "url": "fonts/Sassafras Std/SassafrasStd-Roman.woff2"
         }
       ]
     },
@@ -14790,14 +16294,16 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22920
+          "fileSize": 22920,
+          "url": "fonts/Scotch Roman MT Std/ScotchRomanMTStd-Italic.woff2"
         },
         {
           "name": "ScotchRomanMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20204
+          "fileSize": 20204,
+          "url": "fonts/Scotch Roman MT Std/ScotchRomanMTStd.woff2"
         }
       ]
     },
@@ -14816,7 +16322,8 @@
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24588
+          "fileSize": 24588,
+          "url": "fonts/Script MT Std/ScriptMTStd-Bold.woff2"
         }
       ]
     },
@@ -14835,42 +16342,48 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16952
+          "fileSize": 16952,
+          "url": "fonts/Serifa Std/SerifaStd-LightItalic.woff2"
         },
         {
           "name": "SerifaStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16040
+          "fileSize": 16040,
+          "url": "fonts/Serifa Std/SerifaStd-Light.woff2"
         },
         {
           "name": "SerifaStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16800
+          "fileSize": 16800,
+          "url": "fonts/Serifa Std/SerifaStd-Italic.woff2"
         },
         {
           "name": "SerifaStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17528
+          "fileSize": 17528,
+          "url": "fonts/Serifa Std/SerifaStd-Black.woff2"
         },
         {
           "name": "SerifaStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16228
+          "fileSize": 16228,
+          "url": "fonts/Serifa Std/SerifaStd-Roman.woff2"
         },
         {
           "name": "SerifaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316
+          "fileSize": 16316,
+          "url": "fonts/Serifa Std/SerifaStd-Bold.woff2"
         }
       ]
     },
@@ -14889,7 +16402,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23748
+          "fileSize": 23748,
+          "url": "fonts/Serlio LT Std/SerlioLTStd.woff2"
         }
       ]
     },
@@ -14908,7 +16422,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43864
+          "fileSize": 43864,
+          "url": "fonts/Shelley Script LT Std/ShelleyLTStd-Script.woff2"
         }
       ]
     },
@@ -14927,7 +16442,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22368
+          "fileSize": 22368,
+          "url": "fonts/Sho LT Std/ShoLTStd-Roman.woff2"
         }
       ]
     },
@@ -14946,7 +16462,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19476
+          "fileSize": 19476,
+          "url": "fonts/Shuriken Boy Std/ShurikenStd-Boy.woff2"
         }
       ]
     },
@@ -14965,14 +16482,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 75064
+          "fileSize": 75064,
+          "url": "fonts/Silentium Pro/SilentiumPro-RomanI.woff2"
         },
         {
           "name": "SilentiumPro-RomanII",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 52612
+          "fileSize": 52612,
+          "url": "fonts/Silentium Pro/SilentiumPro-RomanII.woff2"
         }
       ]
     },
@@ -14991,21 +16510,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22012
+          "fileSize": 22012,
+          "url": "fonts/Simoncini Garamond Std/SimonciniGaramondStd-Italic.woff2"
         },
         {
           "name": "SimonciniGaramondStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20568
+          "fileSize": 20568,
+          "url": "fonts/Simoncini Garamond Std/SimonciniGaramondStd.woff2"
         },
         {
           "name": "SimonciniGaramondStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21128
+          "fileSize": 21128,
+          "url": "fonts/Simoncini Garamond Std/SimonciniGaramondStd-Bold.woff2"
         }
       ]
     },
@@ -15024,7 +16546,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24124
+          "fileSize": 24124,
+          "url": "fonts/Smaragd LT Std/SmaragdLTStd.woff2"
         }
       ]
     },
@@ -15043,21 +16566,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27428
+          "fileSize": 27428,
+          "url": "fonts/Snell Roundhand LT Std/SnellRoundhandLTStd-BdScr.woff2"
         },
         {
           "name": "SnellRoundhandLTStd-BlkScr",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27800
+          "fileSize": 27800,
+          "url": "fonts/Snell Roundhand LT Std/SnellRoundhandLTStd-BlkScr.woff2"
         },
         {
           "name": "SnellRoundhandLTStd-Scr",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27444
+          "fileSize": 27444,
+          "url": "fonts/Snell Roundhand LT Std/SnellRoundhandLTStd-Scr.woff2"
         }
       ]
     },
@@ -15076,7 +16602,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17384
+          "fileSize": 17384,
+          "url": "fonts/Sonata Std/SonataStd.woff2"
         }
       ]
     },
@@ -15095,14 +16622,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16052
+          "fileSize": 16052,
+          "url": "fonts/Spartan LT Std/SpartanLTStd-BookClass.woff2"
         },
         {
           "name": "SpartanLTStd-HeavyClass",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16120
+          "fileSize": 16120,
+          "url": "fonts/Spartan LT Std/SpartanLTStd-HeavyClass.woff2"
         }
       ]
     },
@@ -15121,21 +16650,24 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 27808
+          "fileSize": 27808,
+          "url": "fonts/Spectrum MT Std/SpectrumMTStd-Italic.woff2"
         },
         {
           "name": "SpectrumMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 32908
+          "fileSize": 32908,
+          "url": "fonts/Spectrum MT Std/SpectrumMTStd.woff2"
         },
         {
           "name": "SpectrumMTStd-SemiBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27476
+          "fileSize": 27476,
+          "url": "fonts/Spectrum MT Std/SpectrumMTStd-SemiBold.woff2"
         }
       ]
     },
@@ -15154,14 +16686,16 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30248
+          "fileSize": 30248,
+          "url": "fonts/Spring LP Std/SpringLPStd-Light.woff2"
         },
         {
           "name": "SpringLPStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31964
+          "fileSize": 31964,
+          "url": "fonts/Spring LP Std/SpringLPStd.woff2"
         }
       ]
     },
@@ -15180,7 +16714,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30484
+          "fileSize": 30484,
+          "url": "fonts/Spumoni LP Std/SpumoniLPStd.woff2"
         }
       ]
     },
@@ -15199,28 +16734,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24296
+          "fileSize": 24296,
+          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-Italic.woff2"
         },
         {
           "name": "StempelGaramondLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31232
+          "fileSize": 31232,
+          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-Roman.woff2"
         },
         {
           "name": "StempelGaramondLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24812
+          "fileSize": 24812,
+          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-Bold.woff2"
         },
         {
           "name": "StempelGaramondLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24104
+          "fileSize": 24104,
+          "url": "fonts/Stempel Garamond LT Std/StempelGaramondLTStd-BoldIt.woff2"
         }
       ]
     },
@@ -15239,70 +16778,80 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20268
+          "fileSize": 20268,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Light.woff2"
         },
         {
           "name": "StempelSchneidlerStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 21136
+          "fileSize": 21136,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Italic.woff2"
         },
         {
           "name": "StempelSchneidlerStd-BdIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21536
+          "fileSize": 21536,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-BdIt.woff2"
         },
         {
           "name": "StempelSchneidlerStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21308
+          "fileSize": 21308,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Black.woff2"
         },
         {
           "name": "StempelSchneidlerStd-BlkIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22112
+          "fileSize": 22112,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-BlkIt.woff2"
         },
         {
           "name": "StempelSchneidlerStd-LtIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20640
+          "fileSize": 20640,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-LtIt.woff2"
         },
         {
           "name": "StempelSchneidlerStd-MedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21144
+          "fileSize": 21144,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-MedIt.woff2"
         },
         {
           "name": "StempelSchneidlerStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20224
+          "fileSize": 20224,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Medium.woff2"
         },
         {
           "name": "StempelSchneidlerStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20808
+          "fileSize": 20808,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Roman.woff2"
         },
         {
           "name": "StempelSchneidlerStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20944
+          "fileSize": 20944,
+          "url": "fonts/Stempel Schneidler Std/StempelSchneidlerStd-Bold.woff2"
         }
       ]
     },
@@ -15321,7 +16870,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17592
+          "fileSize": 17592,
+          "url": "fonts/Stencil Std/StencilStd.woff2"
         }
       ]
     },
@@ -15340,56 +16890,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24772
+          "fileSize": 24772,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-LightItalic.woff2"
         },
         {
           "name": "StrayhornMTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 30508
+          "fileSize": 30508,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Light.woff2"
         },
         {
           "name": "StrayhornMTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 25024
+          "fileSize": 25024,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Italic.woff2"
         },
         {
           "name": "StrayhornMTStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 31180
+          "fileSize": 31180,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Regular.woff2"
         },
         {
           "name": "StrayhornMTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 24828
+          "fileSize": 24828,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-BoldItalic.woff2"
         },
         {
           "name": "StrayhornMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24576
+          "fileSize": 24576,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-Bold.woff2"
         },
         {
           "name": "StrayhornMTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24324
+          "fileSize": 24324,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-ExtraBold.woff2"
         },
         {
           "name": "StrayhornMTStd-ExtraBoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24472
+          "fileSize": 24472,
+          "url": "fonts/Strayhorn MT Std/StrayhornMTStd-ExtraBoldIt.woff2"
         }
       ]
     },
@@ -15408,14 +16966,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45476
+          "fileSize": 45476,
+          "url": "fonts/Strumpf Std/StrumpfStd-Contour.woff2"
         },
         {
           "name": "StrumpfStd-Open",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 34400
+          "fileSize": 34400,
+          "url": "fonts/Strumpf Std/StrumpfStd-Open.woff2"
         }
       ]
     },
@@ -15434,7 +16994,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 44816
+          "fileSize": 44816,
+          "url": "fonts/Studz Std/StudzStd.woff2"
         }
       ]
     },
@@ -15453,7 +17014,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18240
+          "fileSize": 18240,
+          "url": "fonts/Symbol Std/SymbolStd.woff2"
         }
       ]
     },
@@ -15472,35 +17034,40 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 15764
+          "fileSize": 15764,
+          "url": "fonts/Syntax LT Std/SyntaxLTStd-Italic.woff2"
         },
         {
           "name": "SyntaxLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15876
+          "fileSize": 15876,
+          "url": "fonts/Syntax LT Std/SyntaxLTStd-Black.woff2"
         },
         {
           "name": "SyntaxLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15512
+          "fileSize": 15512,
+          "url": "fonts/Syntax LT Std/SyntaxLTStd-Roman.woff2"
         },
         {
           "name": "SyntaxLTStd-UltraBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16464
+          "fileSize": 16464,
+          "url": "fonts/Syntax LT Std/SyntaxLTStd-UltraBlack.woff2"
         },
         {
           "name": "SyntaxLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15972
+          "fileSize": 15972,
+          "url": "fonts/Syntax LT Std/SyntaxLTStd-Bold.woff2"
         }
       ]
     },
@@ -15519,126 +17086,144 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45564
+          "fileSize": 45564,
+          "url": "fonts/Tekton Pro/TektonPro-Light.woff2"
         },
         {
           "name": "TektonPro-LightCond",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43720
+          "fileSize": 43720,
+          "url": "fonts/Tekton Pro/TektonPro-LightCond.woff2"
         },
         {
           "name": "TektonPro-LightCondObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 43736
+          "fileSize": 43736,
+          "url": "fonts/Tekton Pro/TektonPro-LightCondObl.woff2"
         },
         {
           "name": "TektonPro-LightExt",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45648
+          "fileSize": 45648,
+          "url": "fonts/Tekton Pro/TektonPro-LightExt.woff2"
         },
         {
           "name": "TektonPro-LightExtObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45800
+          "fileSize": 45800,
+          "url": "fonts/Tekton Pro/TektonPro-LightExtObl.woff2"
         },
         {
           "name": "TektonPro-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45664
+          "fileSize": 45664,
+          "url": "fonts/Tekton Pro/TektonPro-LightObl.woff2"
         },
         {
           "name": "TektonPro-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45492
+          "fileSize": 45492,
+          "url": "fonts/Tekton Pro/TektonPro-Cond.woff2"
         },
         {
           "name": "TektonPro-CondObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45584
+          "fileSize": 45584,
+          "url": "fonts/Tekton Pro/TektonPro-CondObl.woff2"
         },
         {
           "name": "TektonPro-Ext",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46740
+          "fileSize": 46740,
+          "url": "fonts/Tekton Pro/TektonPro-Ext.woff2"
         },
         {
           "name": "TektonPro-ExtObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46828
+          "fileSize": 46828,
+          "url": "fonts/Tekton Pro/TektonPro-ExtObl.woff2"
         },
         {
           "name": "TektonPro-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45764
+          "fileSize": 45764,
+          "url": "fonts/Tekton Pro/TektonPro-Obl.woff2"
         },
         {
           "name": "TektonPro-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45712
+          "fileSize": 45712,
+          "url": "fonts/Tekton Pro/TektonPro-Regular.woff2"
         },
         {
           "name": "TektonPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46044
+          "fileSize": 46044,
+          "url": "fonts/Tekton Pro/TektonPro-Bold.woff2"
         },
         {
           "name": "TektonPro-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45124
+          "fileSize": 45124,
+          "url": "fonts/Tekton Pro/TektonPro-BoldCond.woff2"
         },
         {
           "name": "TektonPro-BoldCondObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 45052
+          "fileSize": 45052,
+          "url": "fonts/Tekton Pro/TektonPro-BoldCondObl.woff2"
         },
         {
           "name": "TektonPro-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46780
+          "fileSize": 46780,
+          "url": "fonts/Tekton Pro/TektonPro-BoldExt.woff2"
         },
         {
           "name": "TektonPro-BoldExtObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46932
+          "fileSize": 46932,
+          "url": "fonts/Tekton Pro/TektonPro-BoldExtObl.woff2"
         },
         {
           "name": "TektonPro-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 46124
+          "fileSize": 46124,
+          "url": "fonts/Tekton Pro/TektonPro-BoldObl.woff2"
         }
       ]
     },
@@ -15657,14 +17242,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14964
+          "fileSize": 14964,
+          "url": "fonts/Tempo Std/TempoStd-HeavyCondensed.woff2"
         },
         {
           "name": "TempoStd-HeavyCondensedIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15460
+          "fileSize": 15460,
+          "url": "fonts/Tempo Std/TempoStd-HeavyCondensedIt.woff2"
         }
       ]
     },
@@ -15683,28 +17270,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20340
+          "fileSize": 20340,
+          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-Italic.woff2"
         },
         {
           "name": "TimesEuropaLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20404
+          "fileSize": 20404,
+          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-Roman.woff2"
         },
         {
           "name": "TimesEuropaLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20552
+          "fileSize": 20552,
+          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-BoldItalic.woff2"
         },
         {
           "name": "TimesEuropaLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19936
+          "fileSize": 19936,
+          "url": "fonts/Times Europa LT Std/TimesEuropaLTStd-Bold.woff2"
         }
       ]
     },
@@ -15723,56 +17314,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22572
+          "fileSize": 22572,
+          "url": "fonts/Times LT Std/TimesLTStd-Italic.woff2"
         },
         {
           "name": "TimesLTStd-Phonetic",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 49264
+          "fileSize": 49264,
+          "url": "fonts/Times LT Std/TimesLTStd-Phonetic.woff2"
         },
         {
           "name": "TimesLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27096
+          "fileSize": 27096,
+          "url": "fonts/Times LT Std/TimesLTStd-Roman.woff2"
         },
         {
           "name": "TimesLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22148
+          "fileSize": 22148,
+          "url": "fonts/Times LT Std/TimesLTStd-BoldItalic.woff2"
         },
         {
           "name": "TimesLTStd-SemiboldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20160
+          "fileSize": 20160,
+          "url": "fonts/Times LT Std/TimesLTStd-SemiboldItalic.woff2"
         },
         {
           "name": "TimesLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26760
+          "fileSize": 26760,
+          "url": "fonts/Times LT Std/TimesLTStd-Bold.woff2"
         },
         {
           "name": "TimesLTStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18660
+          "fileSize": 18660,
+          "url": "fonts/Times LT Std/TimesLTStd-ExtraBold.woff2"
         },
         {
           "name": "TimesLTStd-Semibold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18516
+          "fileSize": 18516,
+          "url": "fonts/Times LT Std/TimesLTStd-Semibold.woff2"
         }
       ]
     },
@@ -15791,49 +17390,56 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22640
+          "fileSize": 22640,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-Italic.woff2"
         },
         {
           "name": "TimesNewRomanMTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 20212
+          "fileSize": 20212,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd.woff2"
         },
         {
           "name": "TimesNewRomanMTStd-Cond",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19608
+          "fileSize": 19608,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-Cond.woff2"
         },
         {
           "name": "TimesNewRomanMTStd-CondIt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21188
+          "fileSize": 21188,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-CondIt.woff2"
         },
         {
           "name": "TimesNewRomanMTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19676
+          "fileSize": 19676,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-Bold.woff2"
         },
         {
           "name": "TimesNewRomanMTStd-BoldCond",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19732
+          "fileSize": 19732,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-BoldCond.woff2"
         },
         {
           "name": "TimesNewRomanMTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 21560
+          "fileSize": 21560,
+          "url": "fonts/Times New Roman MT Std/TimesNewRomanMTStd-BoldIt.woff2"
         }
       ]
     },
@@ -15852,28 +17458,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 30852
+          "fileSize": 30852,
+          "url": "fonts/Times Ten LT Std/TimesTenLTStd-Italic.woff2"
         },
         {
           "name": "TimesTenLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33648
+          "fileSize": 33648,
+          "url": "fonts/Times Ten LT Std/TimesTenLTStd-Roman.woff2"
         },
         {
           "name": "TimesTenLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 31700
+          "fileSize": 31700,
+          "url": "fonts/Times Ten LT Std/TimesTenLTStd-BoldItalic.woff2"
         },
         {
           "name": "TimesTenLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 29040
+          "fileSize": 29040,
+          "url": "fonts/Times Ten LT Std/TimesTenLTStd-Bold.woff2"
         }
       ]
     },
@@ -15892,7 +17502,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28260
+          "fileSize": 28260,
+          "url": "fonts/Toolbox Std/ToolboxStd.woff2"
         }
       ]
     },
@@ -15911,98 +17522,112 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15180
+          "fileSize": 15180,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Light.woff2"
         },
         {
           "name": "TradeGothicLTStd-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16352
+          "fileSize": 16352,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-LightObl.woff2"
         },
         {
           "name": "TradeGothicLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15320
+          "fileSize": 15320,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd.woff2"
         },
         {
           "name": "TradeGothicLTStd-Bd2",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15528
+          "fileSize": 15528,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Bd2.woff2"
         },
         {
           "name": "TradeGothicLTStd-Bd2Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16460
+          "fileSize": 16460,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Bd2Obl.woff2"
         },
         {
           "name": "TradeGothicLTStd-BdCn20",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15336
+          "fileSize": 15336,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BdCn20.woff2"
         },
         {
           "name": "TradeGothicLTStd-BdCn20Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16432
+          "fileSize": 16432,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BdCn20Obl.woff2"
         },
         {
           "name": "TradeGothicLTStd-Cn18",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15092
+          "fileSize": 15092,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Cn18.woff2"
         },
         {
           "name": "TradeGothicLTStd-Cn18Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16264
+          "fileSize": 16264,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Cn18Obl.woff2"
         },
         {
           "name": "TradeGothicLTStd-Extended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16064
+          "fileSize": 16064,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Extended.woff2"
         },
         {
           "name": "TradeGothicLTStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16700
+          "fileSize": 16700,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Obl.woff2"
         },
         {
           "name": "TradeGothicLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15388
+          "fileSize": 15388,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-Bold.woff2"
         },
         {
           "name": "TradeGothicLTStd-BoldExt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16344
+          "fileSize": 16344,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BoldExt.woff2"
         },
         {
           "name": "TradeGothicLTStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316
+          "fileSize": 16316,
+          "url": "fonts/Trade Gothic LT Std/TradeGothicLTStd-BoldObl.woff2"
         }
       ]
     },
@@ -16021,14 +17646,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35508
+          "fileSize": 35508,
+          "url": "fonts/Trajan Pro/TrajanPro-Regular.woff2"
         },
         {
           "name": "TrajanPro-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35184
+          "fileSize": 35184,
+          "url": "fonts/Trajan Pro/TrajanPro-Bold.woff2"
         }
       ]
     },
@@ -16047,28 +17674,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19660
+          "fileSize": 19660,
+          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-Italic.woff2"
         },
         {
           "name": "TrumpMediaevalLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24404
+          "fileSize": 24404,
+          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-Roman.woff2"
         },
         {
           "name": "TrumpMediaevalLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18992
+          "fileSize": 18992,
+          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-Bold.woff2"
         },
         {
           "name": "TrumpMediaevalLTStd-BoldIt",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19780
+          "fileSize": 19780,
+          "url": "fonts/Trump Mediaeval LT Std/TrumpMediaevalLTStd-BoldIt.woff2"
         }
       ]
     },
@@ -16087,7 +17718,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16088
+          "fileSize": 16088,
+          "url": "fonts/Umbra Std/UmbraStd.woff2"
         }
       ]
     },
@@ -16106,189 +17738,216 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16328
+          "fileSize": 16328,
+          "url": "fonts/Univers LT Std/UniversLTStd-Light.woff2"
         },
         {
           "name": "UniversLTStd-LightCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15580
+          "fileSize": 15580,
+          "url": "fonts/Univers LT Std/UniversLTStd-LightCn.woff2"
         },
         {
           "name": "UniversLTStd-LightCnObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16496
+          "fileSize": 16496,
+          "url": "fonts/Univers LT Std/UniversLTStd-LightCnObl.woff2"
         },
         {
           "name": "UniversLTStd-LightObl",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17272
+          "fileSize": 17272,
+          "url": "fonts/Univers LT Std/UniversLTStd-LightObl.woff2"
         },
         {
           "name": "UniversLTStd-LightUltraCn",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14808
+          "fileSize": 14808,
+          "url": "fonts/Univers LT Std/UniversLTStd-LightUltraCn.woff2"
         },
         {
           "name": "UniversLTStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17740
+          "fileSize": 17740,
+          "url": "fonts/Univers LT Std/UniversLTStd.woff2"
         },
         {
           "name": "UniversLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18208
+          "fileSize": 18208,
+          "url": "fonts/Univers LT Std/UniversLTStd-Black.woff2"
         },
         {
           "name": "UniversLTStd-BlackEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16216
+          "fileSize": 16216,
+          "url": "fonts/Univers LT Std/UniversLTStd-BlackEx.woff2"
         },
         {
           "name": "UniversLTStd-BlackExObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17092
+          "fileSize": 17092,
+          "url": "fonts/Univers LT Std/UniversLTStd-BlackExObl.woff2"
         },
         {
           "name": "UniversLTStd-BlackObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18832
+          "fileSize": 18832,
+          "url": "fonts/Univers LT Std/UniversLTStd-BlackObl.woff2"
         },
         {
           "name": "UniversLTStd-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15404
+          "fileSize": 15404,
+          "url": "fonts/Univers LT Std/UniversLTStd-Cn.woff2"
         },
         {
           "name": "UniversLTStd-CnObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16132
+          "fileSize": 16132,
+          "url": "fonts/Univers LT Std/UniversLTStd-CnObl.woff2"
         },
         {
           "name": "UniversLTStd-Ex",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16140
+          "fileSize": 16140,
+          "url": "fonts/Univers LT Std/UniversLTStd-Ex.woff2"
         },
         {
           "name": "UniversLTStd-ExObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16952
+          "fileSize": 16952,
+          "url": "fonts/Univers LT Std/UniversLTStd-ExObl.woff2"
         },
         {
           "name": "UniversLTStd-Obl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18900
+          "fileSize": 18900,
+          "url": "fonts/Univers LT Std/UniversLTStd-Obl.woff2"
         },
         {
           "name": "UniversLTStd-ThinUltraCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 14796
+          "fileSize": 14796,
+          "url": "fonts/Univers LT Std/UniversLTStd-ThinUltraCn.woff2"
         },
         {
           "name": "UniversLTStd-UltraCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15748
+          "fileSize": 15748,
+          "url": "fonts/Univers LT Std/UniversLTStd-UltraCn.woff2"
         },
         {
           "name": "UniversLTStd-XBlack",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16740
+          "fileSize": 16740,
+          "url": "fonts/Univers LT Std/UniversLTStd-XBlack.woff2"
         },
         {
           "name": "UniversLTStd-XBlackEx",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17072
+          "fileSize": 17072,
+          "url": "fonts/Univers LT Std/UniversLTStd-XBlackEx.woff2"
         },
         {
           "name": "UniversLTStd-XBlackExObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18012
+          "fileSize": 18012,
+          "url": "fonts/Univers LT Std/UniversLTStd-XBlackExObl.woff2"
         },
         {
           "name": "UniversLTStd-XBlackObl",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17424
+          "fileSize": 17424,
+          "url": "fonts/Univers LT Std/UniversLTStd-XBlackObl.woff2"
         },
         {
           "name": "UniversLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18236
+          "fileSize": 18236,
+          "url": "fonts/Univers LT Std/UniversLTStd-Bold.woff2"
         },
         {
           "name": "UniversLTStd-BoldCn",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15660
+          "fileSize": 15660,
+          "url": "fonts/Univers LT Std/UniversLTStd-BoldCn.woff2"
         },
         {
           "name": "UniversLTStd-BoldCnObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16724
+          "fileSize": 16724,
+          "url": "fonts/Univers LT Std/UniversLTStd-BoldCnObl.woff2"
         },
         {
           "name": "UniversLTStd-BoldEx",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16504
+          "fileSize": 16504,
+          "url": "fonts/Univers LT Std/UniversLTStd-BoldEx.woff2"
         },
         {
           "name": "UniversLTStd-BoldExObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 17420
+          "fileSize": 17420,
+          "url": "fonts/Univers LT Std/UniversLTStd-BoldExObl.woff2"
         },
         {
           "name": "UniversLTStd-BoldObl",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18952
+          "fileSize": 18952,
+          "url": "fonts/Univers LT Std/UniversLTStd-BoldObl.woff2"
         }
       ]
     },
@@ -16307,14 +17966,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 10784
+          "fileSize": 10784,
+          "url": "fonts/Universal Std/UniversalStd-GreekwMathPi.woff2"
         },
         {
           "name": "UniversalStd-NewswithCommPi",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 9984
+          "fileSize": 9984,
+          "url": "fonts/Universal Std/UniversalStd-NewswithCommPi.woff2"
         }
       ]
     },
@@ -16333,7 +17994,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048
+          "fileSize": 19048,
+          "url": "fonts/University Roman Std/UniversityRomanStd.woff2"
         }
       ]
     },
@@ -16352,28 +18014,32 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16144
+          "fileSize": 16144,
+          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Light.woff2"
         },
         {
           "name": "VAGRoundedStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16772
+          "fileSize": 16772,
+          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Black.woff2"
         },
         {
           "name": "VAGRoundedStd-Thin",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16036
+          "fileSize": 16036,
+          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Thin.woff2"
         },
         {
           "name": "VAGRoundedStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16872
+          "fileSize": 16872,
+          "url": "fonts/VAG Rounded Std/VAGRoundedStd-Bold.woff2"
         }
       ]
     },
@@ -16392,56 +18058,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16084
+          "fileSize": 16084,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-LightItalic.woff2"
         },
         {
           "name": "VectoraLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15696
+          "fileSize": 15696,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-Light.woff2"
         },
         {
           "name": "VectoraLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16676
+          "fileSize": 16676,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-BlackItalic.woff2"
         },
         {
           "name": "VectoraLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16472
+          "fileSize": 16472,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-Italic.woff2"
         },
         {
           "name": "VectoraLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16316
+          "fileSize": 16316,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-Black.woff2"
         },
         {
           "name": "VectoraLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15836
+          "fileSize": 15836,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-Roman.woff2"
         },
         {
           "name": "VectoraLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 16400
+          "fileSize": 16400,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-BoldItalic.woff2"
         },
         {
           "name": "VectoraLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16108
+          "fileSize": 16108,
+          "url": "fonts/Vectora LT Std/VectoraLTStd-Bold.woff2"
         }
       ]
     },
@@ -16460,56 +18134,64 @@
           "weight": 300,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19640
+          "fileSize": 19640,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-LightItalic.woff2"
         },
         {
           "name": "VersaillesLTStd-Light",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18488
+          "fileSize": 18488,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-Light.woff2"
         },
         {
           "name": "VersaillesLTStd-BlackItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19980
+          "fileSize": 19980,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-BlackItalic.woff2"
         },
         {
           "name": "VersaillesLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19412
+          "fileSize": 19412,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-Italic.woff2"
         },
         {
           "name": "VersaillesLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19076
+          "fileSize": 19076,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-Black.woff2"
         },
         {
           "name": "VersaillesLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18616
+          "fileSize": 18616,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-Roman.woff2"
         },
         {
           "name": "VersaillesLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19680
+          "fileSize": 19680,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-BoldItalic.woff2"
         },
         {
           "name": "VersaillesLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19048
+          "fileSize": 19048,
+          "url": "fonts/Versailles LT Std/VersaillesLTStd-Bold.woff2"
         }
       ]
     },
@@ -16528,21 +18210,24 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16552
+          "fileSize": 16552,
+          "url": "fonts/Verve Std/VerveStd-Black.woff2"
         },
         {
           "name": "VerveStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 15640
+          "fileSize": 15640,
+          "url": "fonts/Verve Std/VerveStd-Regular.woff2"
         },
         {
           "name": "VerveStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 16704
+          "fileSize": 16704,
+          "url": "fonts/Verve Std/VerveStd-Bold.woff2"
         }
       ]
     },
@@ -16561,63 +18246,72 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35468
+          "fileSize": 35468,
+          "url": "fonts/Viva Std/VivaStd-Light.woff2"
         },
         {
           "name": "VivaStd-LightCondensed",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33000
+          "fileSize": 33000,
+          "url": "fonts/Viva Std/VivaStd-LightCondensed.woff2"
         },
         {
           "name": "VivaStd-LightExtraExtended",
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33952
+          "fileSize": 33952,
+          "url": "fonts/Viva Std/VivaStd-LightExtraExtended.woff2"
         },
         {
           "name": "VivaStd-Condensed",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35664
+          "fileSize": 35664,
+          "url": "fonts/Viva Std/VivaStd-Condensed.woff2"
         },
         {
           "name": "VivaStd-ExtraExtended",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 37244
+          "fileSize": 37244,
+          "url": "fonts/Viva Std/VivaStd-ExtraExtended.woff2"
         },
         {
           "name": "VivaStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 36176
+          "fileSize": 36176,
+          "url": "fonts/Viva Std/VivaStd-Regular.woff2"
         },
         {
           "name": "VivaStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35912
+          "fileSize": 35912,
+          "url": "fonts/Viva Std/VivaStd-Bold.woff2"
         },
         {
           "name": "VivaStd-BoldCondensed",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33860
+          "fileSize": 33860,
+          "url": "fonts/Viva Std/VivaStd-BoldCondensed.woff2"
         },
         {
           "name": "VivaStd-BoldExtraExtended",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 35460
+          "fileSize": 35460,
+          "url": "fonts/Viva Std/VivaStd-BoldExtraExtended.woff2"
         }
       ]
     },
@@ -16636,7 +18330,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 68416
+          "fileSize": 68416,
+          "url": "fonts/Voluta Script Pro/VolutaScriptPro-Regular.woff2"
         }
       ]
     },
@@ -16655,84 +18350,96 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 61492
+          "fileSize": 61492,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Bd.woff2"
         },
         {
           "name": "WatersTitlingPro-BdCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 58876
+          "fileSize": 58876,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-BdCn.woff2"
         },
         {
           "name": "WatersTitlingPro-BdScn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 68688
+          "fileSize": 68688,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-BdScn.woff2"
         },
         {
           "name": "WatersTitlingPro-Cn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67096
+          "fileSize": 67096,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Cn.woff2"
         },
         {
           "name": "WatersTitlingPro-Lt",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 57952
+          "fileSize": 57952,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Lt.woff2"
         },
         {
           "name": "WatersTitlingPro-LtCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 59032
+          "fileSize": 59032,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-LtCn.woff2"
         },
         {
           "name": "WatersTitlingPro-LtScn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67468
+          "fileSize": 67468,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-LtScn.woff2"
         },
         {
           "name": "WatersTitlingPro-Rg",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69480
+          "fileSize": 69480,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Rg.woff2"
         },
         {
           "name": "WatersTitlingPro-Sb",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69340
+          "fileSize": 69340,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Sb.woff2"
         },
         {
           "name": "WatersTitlingPro-SbCn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 67296
+          "fileSize": 67296,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-SbCn.woff2"
         },
         {
           "name": "WatersTitlingPro-SbScn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69488
+          "fileSize": 69488,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-SbScn.woff2"
         },
         {
           "name": "WatersTitlingPro-Scn",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 69868
+          "fileSize": 69868,
+          "url": "fonts/Waters Titling Pro/WatersTitlingPro-Scn.woff2"
         }
       ]
     },
@@ -16751,56 +18458,64 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20080
+          "fileSize": 20080,
+          "url": "fonts/Weidemann Std/WeidemannStd-BlackItalic.woff2"
         },
         {
           "name": "WeidemannStd-BookItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19384
+          "fileSize": 19384,
+          "url": "fonts/Weidemann Std/WeidemannStd-BookItalic.woff2"
         },
         {
           "name": "WeidemannStd-MediumItalic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19192
+          "fileSize": 19192,
+          "url": "fonts/Weidemann Std/WeidemannStd-MediumItalic.woff2"
         },
         {
           "name": "WeidemannStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19000
+          "fileSize": 19000,
+          "url": "fonts/Weidemann Std/WeidemannStd-Black.woff2"
         },
         {
           "name": "WeidemannStd-Book",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18308
+          "fileSize": 18308,
+          "url": "fonts/Weidemann Std/WeidemannStd-Book.woff2"
         },
         {
           "name": "WeidemannStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18612
+          "fileSize": 18612,
+          "url": "fonts/Weidemann Std/WeidemannStd-Medium.woff2"
         },
         {
           "name": "WeidemannStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 20132
+          "fileSize": 20132,
+          "url": "fonts/Weidemann Std/WeidemannStd-BoldItalic.woff2"
         },
         {
           "name": "WeidemannStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19104
+          "fileSize": 19104,
+          "url": "fonts/Weidemann Std/WeidemannStd-Bold.woff2"
         }
       ]
     },
@@ -16819,28 +18534,32 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 19368
+          "fileSize": 19368,
+          "url": "fonts/Weiss Std/WeissStd-Italic.woff2"
         },
         {
           "name": "WeissStd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19176
+          "fileSize": 19176,
+          "url": "fonts/Weiss Std/WeissStd.woff2"
         },
         {
           "name": "WeissStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19468
+          "fileSize": 19468,
+          "url": "fonts/Weiss Std/WeissStd-Bold.woff2"
         },
         {
           "name": "WeissStd-ExtraBold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 19824
+          "fileSize": 19824,
+          "url": "fonts/Weiss Std/WeissStd-ExtraBold.woff2"
         }
       ]
     },
@@ -16859,21 +18578,24 @@
           "weight": 300,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 28276
+          "fileSize": 28276,
+          "url": "fonts/Wendy LP Std/WendyLPStd-Light.woff2"
         },
         {
           "name": "WendyLPStd-Medium",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27392
+          "fileSize": 27392,
+          "url": "fonts/Wendy LP Std/WendyLPStd-Medium.woff2"
         },
         {
           "name": "WendyLPStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27208
+          "fileSize": 27208,
+          "url": "fonts/Wendy LP Std/WendyLPStd-Bold.woff2"
         }
       ]
     },
@@ -16892,14 +18614,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 91240
+          "fileSize": 91240,
+          "url": "fonts/Wiesbaden Swing LT Std/WiesbadenSwingLTStd-Ding.woff2"
         },
         {
           "name": "WiesbadenSwingLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24180
+          "fileSize": 24180,
+          "url": "fonts/Wiesbaden Swing LT Std/WiesbadenSwingLTStd-Roman.woff2"
         }
       ]
     },
@@ -16918,7 +18642,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 27692
+          "fileSize": 27692,
+          "url": "fonts/Wilhelm Klingspor Gothic LT Std/WilhelmKlingsporGotLTStd.woff2"
         }
       ]
     },
@@ -16937,42 +18662,48 @@
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23944
+          "fileSize": 23944,
+          "url": "fonts/Wilke LT Std/WilkeLTStd-BlackItalic.woff2"
         },
         {
           "name": "WilkeLTStd-Italic",
           "weight": 400,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 22896
+          "fileSize": 22896,
+          "url": "fonts/Wilke LT Std/WilkeLTStd-Italic.woff2"
         },
         {
           "name": "WilkeLTStd-Black",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 24828
+          "fileSize": 24828,
+          "url": "fonts/Wilke LT Std/WilkeLTStd-Black.woff2"
         },
         {
           "name": "WilkeLTStd-Roman",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23652
+          "fileSize": 23652,
+          "url": "fonts/Wilke LT Std/WilkeLTStd-Roman.woff2"
         },
         {
           "name": "WilkeLTStd-BoldItalic",
           "weight": 700,
           "style": "italic",
           "format": "woff2",
-          "fileSize": 23916
+          "fileSize": 23916,
+          "url": "fonts/Wilke LT Std/WilkeLTStd-BoldItalic.woff2"
         },
         {
           "name": "WilkeLTStd-Bold",
           "weight": 700,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 23220
+          "fileSize": 23220,
+          "url": "fonts/Wilke LT Std/WilkeLTStd-Bold.woff2"
         }
       ]
     },
@@ -16991,7 +18722,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 18944
+          "fileSize": 18944,
+          "url": "fonts/Willow Std/WillowStd.woff2"
         }
       ]
     },
@@ -17010,14 +18742,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26944
+          "fileSize": 26944,
+          "url": "fonts/Wittenberger Fraktur MT Std/WittenbergerFrakturMTStd.woff2"
         },
         {
           "name": "WittenbergerFrakturMTStd-Bd",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 26352
+          "fileSize": 26352,
+          "url": "fonts/Wittenberger Fraktur MT Std/WittenbergerFrakturMTStd-Bd.woff2"
         }
       ]
     },
@@ -17036,14 +18770,16 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 22732
+          "fileSize": 22732,
+          "url": "fonts/Zebrawood Std/ZebrawoodStd-Fill.woff2"
         },
         {
           "name": "ZebrawoodStd-Regular",
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 63840
+          "fileSize": 63840,
+          "url": "fonts/Zebrawood Std/ZebrawoodStd-Regular.woff2"
         }
       ]
     },
@@ -17062,7 +18798,8 @@
           "weight": 400,
           "style": "normal",
           "format": "woff2",
-          "fileSize": 33828
+          "fileSize": 33828,
+          "url": "fonts/Zipty Do Std/ZiptyDoStd.woff2"
         }
       ]
     }

--- a/index.html
+++ b/index.html
@@ -539,11 +539,11 @@
                 <div class="logo-container">
                     <div class="logo-text" data-text="Manic">Manic</div>
                 </div>
-                <div class="size-indicator" title="Approximate rendered size of the text element (pixels)">
-                    <span id="logoWidth">0</span>×<span id="logoHeight">0</span>px
-                </div>
-            </div>
 
+            </div>
+            <div class="size-indicator" title="Approximate rendered size of the text element (pixels)">
+                <span id="logoWidth">0</span>×<span id="logoHeight">0</span>px
+            </div>
             <div class="button-container main-actions">
                 <button id="randomizeStyleBtn" class="randomize-btn" title="Apply Random Style Settings (Keeps Text & Font)">
                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 3h5v5"/><path d="M4 20L21 3"/><path d="M21 16v5h-5"/><path d="M15 15l6 6"/><path d="M4 4l5 5"/></svg>

--- a/js/captureTextStyles.js
+++ b/js/captureTextStyles.js
@@ -14,6 +14,7 @@ console.log("[CaptureStyles] Enhanced Module v17 loaded.");
  * Main function to capture all computed styles from the logo elements.
  * @returns {object|null} Complete style object or null on critical failure.
  */
+
 export function captureAdvancedStyles() {
     console.log("[Style Capture v17] ========== STARTING ENHANCED STYLE CAPTURE ==========");
     
@@ -24,9 +25,9 @@ export function captureAdvancedStyles() {
     }
     
     // --- Element Finding ---
+    const previewContainer = document.getElementById('previewContainer');
     const logoContainer = document.querySelector('.logo-container');
     const logoText = document.querySelector('.logo-text');
-    const previewContainer = document.getElementById('previewContainer');
 
     if (!logoContainer || !logoText) {
         console.error("[Style Capture] CRITICAL ERROR: Failed to find logo elements in DOM");
@@ -37,12 +38,19 @@ export function captureAdvancedStyles() {
     }
     console.log("[Style Capture] Found elements: logoContainer, logoText", previewContainer ? '& previewContainer' : '(previewContainer NOT found)');
 
+    // --- Get Container Size for Scaling ---
+    const containerRect = previewContainer ? previewContainer.getBoundingClientRect() : logoContainer.getBoundingClientRect();
+    const containerWidth = containerRect.width;
+    const containerHeight = containerRect.height;
+    
     // --- Get Computed Styles & Settings FIRST ---
     const containerStyle = window.getComputedStyle(logoContainer);
     const textStyle = window.getComputedStyle(logoText);
     const previewContainerStyle = previewContainer ? window.getComputedStyle(previewContainer) : {};
     const rootStyle = window.getComputedStyle(document.documentElement);
     const currentSettings = window.SettingsManager?.getCurrentSettings?.() || {};
+
+
 
     // --- Initialize Result Object ---
     // Declare the main 'styles' object FIRST
@@ -113,6 +121,7 @@ export function captureAdvancedStyles() {
 
     // --- Text Alignment ---
     const textAlign = textStyle.textAlign.trim().toLowerCase();
+    styles.textAlign = textAlign; // Explicitly capture this
     if (textAlign === 'left') {
         styles.textAnchor = 'start';
         styles.textAlign = 'left';
@@ -122,6 +131,27 @@ export function captureAdvancedStyles() {
     } else {
         styles.textAnchor = 'middle';
         styles.textAlign = 'center';
+    }
+    console.log(`[Style Capture] Text alignment: CSS=${styles.textAlign}, SVG=${styles.textAnchor}`);
+
+    // Also ensure we capture the relevant classes:
+    if (logoText.classList) {
+        styles.textClassList = Array.from(logoText.classList);
+        
+        // Explicitly check for text alignment classes
+        const alignmentClasses = ['text-align-left', 'text-align-center', 'text-align-right'];
+        const hasAlignmentClass = alignmentClasses.some(cls => logoText.classList.contains(cls));
+        
+        if (!hasAlignmentClass) {
+            // Add appropriate class if missing
+            if (styles.textAlign === 'left') {
+                styles.textClassList.push('text-align-left');
+            } else if (styles.textAlign === 'right') {
+                styles.textClassList.push('text-align-right');
+            } else {
+                styles.textClassList.push('text-align-center');
+            }
+        }
     }
     console.log(`[Style Capture] Text alignment: CSS=${styles.textAlign}, SVG=${styles.textAnchor}`);
 

--- a/js/fontManager.js
+++ b/js/fontManager.js
@@ -532,20 +532,55 @@ async function _populateFontDropdown(fonts) {
  */
 async function _populateFontDropdownWithFallbacks() {
     const fallbackFonts = [
-        { familyName: 'Arial', displayName: 'Arial (System)' },
-        { familyName: 'Verdana', displayName: 'Verdana (System)' },
-        { familyName: 'Helvetica', displayName: 'Helvetica (System)' },
-        { familyName: 'Times New Roman', displayName: 'Times New Roman (System)' },
-        { familyName: 'Courier New', displayName: 'Courier New (System)' },
-        { familyName: 'Georgia', displayName: 'Georgia (System)' },
-        { familyName: 'Tahoma', displayName: 'Tahoma (System)' },
-        { familyName: 'Impact', displayName: 'Impact (System)' }
+        { familyName: 'Arial', displayName: 'Arial (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Verdana', displayName: 'Verdana (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Helvetica', displayName: 'Helvetica (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Times New Roman', displayName: 'Times New Roman (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Courier New', displayName: 'Courier New (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Georgia', displayName: 'Georgia (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Tahoma', displayName: 'Tahoma (System)', variants: [
+            { weight: '400', style: 'normal', url: '' },
+            { weight: '700', style: 'normal', url: '' }
+        ]},
+        { familyName: 'Impact', displayName: 'Impact (System)', variants: [
+            { weight: '400', style: 'normal', url: '' }
+        ]}
     ];
 
     console.warn('[FontMan] Using system fallback fonts only.');
+    
+    // Add these to _fontDataCache to make them accessible through getFontDataByName
+    if (!_fontDataCache) {
+        _fontDataCache = fallbackFonts;
+    } else {
+        // Avoid duplicates
+        for (const fallbackFont of fallbackFonts) {
+            if (!_fontDataCache.some(f => f.familyName === fallbackFont.familyName)) {
+                _fontDataCache.push(fallbackFont);
+            }
+        }
+    }
+    
     await _populateFontDropdown(fallbackFonts);
 }
-
 /**
  * Dispatch a progress event to inform the UI about ongoing font loading
  * @param {number} percent - Loading progress percentage (0-100)

--- a/js/misc.js
+++ b/js/misc.js
@@ -741,11 +741,11 @@ export function initializeRandomizeShortcut() {
 // --- Example Usage (in your main app initialization) ---
 // import { initializeRandomizeShortcut } from './randomizer'; // Adjust path
 //
-// document.addEventListener('DOMContentLoaded', () => {
-//   // ... other initializations ...
-//   initializeRandomizeShortcut();
-//   // ...
-// });
+document.addEventListener('DOMContentLoaded', () => {
+  // ... other initializations ...
+  initializeRandomizeShortcut();
+  // ...
+});
 
 // --- Tooltip Setup (Placeholder) ---
 export function setupTooltips() { // EXPORTED

--- a/js/renderers/SVGRenderer.js
+++ b/js/renderers/SVGRenderer.js
@@ -281,6 +281,7 @@ const updatePreview = debounce(() => {
 
 
 /** Update the metadata display area */
+
 function updateMetadataInfo() {
     if (!metadataInfoDiv) return;
     console.log("[SVG UI] Updating metadata info display...");
@@ -297,9 +298,10 @@ function updateMetadataInfo() {
 
         let infoHTML = '<h4>SVG Export Details</h4><ul>';
 
-        // Font info
+        // Font info with better system font detection
         const fontName = styles.font.family?.split(',')[0].trim().replace(/['"]/g, '') || 'N/A';
-        infoHTML += `<li>Font: <code>${fontName}</code> (${styles.font.weight || 'N/A'})</li>`;
+        const isSystemFont = ['Arial', 'Verdana', 'Helvetica', 'Times New Roman', 'Courier New', 'Georgia', 'Tahoma', 'Impact'].includes(fontName);
+        infoHTML += `<li>Font: <code>${fontName}</code> (${styles.font.weight || 'N/A'})${isSystemFont ? ' (System Font)' : ''}</li>`;
 
         // Color mode
         if (styles.color?.mode === 'gradient' && styles.color.gradient?.colors?.length) {
@@ -457,22 +459,22 @@ function attachModalEventListeners() {
     console.log('[SVG UI] Event listeners attached.');
 }
 
-/** Remove event listeners */
-function removeModalEventListeners() {
-     if (!modal || modal.dataset.listenersAttached !== 'true') return;
-     console.log('[SVG UI] Removing event listeners...');
-    closeBtn?.removeEventListener('click', closeModal);
-    cancelBtn?.removeEventListener('click', closeModal);
-    exportBtn?.removeEventListener('click', handleExport);
-    modal?.removeEventListener('click', (e) => { if (e.target === modal) closeModal(); });
-    widthInput?.removeEventListener('input', updatePreview);
-    heightInput?.removeEventListener('input', updatePreview);
-    transparentCheckbox?.removeEventListener('change', updatePreview);
-     document.removeEventListener('keydown', handleEscapeKey);
+// /** Remove event listeners */
+// function removeModalEventListeners() {
+//      if (!modal || modal.dataset.listenersAttached !== 'true') return;
+//      console.log('[SVG UI] Removing event listeners...');
+//     closeBtn?.removeEventListener('click', closeModal);
+//     cancelBtn?.removeEventListener('click', closeModal);
+//     exportBtn?.removeEventListener('click', handleExport);
+//     modal?.removeEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+//     widthInput?.removeEventListener('input', updatePreview);
+//     heightInput?.removeEventListener('input', updatePreview);
+//     transparentCheckbox?.removeEventListener('change', updatePreview);
+//      document.removeEventListener('keydown', handleEscapeKey);
 
-    modal.removeAttribute('data-listeners-attached');
-     console.log('[SVG UI] Event listeners removed.');
-}
+//     modal.removeAttribute('data-listeners-attached');
+//      console.log('[SVG UI] Event listeners removed.');
+// }
 
 /** Handle escape key press */
 function handleEscapeKey(event) {

--- a/js/settingsManager.js
+++ b/js/settingsManager.js
@@ -851,13 +851,34 @@ const SettingsManager = {
 
     /**
      * Applies text alignment (left, center, right) using CSS classes.
-     * Assumes classes like `.text-align-center` exist.
+     * @param {string} align - The alignment value ('left', 'center', 'right')
      * @private
-     * @param {string} align - The alignment value ('left', 'center', 'right').
      */
     _applyTextAlign(align) {
-        if (!this._logoElement || !align) return;
-        this._applyClass(this._logoElement, TEXT_ALIGN_CLASS_PREFIX + align, TEXT_ALIGN_CLASS_PREFIX);
+        const validAlignments = ['left', 'center', 'right'];
+        if (!align || !validAlignments.includes(align)) {
+            align = 'center'; // Default to center
+        }
+
+        const logoText = document.querySelector('.logo-text');
+        if (!logoText) return;
+
+        // First remove all alignment classes
+        validAlignments.forEach(a => {
+            logoText.classList.remove(`${TEXT_ALIGN_CLASS_PREFIX}${a}`);
+        });
+
+        // Apply the new alignment class
+        logoText.classList.add(`${TEXT_ALIGN_CLASS_PREFIX}${align}`);
+        
+        // Also set inline style as a fallback
+        logoText.style.textAlign = align;
+        
+        // Add debug output to check if this function is being called
+        console.log(`[SettingsManager] Applied text alignment: ${align}`);
+        
+        // Update CSS variable if we're using it anywhere
+        document.documentElement.style.setProperty('--text-align', align);
     },
 
     /**

--- a/js/utils/html2Canvas.js
+++ b/js/utils/html2Canvas.js
@@ -16,283 +16,118 @@ console.log("[HTML2Canvas Util] Module loading (v2.6 - Simplified onclone Border
  * @returns {Promise<HTMLCanvasElement>} Canvas with captured content.
  */
 export async function captureLogoWithHTML2Canvas(elementToCapture, options = {}) {
-    // Ensure html2canvas library is loaded (should be global via script tag)
-    if (typeof html2canvas !== 'function') {
-        console.error("[Capture v2.6] FATAL: html2canvas library not loaded!");
-        throw new Error("HTML2Canvas library not found. Cannot perform snapshot.");
-    }
-    // Ensure the target element exists
-    if (!elementToCapture || !(elementToCapture instanceof HTMLElement)) {
-        console.error("[Capture v2.6] FATAL: Invalid or missing element provided for capture.");
-        throw new Error("Invalid element provided for HTML2Canvas capture.");
+    if (!elementToCapture) {
+        throw new Error("No element provided for capture");
     }
 
-    console.log(`[Capture v2.6] Starting enhanced HTML2Canvas capture on element: #${elementToCapture.id || elementToCapture.tagName}`);
-    console.log("[Capture v2.6] Incoming options:", options);
-
-    let preparedElement = null; // Keep track for cleanup
-    // Declare error variable accessible in finally block
-    let errorOccurred = null;
-
-
-    try {
-        // --- Step 1: Prepare the element ---
-        preparedElement = await prepareElementForCapture(elementToCapture, options);
-        console.log("[Capture v2.6] Element prepared.");
-
-        // --- Step 2: Configure html2canvas options ---
-        const captureWidth = parseInt(preparedElement.style.width) || options.width || 800;
-        const captureHeight = parseInt(preparedElement.style.height) || options.height || 400;
-
-        const defaultOptions = {
-            scale: window.devicePixelRatio * 2, // Higher quality render scale
-            allowTaint: true,                   // Allows cross-origin images if server headers permit
-            useCORS: true,                      // Attempts to load cross-origin images via CORS
-            // Determine background: Use explicit option first, then element's computed style, fallback white
-            backgroundColor: options.transparentBackground ? null : (getComputedStyle(preparedElement).backgroundColor || '#ffffff'),
-            logging: false,                     // Set to true for verbose html2canvas debugging
-            width: captureWidth,                // Use determined width
-            height: captureHeight,              // Use determined height
-            scrollX: -window.scrollX,           // Account for page scroll
-            scrollY: -window.scrollY,
-            windowWidth: document.documentElement.scrollWidth, // Try using actual scroll width/height
-            windowHeight: document.documentElement.scrollHeight,
-
-            onclone: (clonedDoc, originalElement) => {
-                console.log("[Capture v2.6 - onclone] Enhancing cloned document...");
-
-                // --- Define rootComputed HERE, accessible throughout onclone ---
-                let rootComputed;
-                try {
-                    // Use the *original* document's root for computed variables
-                    rootComputed = window.getComputedStyle(document.documentElement);
-                    if (!rootComputed) throw new Error("Could not get computed styles from documentElement");
-                     console.log("[Capture v2.6 - onclone] Successfully obtained rootComputed styles.");
-                } catch (e) {
-                    console.error("[Capture v2.6 - onclone] CRITICAL: Failed to get root computed styles from original document!", e);
-                    // Cannot proceed reliably without root styles, html2canvas might fail severely
-                    return; // Stop further onclone processing
-                }
-                // --- End defining rootComputed ---
-
-                // Find the cloned version of the element we captured (usually #previewContainer)
-                // It might not have the same ID in the clone, find based on structure if needed, but ID is best
-                const clonedPreviewContainer = clonedDoc.getElementById(originalElement.id);
-                if (!clonedPreviewContainer) {
-                    console.error(`[Capture v2.6 - onclone] CRITICAL: Could not find cloned element with ID: ${originalElement.id}`);
-                    return; // Stop further onclone processing
-                } else {
-                    console.log(`[Capture v2.6 - onclone] Found cloned container: #${clonedPreviewContainer.id}`);
-                }
-
-                // Find children within the cloned container
-                const clonedLogoContainer = clonedPreviewContainer.querySelector('.logo-container');
-                const clonedLogoText = clonedPreviewContainer.querySelector('.logo-text');
-
-                // Get originals for comparison
-                const originalLogoContainer = originalElement.querySelector('.logo-container');
-                const originalLogoText = originalElement.querySelector('.logo-text');
-
-                // --- Style .logo-container (Simplified Approach) ---
-                if (clonedLogoContainer && originalLogoContainer) {
-                    try {
-                        const computedContainer = window.getComputedStyle(originalLogoContainer);
-                        console.log(`[Capture v2.6 - onclone] Applying styles to cloned .logo-container (variables + essential inline)...`);
-
-                        // 1. Ensure essential classes are cloned (html2canvas *should* do this)
-                        // Manually copy classes just in case html2canvas misses some? (Optional, can add complexity)
-                        // clonedLogoContainer.className = originalLogoContainer.className;
-
-                        // 2. Apply CSS Variables related to border/padding
-                        const borderVars = ['--dynamic-border-width', '--dynamic-border-color', '--dynamic-border-radius', '--dynamic-border-padding'];
-                        let varsApplied = 0;
-                        borderVars.forEach(varName => {
-                            const value = rootComputed?.getPropertyValue(varName).trim(); // Use optional chaining just in case
-                            if (value) {
-                                clonedLogoContainer.style.setProperty(varName, value);
-                                varsApplied++;
-                            }
-                        });
-                         console.log(`[Capture v2.6 - onclone] Applied ${varsApplied} border CSS variables to .logo-container.`);
-
-                        // 3. Apply only ESSENTIAL computed inline styles that might be missed or conflict
-                        clonedLogoContainer.style.boxSizing = computedContainer.boxSizing;
-                        clonedLogoContainer.style.padding = computedContainer.padding;
-                        clonedLogoContainer.style.borderRadius = computedContainer.borderRadius; // Still apply this inline for safety
-
-                        // 4. Apply box-shadow for glow effects
-                        clonedLogoContainer.style.boxShadow = computedContainer.boxShadow;
-                         if(computedContainer.boxShadow && computedContainer.boxShadow !== 'none') {
-                             console.log(`[Capture v2.6 - onclone] Applied effect to .logo-container: boxShadow=${computedContainer.boxShadow}`);
-                         }
-
-                         // --- REMOVED applying computedContainer.border, borderStyle, borderWidth, borderColor inline ---
-                         // Relying more on cloned classes + CSS vars now.
-
-                    } catch (containerStyleError) {
-                        console.error("[Capture v2.6 - onclone] Error applying styles to cloned container:", containerStyleError);
+    // Merge default options with provided options
+    const defaultOptions = {
+        scale: window.devicePixelRatio || 1,
+        allowTaint: true,
+        useCORS: true,
+        logging: false,
+        backgroundColor: null, // For transparent backgrounds
+        ignoreElements: (element) => {
+            // Ignore size indicator and any other elements we don't want
+            return element.classList && (
+                element.classList.contains('size-indicator') ||
+                element.classList.contains('loading-spinner')
+            );
+        },
+        // Capture inlined styles instead of loading external CSS
+        imageTimeout: 0, // Prevent timeouts on image loading
+        // Disable the iFrame approach that's causing connection errors
+        onclone: (documentClone) => {
+            // Copy all styles directly to cloned element
+            const sourceStyles = window.getComputedStyle(elementToCapture);
+            const targetElement = documentClone.querySelector('#' + elementToCapture.id) || 
+                                 documentClone.querySelector('.' + Array.from(elementToCapture.classList).join('.'));
+            
+            if (targetElement) {
+                // Apply relevant computed styles directly
+                const styles = [
+                    'background', 'backgroundColor', 'backgroundImage', 'backgroundSize', 
+                    'backgroundPosition', 'backgroundRepeat', 'color', 'fontFamily',
+                    'fontSize', 'fontWeight', 'letterSpacing', 'textAlign', 'textTransform',
+                    'borderRadius', 'border', 'boxShadow', 'opacity', 'padding'
+                ];
+                
+                styles.forEach(prop => {
+                    targetElement.style[prop] = sourceStyles[prop];
+                });
+                
+                // Copy styles of child elements (logo-container and logo-text)
+                const sourceLogoContainer = elementToCapture.querySelector('.logo-container');
+                const targetLogoContainer = targetElement.querySelector('.logo-container');
+                
+                if (sourceLogoContainer && targetLogoContainer) {
+                    const logoContainerStyles = window.getComputedStyle(sourceLogoContainer);
+                    styles.forEach(prop => {
+                        targetLogoContainer.style[prop] = logoContainerStyles[prop];
+                    });
+                    
+                    // Also copy animation
+                    if (logoContainerStyles.animation) {
+                        targetLogoContainer.style.animation = logoContainerStyles.animation;
                     }
-                } else {
-                    console.warn("[Capture v2.6 - onclone] Could not find .logo-container in original or cloned document.");
                 }
-
-                // --- Style .logo-text (Keep robust application) ---
-                 if (clonedLogoText && originalLogoText) {
-                      try {
-                          const computed = window.getComputedStyle(originalLogoText);
-                          // rootComputed defined earlier
-
-                          console.log(`[Capture v2.6 - onclone] Applying computed styles to cloned .logo-text...`);
-
-                          clonedLogoText.style.fontFamily = computed.fontFamily;
-                          clonedLogoText.style.fontWeight = computed.fontWeight;
-                          clonedLogoText.style.fontStyle = computed.fontStyle;
-                          clonedLogoText.style.fontSize = computed.fontSize;
-                          clonedLogoText.style.letterSpacing = rootComputed?.getPropertyValue('--dynamic-letter-spacing').trim() || computed.letterSpacing;
-                          clonedLogoText.style.color = computed.color;
-                          clonedLogoText.style.transform = computed.transform;
-                          clonedLogoText.style.textShadow = computed.textShadow;
-                          clonedLogoText.style.lineHeight = computed.lineHeight;
-                          clonedLogoText.style.opacity = computed.opacity;
-                          clonedLogoText.style.textAlign = computed.textAlign;
-                          clonedLogoText.style.whiteSpace = computed.whiteSpace;
-                          clonedLogoText.style.textTransform = computed.textTransform;
-
-                          // Handle gradient text fill
-                          if (computed.backgroundClip === 'text' || computed.webkitBackgroundClip === 'text') {
-                              clonedLogoText.style.backgroundImage = computed.backgroundImage;
-                              clonedLogoText.style.backgroundClip = 'text';
-                              clonedLogoText.style.webkitBackgroundClip = 'text';
-                              clonedLogoText.style.color = 'transparent';
-                              clonedLogoText.style.webkitTextFillColor = 'transparent';
-                              // console.log("[Capture v2.6 - onclone] Applied gradient text styles.");
-                          } else {
-                              // Ensure non-gradient text doesn't have residual gradient styles
-                              clonedLogoText.style.backgroundImage = 'none';
-                              clonedLogoText.style.backgroundClip = 'initial';
-                              clonedLogoText.style.webkitBackgroundClip = 'initial';
-                              // Re-apply color just in case
-                              clonedLogoText.style.color = computed.color;
-                              clonedLogoText.style.webkitTextFillColor = 'initial';
-                          }
-
-                          // Handle glitch data-text attribute
-                          if (originalLogoText.classList.contains('anim-glitch')) {
-                              const textContent = originalLogoText.textContent || '';
-                              clonedLogoText.setAttribute('data-text', textContent);
-                              console.log("[Capture v2.6 - onclone] Applied data-text for glitch animation.");
-                          }
-                      } catch (cloneStyleError) {
-                          console.error("[Capture v2.6 - onclone] Error applying styles to cloned text:", cloneStyleError);
-                      }
-                 } else {
-                     console.warn("[Capture v2.6 - onclone] Could not find .logo-text element in original or cloned document.");
-                 }
-
-                 // --- Apply CSS Variables to Root ---
-                 try {
-                     const clonedRoot = clonedDoc.documentElement;
-                     if (clonedRoot && rootComputed) { // Check if rootComputed was defined
-                         const propsToClone = [
-                             // Include all relevant variables used by components/effects
-                             '--dynamic-font-size', '--dynamic-letter-spacing', '--dynamic-rotation',
-                             '--dynamic-border-color', '--dynamic-border-color-rgb', '--dynamic-border-width',
-                             '--dynamic-border-radius', '--dynamic-border-padding',
-                             '--primary-color', '--secondary-color', '--accent-color',
-                             '--primary-color-rgb', '--secondary-color-rgb', '--accent-color-rgb',
-                             '--animation-duration', '--gradient-direction', '--bg-gradient-direction',
-                             '--border-radius-sm', '--border-radius-md', '--border-radius-lg',
-                             '--surface-sunken-opaque', '--border-subtle', '--bg-base', '--border-default',
-                             '--bg-deep', '--accent-color-rgb',
-                             // Add any theme variables if needed
-                             '--text-color', '--text-color-muted', '--text-color-strong',
-                             '--panel-bg', '--panel-bg-opaque', '--input-bg', '--button-bg',
-                             '--border-color'
-                         ];
-                         let appliedCount = 0;
-                         propsToClone.forEach(prop => {
-                             const value = rootComputed.getPropertyValue(prop).trim();
-                             if (value) {
-                                 clonedRoot.style.setProperty(prop, value);
-                                 appliedCount++;
-                             }
-                         });
-                         console.log(`[Capture v2.6 - onclone] Applied ${appliedCount} CSS variables to cloned root.`);
-                     } else if (!clonedRoot){
-                         console.warn("[Capture v2.6 - onclone] Could not find root element in cloned document.");
-                     } else {
-                         // This case should not happen anymore with the fix, but keep warning just in case
-                         console.warn("[Capture v2.6 - onclone] Could not apply CSS variables because rootComputed failed earlier.");
-                     }
-                 } catch (cloneVarError) {
-                      console.error("[Capture v2.6 - onclone] Error applying CSS variables to cloned root:", cloneVarError);
-                 }
-
-                 console.log("[Capture v2.6 - onclone] Finished enhancing clone.");
-            } // --- End of onclone ---
-        };
-
-        // Merge caller's options with defaults
-        const captureOptions = {
-            ...defaultOptions,
-            ...options,
-            // Re-assert critical options to prevent override if necessary
-            width: captureWidth,
-            height: captureHeight,
-            scale: defaultOptions.scale,
-            backgroundColor: options.transparentBackground ? null : defaultOptions.backgroundColor
-        };
-        console.log("[Capture v2.6] Final html2canvas options:", captureOptions);
-
-        // --- Step 3: Execute the capture ---
-        console.log("[Capture v2.6] Beginning HTML2Canvas rendering...");
-        const canvas = await html2canvas(preparedElement, captureOptions);
-        console.log(`[Capture v2.6] HTML2Canvas capture successful! Canvas size: ${canvas.width}x${canvas.height}`);
-
-        // --- Step 4: Post-processing (Optional Resize - Often handled by exporter) ---
-        let finalCanvas = canvas;
-        // Example resize logic (usually not needed here):
-        /*
-        if (canvas.width !== captureWidth * defaultOptions.scale || canvas.height !== captureHeight * defaultOptions.scale) {
-            console.warn(`[Capture v2.6] Raw canvas size differs from expected scaled size. Resizing...`);
-            finalCanvas = document.createElement('canvas');
-            finalCanvas.width = captureWidth * defaultOptions.scale;
-            finalCanvas.height = captureHeight * defaultOptions.scale;
-            const ctx = finalCanvas.getContext('2d');
-            if (!ctx) throw new Error("Failed to get context for resizing canvas");
-            ctx.imageSmoothingQuality = "high";
-            ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, finalCanvas.width, finalCanvas.height);
-            console.log(`[Capture v2.6] Resized canvas to ${finalCanvas.width}x${finalCanvas.height}`);
+                
+                const sourceLogoText = elementToCapture.querySelector('.logo-text');
+                const targetLogoText = targetElement.querySelector('.logo-text');
+                
+                if (sourceLogoText && targetLogoText) {
+                    const logoTextStyles = window.getComputedStyle(sourceLogoText);
+                    styles.concat([
+                        'transform', 'animation', 'textShadow', 'WebkitBackgroundClip',
+                        'backgroundClip', 'WebkitTextFillColor'
+                    ]).forEach(prop => {
+                        targetLogoText.style[prop] = logoTextStyles[prop];
+                    });
+                    
+                    // Ensure text content is copied
+                    targetLogoText.textContent = sourceLogoText.textContent;
+                    
+                    // Copy CSS animation classes
+                    if (sourceLogoText.className) {
+                        targetLogoText.className = sourceLogoText.className;
+                    }
+                    
+                    // For text effects that use ::before/::after, we may need to inject CSS
+                    const styleElement = documentClone.createElement('style');
+                    styleElement.textContent = `
+                        @keyframes pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.08); opacity: 0.9; } }
+                        .anim-pulse { animation: pulse 1.33s ease-in-out infinite; }
+                        .text-align-left { text-align: left; }
+                        .text-align-center { text-align: center; }
+                        .text-align-right { text-align: right; }
+                    `;
+                    documentClone.head.appendChild(styleElement);
+                }
+            }
         }
-        */
-
-        return finalCanvas; // Return canvas BEFORE cleanup on success
-
+    };
+    
+    const mergedOptions = { ...defaultOptions, ...options };
+    
+    console.log('[Capture v2.6] Final html2canvas options:', mergedOptions);
+    console.log('[Capture v2.6] Beginning HTML2Canvas rendering...');
+    
+    try {
+        // Try to render with html2canvas
+        // html2canvas should be globally available
+        if (typeof html2canvas !== 'function') {
+            throw new Error("html2canvas library not found! Make sure it's included in your project.");
+        }
+        
+        // Make a copy of styles and apply them directly to avoid external CSS problems
+        const canvas = await html2canvas(elementToCapture, mergedOptions);
+        console.log('[Capture v2.6] HTML2Canvas rendering successful.');
+        return canvas;
     } catch (error) {
-        // --- Error Handling ---
-        errorOccurred = error; // Store error to check in finally block
-        console.error("[Capture v2.6] HTML2Canvas capture process failed:", error);
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        let userFriendlyError = `Snapshot failed: ${errorMsg}`;
-        if (errorMsg.includes('SecurityError') || errorMsg.includes('tainted')) {
-             userFriendlyError = "Snapshot failed due to cross-origin security restrictions (external fonts/images?). Ensure CORS is configured if using external resources, or try the SVG Render method.";
-        } else if (errorMsg.includes('Timeout')) {
-             userFriendlyError = "Snapshot timed out, the logo might be too complex for html2canvas.";
-        }
-        // Ensure cleanup runs even on error before throwing
-        if (preparedElement) {
-             try { cleanupAfterCapture(preparedElement); } catch (cleanupErr) { console.error("Error during cleanup after failed capture:", cleanupErr); }
-        }
-        throw new Error(userFriendlyError); // Throw error *after* cleanup attempt
-    } finally {
-        // --- Step 5: Cleanup (if successful) ---
-        // Cleanup only happens here if the try block completed *without* throwing an error
-        if (preparedElement && !errorOccurred) {
-            cleanupAfterCapture(preparedElement);
-        }
+        console.error('[Capture v2.6] HTML2Canvas rendering failed:', error);
+        throw error;
     }
 }
-
 
 /**
  * Prepare element for more accurate capture (v2.5)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,987 @@
             "license": "MIT",
             "devDependencies": {
                 "chokidar": "^3.5.3",
-                "http-server": "^14.1.1"
+                "commitizen": "^4.3.1",
+                "conventional-changelog-cli": "^5.0.0",
+                "cz-conventional-changelog": "^3.3.0",
+                "electron": "^29.1.5",
+                "electron-builder": "^24.13.3",
+                "electron-log": "^5.3.3",
+                "electron-updater": "^6.1.8",
+                "http-server": "^14.1.1",
+                "standard-version": "^9.5.0"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@commitlint/config-validator": {
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz",
+            "integrity": "sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@commitlint/types": "^19.8.0",
+                "ajv": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/execute-rule": {
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz",
+            "integrity": "sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/load": {
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz",
+            "integrity": "sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@commitlint/config-validator": "^19.8.0",
+                "@commitlint/execute-rule": "^19.8.0",
+                "@commitlint/resolve-extends": "^19.8.0",
+                "@commitlint/types": "^19.8.0",
+                "chalk": "^5.3.0",
+                "cosmiconfig": "^9.0.0",
+                "cosmiconfig-typescript-loader": "^6.1.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.merge": "^4.6.2",
+                "lodash.uniq": "^4.5.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/load/node_modules/chalk": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@commitlint/resolve-extends": {
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz",
+            "integrity": "sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@commitlint/config-validator": "^19.8.0",
+                "@commitlint/types": "^19.8.0",
+                "global-directory": "^4.0.1",
+                "import-meta-resolve": "^4.0.0",
+                "lodash.mergewith": "^4.6.2",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/types": {
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
+            "integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/conventional-commits-parser": "^5.0.0",
+                "chalk": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/types/node_modules/chalk": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@conventional-changelog/git-client": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
+            "integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/semver": "^7.5.5",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "conventional-commits-filter": {
+                    "optional": true
+                },
+                "conventional-commits-parser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@conventional-changelog/git-client/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@develar/schema-utils": {
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+            "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.12.0",
+                "ajv-keywords": "^3.4.1"
+            },
+            "engines": {
+                "node": ">= 8.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/@develar/schema-utils/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@develar/schema-utils/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/@develar/schema-utils/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@electron/asar": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.0.tgz",
+            "integrity": "sha512-8ZAmXjsQ17wJxdv4755hZ1Xiw85dwETlWYQwl+imww18CaEK4bxPvAotJEfIZGbRMrNEJOTMyuVQD+yDY03N5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^5.0.0",
+                "glob": "^7.1.6",
+                "minimatch": "^3.0.4"
+            },
+            "bin": {
+                "asar": "bin/asar.js"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            }
+        },
+        "node_modules/@electron/asar/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@electron/asar/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@electron/get": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+            "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "env-paths": "^2.2.0",
+                "fs-extra": "^8.1.0",
+                "got": "^11.8.5",
+                "progress": "^2.0.3",
+                "semver": "^6.2.0",
+                "sumchecker": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "global-agent": "^3.0.0"
+            }
+        },
+        "node_modules/@electron/notarize": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.1.tgz",
+            "integrity": "sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "fs-extra": "^9.0.1",
+                "promise-retry": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@electron/notarize/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@electron/notarize/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@electron/notarize/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@electron/osx-sign": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.5.tgz",
+            "integrity": "sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "compare-version": "^0.1.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^10.0.0",
+                "isbinaryfile": "^4.0.8",
+                "minimist": "^1.2.6",
+                "plist": "^3.0.5"
+            },
+            "bin": {
+                "electron-osx-flat": "bin/electron-osx-flat.js",
+                "electron-osx-sign": "bin/electron-osx-sign.js"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+            "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/gjtorikian/"
+            }
+        },
+        "node_modules/@electron/osx-sign/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@electron/osx-sign/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@electron/universal": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.5.1.tgz",
+            "integrity": "sha512-kbgXxyEauPJiQQUNG2VgUeyfQNFk6hBF11ISN2PNI6agUgPl55pv4eQmaqHzTAzchBvqZ2tQuRVaPStGf0mxGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@electron/asar": "^3.2.1",
+                "@malept/cross-spawn-promise": "^1.1.0",
+                "debug": "^4.3.1",
+                "dir-compare": "^3.0.0",
+                "fs-extra": "^9.0.1",
+                "minimatch": "^3.0.4",
+                "plist": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@electron/universal/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@hutson/parse-repository-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
+            "integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@malept/cross-spawn-promise": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+            "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/malept"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+                }
+            ],
+            "license": "Apache-2.0",
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+            "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "fs-extra": "^9.0.0",
+                "lodash": "^4.17.15",
+                "tmp-promise": "^3.0.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@szmarczak/http-timer": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defer-to-connect": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@types/cacheable-request": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-cache-semantics": "*",
+                "@types/keyv": "^3.1.4",
+                "@types/node": "*",
+                "@types/responselike": "^1.0.0"
+            }
+        },
+        "node_modules/@types/conventional-commits-parser": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
+            "integrity": "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
+        "node_modules/@types/fs-extra": {
+            "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/http-cache-semantics": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/keyv": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "22.14.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+            "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/plist": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+            "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*",
+                "xmlbuilder": ">=11.0.1"
+            }
+        },
+        "node_modules/@types/responselike": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+            "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/verror": {
+            "version": "1.10.11",
+            "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+            "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@types/yauzl": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/7zip-bin": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+            "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/add-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+            "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-escapes/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
@@ -43,11 +1023,324 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/app-builder-bin": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+            "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/app-builder-lib": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.13.3.tgz",
+            "integrity": "sha512-FAzX6IBit2POXYGnTCT8YHFO/lr5AapAII6zzhQO3Rw4cEDOgK+t1xhLc5tNcKlicTHlo9zxIwnYCX9X2DLkig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@develar/schema-utils": "~2.6.5",
+                "@electron/notarize": "2.2.1",
+                "@electron/osx-sign": "1.0.5",
+                "@electron/universal": "1.5.1",
+                "@malept/flatpak-bundler": "^0.4.0",
+                "@types/fs-extra": "9.0.13",
+                "async-exit-hook": "^2.0.1",
+                "bluebird-lst": "^1.0.9",
+                "builder-util": "24.13.1",
+                "builder-util-runtime": "9.2.4",
+                "chromium-pickle-js": "^0.2.0",
+                "debug": "^4.3.4",
+                "ejs": "^3.1.8",
+                "electron-publish": "24.13.1",
+                "form-data": "^4.0.0",
+                "fs-extra": "^10.1.0",
+                "hosted-git-info": "^4.1.0",
+                "is-ci": "^3.0.0",
+                "isbinaryfile": "^5.0.0",
+                "js-yaml": "^4.1.0",
+                "lazy-val": "^1.0.5",
+                "minimatch": "^5.1.1",
+                "read-config-file": "6.3.2",
+                "sanitize-filename": "^1.6.3",
+                "semver": "^7.3.8",
+                "tar": "^6.1.12",
+                "temp-file": "^3.4.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "dmg-builder": "24.13.3",
+                "electron-builder-squirrel-windows": "24.13.3"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+            "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/archiver": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+            "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.4",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.1.2",
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/archiver-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+            "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/async": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
             "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/async-exit-hook": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "license": "MIT"
         },
         "node_modules/basic-auth": {
@@ -76,6 +1369,54 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bluebird-lst": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+            "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bluebird": "^3.5.5"
+            }
+        },
+        "node_modules/boolean": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/braces": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -87,6 +1428,191 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/buffer-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+            "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/builder-util": {
+            "version": "24.13.1",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.13.1.tgz",
+            "integrity": "sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/debug": "^4.1.6",
+                "7zip-bin": "~5.2.0",
+                "app-builder-bin": "4.0.0",
+                "bluebird-lst": "^1.0.9",
+                "builder-util-runtime": "9.2.4",
+                "chalk": "^4.1.2",
+                "cross-spawn": "^7.0.3",
+                "debug": "^4.3.4",
+                "fs-extra": "^10.1.0",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.1",
+                "is-ci": "^3.0.0",
+                "js-yaml": "^4.1.0",
+                "source-map-support": "^0.5.19",
+                "stat-mode": "^1.0.0",
+                "temp-file": "^3.4.0"
+            }
+        },
+        "node_modules/builder-util-runtime": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
+            "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/builder-util/node_modules/builder-util-runtime": {
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+            "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/builder-util/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/builder-util/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/builder-util/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/cacheable-lookup": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.6.0"
+            }
+        },
+        "node_modules/cacheable-request": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clone-response": "^1.0.2",
+                "get-stream": "^5.1.0",
+                "http-cache-semantics": "^4.0.0",
+                "keyv": "^4.0.0",
+                "lowercase-keys": "^2.0.0",
+                "normalize-url": "^6.0.1",
+                "responselike": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cachedir": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+            "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -120,6 +1646,55 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/camelcase-keys": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+            "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelcase": "^5.3.1",
+                "map-obj": "^4.0.0",
+                "quick-lru": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/camelcase-keys/node_modules/quick-lru": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+            "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -136,6 +1711,13 @@
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
+        },
+        "node_modules/chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
@@ -162,6 +1744,131 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/chromium-pickle-js": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+            "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/clone-response": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -182,6 +1889,689 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/commitizen": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.1.tgz",
+            "integrity": "sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cachedir": "2.3.0",
+                "cz-conventional-changelog": "3.3.0",
+                "dedent": "0.7.0",
+                "detect-indent": "6.1.0",
+                "find-node-modules": "^2.1.2",
+                "find-root": "1.1.0",
+                "fs-extra": "9.1.0",
+                "glob": "7.2.3",
+                "inquirer": "8.2.5",
+                "is-utf8": "^0.2.1",
+                "lodash": "4.17.21",
+                "minimist": "1.2.7",
+                "strip-bom": "4.0.0",
+                "strip-json-comments": "3.1.1"
+            },
+            "bin": {
+                "commitizen": "bin/commitizen",
+                "cz": "bin/git-cz",
+                "git-cz": "bin/git-cz"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/commitizen/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/commitizen/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/commitizen/node_modules/minimist": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/commitizen/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/compare-func": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^5.1.0"
+            }
+        },
+        "node_modules/compare-version": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+            "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/compress-commons": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+            "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.2",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "dev": true,
+            "engines": [
+                "node >= 6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/config-file-ts": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
+            "integrity": "sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "glob": "^10.3.10",
+                "typescript": "^5.3.3"
+            }
+        },
+        "node_modules/config-file-ts/node_modules/glob": {
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/config-file-ts/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/config-file-ts/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/conventional-changelog": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
+            "integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-atom": "^5.0.0",
+                "conventional-changelog-codemirror": "^5.0.0",
+                "conventional-changelog-conventionalcommits": "^8.0.0",
+                "conventional-changelog-core": "^8.0.0",
+                "conventional-changelog-ember": "^5.0.0",
+                "conventional-changelog-eslint": "^6.0.0",
+                "conventional-changelog-express": "^5.0.0",
+                "conventional-changelog-jquery": "^6.0.0",
+                "conventional-changelog-jshint": "^5.0.0",
+                "conventional-changelog-preset-loader": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-angular": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-atom": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-5.0.0.tgz",
+            "integrity": "sha512-WfzCaAvSCFPkznnLgLnfacRAzjgqjLUjvf3MftfsJzQdDICqkOOpcMtdJF3wTerxSpv2IAAjX8doM3Vozqle3g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-cli": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
+            "integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "add-stream": "^1.0.0",
+                "conventional-changelog": "^6.0.0",
+                "meow": "^13.0.0",
+                "tempfile": "^5.0.0"
+            },
+            "bin": {
+                "conventional-changelog": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-codemirror": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.0.0.tgz",
+            "integrity": "sha512-8gsBDI5Y3vrKUCxN6Ue8xr6occZ5nsDEc4C7jO/EovFGozx8uttCAyfhRrvoUAWi2WMm3OmYs+0mPJU7kQdYWQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-config-spec": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz",
+            "integrity": "sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/conventional-changelog-conventionalcommits": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+            "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-core": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
+            "integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@hutson/parse-repository-url": "^5.0.0",
+                "add-stream": "^1.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "git-raw-commits": "^5.0.0",
+                "git-semver-tags": "^8.0.0",
+                "hosted-git-info": "^7.0.0",
+                "normalize-package-data": "^6.0.0",
+                "read-package-up": "^11.0.0",
+                "read-pkg": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-ember": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-5.0.0.tgz",
+            "integrity": "sha512-RPflVfm5s4cSO33GH/Ey26oxhiC67akcxSKL8CLRT3kQX2W3dbE19sSOM56iFqUJYEwv9mD9r6k79weWe1urfg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-eslint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
+            "integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-express": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-5.0.0.tgz",
+            "integrity": "sha512-D8Q6WctPkQpvr2HNCCmwU5GkX22BVHM0r4EW8vN0230TSyS/d6VQJDAxGb84lbg0dFjpO22MwmsikKL++Oo/oQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-jquery": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-6.0.0.tgz",
+            "integrity": "sha512-2kxmVakyehgyrho2ZHBi90v4AHswkGzHuTaoH40bmeNqUt20yEkDOSpw8HlPBfvEQBwGtbE+5HpRwzj6ac2UfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-jshint": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-5.0.0.tgz",
+            "integrity": "sha512-gGNphSb/opc76n2eWaO6ma4/Wqu3tpa2w7i9WYqI6Cs2fncDSI2/ihOfMvXveeTTeld0oFvwMVNV+IYQIk3F3g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-preset-loader": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+            "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-writer": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.1.tgz",
+            "integrity": "sha512-hlqcy3xHred2gyYg/zXSMXraY2mjAYYo0msUCpK+BGyaVJMFCKWVXPIHiaacGO2GGp13kvHWXFhYmxT4QQqW3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-changelog-writer/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-commit-types": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
+            "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-parser": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.1.0.tgz",
+            "integrity": "sha512-5nxDo7TwKB5InYBl4ZC//1g9GRwB/F3TXOGR9hgUjMGfvSP4Vu5NkpNro2+1+TIEy1vwxApl5ircECr2ri5JIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-recommended-bump": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
+            "integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "concat-stream": "^2.0.0",
+                "conventional-changelog-preset-loader": "^2.3.4",
+                "conventional-commits-filter": "^2.0.7",
+                "conventional-commits-parser": "^3.2.0",
+                "git-raw-commits": "^2.0.8",
+                "git-semver-tags": "^4.1.1",
+                "meow": "^8.0.0",
+                "q": "^1.5.1"
+            },
+            "bin": {
+                "conventional-recommended-bump": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-changelog-preset-loader": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+            "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-commits-filter": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+            "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.ismatch": "^4.4.0",
+                "modify-values": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-text-path": "^1.0.1",
+                "JSONStream": "^1.0.4",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/git-raw-commits": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
+            "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dargs": "^7.0.0",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "git-raw-commits": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/git-semver-tags": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+            "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^8.0.0",
+                "semver": "^6.0.0"
+            },
+            "bin": {
+                "git-semver-tags": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/meow": {
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+            "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/normalize-package-data": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^4.0.1",
+                "is-core-module": "^2.5.0",
+                "semver": "^7.3.4",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/normalize-package-data/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/conventional-recommended-bump/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/corser": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -190,6 +2580,227 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/cosmiconfig": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/cosmiconfig-typescript-loader": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.1.0.tgz",
+            "integrity": "sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "jiti": "^2.4.1"
+            },
+            "engines": {
+                "node": ">=v18"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "cosmiconfig": ">=9",
+                "typescript": ">=5"
+            }
+        },
+        "node_modules/crc": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "buffer": "^5.1.0"
+            }
+        },
+        "node_modules/crc-32": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+            "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "crc32": "bin/crc32.njs"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/crc32-stream": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+            "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^3.4.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cz-conventional-changelog": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+            "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^2.4.1",
+                "commitizen": "^4.0.3",
+                "conventional-commit-types": "^3.0.0",
+                "lodash.map": "^4.5.1",
+                "longest": "^2.0.1",
+                "word-wrap": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@commitlint/load": ">6.1.1"
+            }
+        },
+        "node_modules/cz-conventional-changelog/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/cz-conventional-changelog/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/cz-conventional-changelog/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/cz-conventional-changelog/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cz-conventional-changelog/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/cz-conventional-changelog/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/cz-conventional-changelog/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/dargs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+            "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/debug": {
@@ -210,6 +2821,480 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decamelize-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+            "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decamelize-keys/node_modules/map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress-response/node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dedent": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+            "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/defaults": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clone": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/defer-to-connect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/detect-indent": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+            "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/dir-compare": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+            "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-equal": "^1.0.0",
+                "minimatch": "^3.0.4"
+            }
+        },
+        "node_modules/dir-compare/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/dir-compare/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dmg-builder": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.13.3.tgz",
+            "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "app-builder-lib": "24.13.3",
+                "builder-util": "24.13.1",
+                "builder-util-runtime": "9.2.4",
+                "fs-extra": "^10.1.0",
+                "iconv-lite": "^0.6.2",
+                "js-yaml": "^4.1.0"
+            },
+            "optionalDependencies": {
+                "dmg-license": "^1.0.11"
+            }
+        },
+        "node_modules/dmg-builder/node_modules/builder-util-runtime": {
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+            "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/dmg-builder/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/dmg-builder/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/dmg-builder/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/dmg-license": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+            "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "@types/plist": "^3.0.1",
+                "@types/verror": "^1.10.3",
+                "ajv": "^6.10.0",
+                "crc": "^3.8.0",
+                "iconv-corefoundation": "^1.1.7",
+                "plist": "^3.0.4",
+                "smart-buffer": "^4.0.2",
+                "verror": "^1.10.0"
+            },
+            "bin": {
+                "dmg-license": "bin/dmg-license.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dmg-license/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/dmg-license/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/dot-prop": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-obj": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+            "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/dotenv-expand": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+            "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/dotgitignore": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",
+            "integrity": "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "find-up": "^3.0.0",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/dotgitignore/node_modules/path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -223,6 +3308,402 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ejs": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "jake": "^10.8.5"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/electron": {
+            "version": "29.4.6",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.6.tgz",
+            "integrity": "sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "@electron/get": "^2.0.0",
+                "@types/node": "^20.9.0",
+                "extract-zip": "^2.0.1"
+            },
+            "bin": {
+                "electron": "cli.js"
+            },
+            "engines": {
+                "node": ">= 12.20.55"
+            }
+        },
+        "node_modules/electron-builder": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.13.3.tgz",
+            "integrity": "sha512-yZSgVHft5dNVlo31qmJAe4BVKQfFdwpRw7sFp1iQglDRCDD6r22zfRJuZlhtB5gp9FHUxCMEoWGq10SkCnMAIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "app-builder-lib": "24.13.3",
+                "builder-util": "24.13.1",
+                "builder-util-runtime": "9.2.4",
+                "chalk": "^4.1.2",
+                "dmg-builder": "24.13.3",
+                "fs-extra": "^10.1.0",
+                "is-ci": "^3.0.0",
+                "lazy-val": "^1.0.5",
+                "read-config-file": "6.3.2",
+                "simple-update-notifier": "2.0.0",
+                "yargs": "^17.6.2"
+            },
+            "bin": {
+                "electron-builder": "cli.js",
+                "install-app-deps": "install-app-deps.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/electron-builder-squirrel-windows": {
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-24.13.3.tgz",
+            "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "app-builder-lib": "24.13.3",
+                "archiver": "^5.3.1",
+                "builder-util": "24.13.1",
+                "fs-extra": "^10.1.0"
+            }
+        },
+        "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/electron-builder/node_modules/builder-util-runtime": {
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+            "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/electron-builder/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/electron-builder/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/electron-builder/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/electron-log": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.3.3.tgz",
+            "integrity": "sha512-ZOnlgCVfhKC0Nef68L0wDhwhg8nh5QkpEOA+udjpBxcPfTHGgbZbfoCBS6hmAgVHTAWByHNPkHKpSbEOPGZcxA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/electron-publish": {
+            "version": "24.13.1",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
+            "integrity": "sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/fs-extra": "^9.0.11",
+                "builder-util": "24.13.1",
+                "builder-util-runtime": "9.2.4",
+                "chalk": "^4.1.2",
+                "fs-extra": "^10.1.0",
+                "lazy-val": "^1.0.5",
+                "mime": "^2.5.2"
+            }
+        },
+        "node_modules/electron-publish/node_modules/builder-util-runtime": {
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+            "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/electron-publish/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/electron-publish/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/electron-publish/node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/electron-publish/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/electron-updater": {
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
+            "integrity": "sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "builder-util-runtime": "9.3.1",
+                "fs-extra": "^10.1.0",
+                "js-yaml": "^4.1.0",
+                "lazy-val": "^1.0.5",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isequal": "^4.5.0",
+                "semver": "^7.6.3",
+                "tiny-typed-emitter": "^2.1.0"
+            }
+        },
+        "node_modules/electron-updater/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/electron-updater/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/electron-updater/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/electron-updater/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/electron/node_modules/@types/node": {
+            "version": "20.17.30",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
+            "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.19.2"
+            }
+        },
+        "node_modules/electron/node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/err-code": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-define-property": {
@@ -258,12 +3739,211 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "homedir-polyfill": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/external-editor/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "bin": {
+                "extract-zip": "cli.js"
+            },
+            "engines": {
+                "node": ">= 10.17.0"
+            },
+            "optionalDependencies": {
+                "@types/yauzl": "^2.9.1"
+            }
+        },
+        "node_modules/extsprintf": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+            "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+            "dev": true,
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true
+        },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pend": "~1.2.0"
+            }
+        },
+        "node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/figures/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/filelist": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+            "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "minimatch": "^5.0.1"
+            }
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
@@ -276,6 +3956,70 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/find-node-modules": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
+            "integrity": "sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "findup-sync": "^4.0.0",
+                "merge": "^2.1.1"
+            }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-up-simple": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/findup-sync": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+            "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "micromatch": "^4.0.2",
+                "resolve-dir": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/follow-redirects": {
@@ -298,6 +4042,108 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -322,6 +4168,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -349,6 +4205,139 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-pkg-repo": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+            "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@hutson/parse-repository-url": "^3.0.0",
+                "hosted-git-info": "^4.0.0",
+                "through2": "^2.0.0",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "get-pkg-repo": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/@hutson/parse-repository-url": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+            "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/get-pkg-repo/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/get-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -361,6 +4350,109 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/git-raw-commits": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.0.tgz",
+            "integrity": "sha512-I2ZXrXeOc0KrCvC7swqtIFXFN+rbjnC7b2T943tvemIOVNl+XP8YnA9UVwqFhzzLClnSA60KR/qEjLpXzs73Qg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@conventional-changelog/git-client": "^1.0.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "git-raw-commits": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/git-remote-origin-url": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+            "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "gitconfiglocal": "^1.0.0",
+                "pify": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/git-semver-tags": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.0.tgz",
+            "integrity": "sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@conventional-changelog/git-client": "^1.0.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "git-semver-tags": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/gitconfiglocal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+            "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+            "dev": true,
+            "license": "BSD",
+            "dependencies": {
+                "ini": "^1.3.2"
+            }
+        },
+        "node_modules/gitconfiglocal/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -376,6 +4468,150 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/global-agent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "dependencies": {
+                "boolean": "^3.0.1",
+                "es6-error": "^4.1.1",
+                "matcher": "^3.0.0",
+                "roarr": "^2.15.3",
+                "semver": "^7.3.2",
+                "serialize-error": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            }
+        },
+        "node_modules/global-agent/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/global-directory": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ini": "4.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-prefix/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/global-prefix/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -389,6 +4625,71 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/got": {
+            "version": "11.8.6",
+            "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+            "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^4.0.0",
+                "@szmarczak/http-timer": "^4.0.5",
+                "@types/cacheable-request": "^6.0.1",
+                "@types/responselike": "^1.0.0",
+                "cacheable-lookup": "^5.0.3",
+                "cacheable-request": "^7.0.2",
+                "decompress-response": "^6.0.0",
+                "http2-wrapper": "^1.0.0-beta.5.2",
+                "lowercase-keys": "^2.0.0",
+                "p-cancelable": "^2.0.0",
+                "responselike": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/hard-rejection": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+            "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -399,12 +4700,42 @@
                 "node": ">=8"
             }
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -435,6 +4766,32 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-passwd": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
         "node_modules/html-encoding-sniffer": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -447,6 +4804,13 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/http-cache-semantics": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy": {
             "version": "1.18.1",
@@ -461,6 +4825,21 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/http-server": {
@@ -491,6 +4870,52 @@
                 "node": ">=12"
             }
         },
+        "node_modules/http2-wrapper": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/iconv-corefoundation": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+            "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "cli-truncate": "^2.1.0",
+                "node-addon-api": "^1.6.3"
+            },
+            "engines": {
+                "node": "^8.11.2 || >=10"
+            }
+        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -503,6 +4928,155 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/import-meta-resolve": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+            "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/index-to-position": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.0.0.tgz",
+            "integrity": "sha512-sCO7uaLVhRJ25vz1o8s9IFM3nVS4DkuQnyjMwiQPKvQuBYBDmb8H7zx8ki7nVh4HJQOdVWebyvLE0qt+clruxA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/inquirer": {
+            "version": "8.2.5",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+            "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.5.5",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -517,6 +5091,35 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-ci": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ci-info": "^3.2.0"
+            },
+            "bin": {
+                "is-ci": "bin.js"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -525,6 +5128,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-glob": {
@@ -540,6 +5153,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -550,6 +5173,584 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-text-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+            "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "text-extensions": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/isbinaryfile": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.4.tgz",
+            "integrity": "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/gjtorikian/"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/jake": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+            "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "async": "^3.2.3",
+                "chalk": "^4.0.2",
+                "filelist": "^1.0.4",
+                "minimatch": "^3.1.2"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jake/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/jake/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/jiti": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+            "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+            "dev": true,
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "license": "MIT"
+        },
+        "node_modules/JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "license": "(MIT OR Apache-2.0)",
+            "dependencies": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            },
+            "bin": {
+                "JSONStream": "bin.js"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/lazy-val": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+            "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lazystream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+            "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "^2.0.5"
+            },
+            "engines": {
+                "node": ">= 0.6.3"
+            }
+        },
+        "node_modules/lazystream/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/lazystream/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/load-json-file/node_modules/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/load-json-file/node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/load-json-file/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash.difference": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+            "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.ismatch": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+            "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.map": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/lodash.mergewith": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/lodash.union": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+            "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/longest": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
+            "integrity": "sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/lowercase-keys": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/map-obj": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+            "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/matcher": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "escape-string-regexp": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -558,6 +5759,40 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+            "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime": {
@@ -573,6 +5808,72 @@
                 "node": ">=4"
             }
         },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/minimist": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -583,12 +5884,137 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/minimist-options": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+            "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0",
+                "kind-of": "^6.0.3"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/modify-values": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+            "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-addon-api": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/normalize-package-data": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/normalize-package-data/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -598,6 +6024,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/normalize-url": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/object-inspect": {
@@ -613,6 +6052,43 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/opener": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -622,6 +6098,233 @@
             "bin": {
                 "opener": "bin/opener-bin.js"
             }
+        },
+        "node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/p-cancelable": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/path-type/node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -636,6 +6339,31 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/plist": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+            "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.8.8",
+                "base64-js": "^1.5.1",
+                "xmlbuilder": "^15.1.1"
+            },
+            "engines": {
+                "node": ">=10.4.0"
+            }
+        },
         "node_modules/portfinder": {
             "version": "1.0.35",
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.35.tgz",
@@ -648,6 +6376,70 @@
             },
             "engines": {
                 "node": ">= 10.12"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/promise-retry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "err-code": "^2.0.2",
+                "retry": "^0.12.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/pump": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+            "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+            "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.0",
+                "teleport": ">=0.2.0"
             }
         },
         "node_modules/qs": {
@@ -666,6 +6458,285 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-config-file": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
+            "integrity": "sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-file-ts": "^0.2.4",
+                "dotenv": "^9.0.2",
+                "dotenv-expand": "^5.1.0",
+                "js-yaml": "^4.1.0",
+                "json5": "^2.2.0",
+                "lazy-val": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/read-package-up": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+            "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.0",
+                "read-pkg": "^9.0.0",
+                "type-fest": "^4.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-package-up/node_modules/type-fest": {
+            "version": "4.39.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+            "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.3",
+                "normalize-package-data": "^6.0.0",
+                "parse-json": "^8.0.0",
+                "type-fest": "^4.6.0",
+                "unicorn-magic": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/read-pkg-up/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg/node_modules/parse-json": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.2.0.tgz",
+            "integrity": "sha512-eONBZy4hm2AgxjNFd8a4nyDJnzUAH0g34xSQAwWEVGCjdZ4ZL7dKZBfq267GWP/JaS9zW62Xs2FeAdDvpHHJGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.0.0",
+                "type-fest": "^4.37.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "4.39.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+            "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/readdir-glob": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+            "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "minimatch": "^5.1.0"
+            }
+        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -679,12 +6750,176 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/resolve": {
+            "version": "1.22.10",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.16.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/responselike": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lowercase-keys": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/roarr": {
+            "version": "2.15.4",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "dependencies": {
+                "boolean": "^3.0.1",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.1",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -700,12 +6935,87 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/sanitize-filename": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+            "dev": true,
+            "license": "WTFPL OR ISC",
+            "dependencies": {
+                "truncate-utf8-bytes": "^1.0.0"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/secure-compare": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
             "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/serialize-error": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "type-fest": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
@@ -783,6 +7093,1121 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/simple-update-notifier": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/simple-update-notifier/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/slice-ansi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.21",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "readable-stream": "^3.0.0"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true
+        },
+        "node_modules/standard-version": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
+            "integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^2.4.2",
+                "conventional-changelog": "3.1.25",
+                "conventional-changelog-config-spec": "2.1.0",
+                "conventional-changelog-conventionalcommits": "4.6.3",
+                "conventional-recommended-bump": "6.1.0",
+                "detect-indent": "^6.0.0",
+                "detect-newline": "^3.1.0",
+                "dotgitignore": "^2.1.0",
+                "figures": "^3.1.0",
+                "find-up": "^5.0.0",
+                "git-semver-tags": "^4.0.0",
+                "semver": "^7.1.1",
+                "stringify-package": "^1.0.1",
+                "yargs": "^16.0.0"
+            },
+            "bin": {
+                "standard-version": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/standard-version/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/standard-version/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog": {
+            "version": "3.1.25",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+            "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^5.0.12",
+                "conventional-changelog-atom": "^2.0.8",
+                "conventional-changelog-codemirror": "^2.0.8",
+                "conventional-changelog-conventionalcommits": "^4.5.0",
+                "conventional-changelog-core": "^4.2.1",
+                "conventional-changelog-ember": "^2.0.9",
+                "conventional-changelog-eslint": "^3.0.9",
+                "conventional-changelog-express": "^2.0.6",
+                "conventional-changelog-jquery": "^3.0.11",
+                "conventional-changelog-jshint": "^2.0.9",
+                "conventional-changelog-preset-loader": "^2.3.4"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-angular": {
+            "version": "5.0.13",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0",
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-atom": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+            "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-codemirror": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+            "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-conventionalcommits": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+            "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0",
+                "lodash": "^4.17.15",
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-core": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+            "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "add-stream": "^1.0.0",
+                "conventional-changelog-writer": "^5.0.0",
+                "conventional-commits-parser": "^3.2.0",
+                "dateformat": "^3.0.0",
+                "get-pkg-repo": "^4.0.0",
+                "git-raw-commits": "^2.0.8",
+                "git-remote-origin-url": "^2.0.0",
+                "git-semver-tags": "^4.1.1",
+                "lodash": "^4.17.15",
+                "normalize-package-data": "^3.0.0",
+                "q": "^1.5.1",
+                "read-pkg": "^3.0.0",
+                "read-pkg-up": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-ember": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+            "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-eslint": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+            "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-express": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+            "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-jquery": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+            "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-jshint": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+            "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0",
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-preset-loader": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+            "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-writer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+            "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-commits-filter": "^2.0.7",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.7.7",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "semver": "^6.0.0",
+                "split": "^1.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "conventional-changelog-writer": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-changelog-writer/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-commits-filter": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+            "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.ismatch": "^4.4.0",
+                "modify-values": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/conventional-commits-parser": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-text-path": "^1.0.1",
+                "JSONStream": "^1.0.4",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/standard-version/node_modules/git-raw-commits": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
+            "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dargs": "^7.0.0",
+                "lodash": "^4.17.15",
+                "meow": "^8.0.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "git-raw-commits": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/git-semver-tags": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+            "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^8.0.0",
+                "semver": "^6.0.0"
+            },
+            "bin": {
+                "git-semver-tags": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/git-semver-tags/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/standard-version/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-version/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow": {
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+            "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/read-pkg/node_modules/type-fest": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-version/node_modules/meow/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/standard-version/node_modules/normalize-package-data": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^4.0.1",
+                "is-core-module": "^2.5.0",
+                "semver": "^7.3.4",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/standard-version/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+            "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up/node_modules/find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up/node_modules/locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up/node_modules/p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up/node_modules/p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up/node_modules/p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg-up/node_modules/path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/standard-version/node_modules/read-pkg/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/standard-version/node_modules/read-pkg/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/standard-version/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/standard-version/node_modules/type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/standard-version/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/standard-version/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/stat-mode": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+            "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/stringify-package": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+            "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
+            "deprecated": "This module is not used anymore, and has been replaced by @npmcli/package-json",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/sumchecker": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+            "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "debug": "^4.1.0"
+            },
+            "engines": {
+                "node": ">= 8.0"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -794,6 +8219,197 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tar": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^5.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/temp-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/temp-file": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+            "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async-exit-hook": "^2.0.1",
+                "fs-extra": "^10.0.0"
+            }
+        },
+        "node_modules/temp-file/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/temp-file/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/temp-file/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/tempfile": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-5.0.0.tgz",
+            "integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "temp-dir": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/text-extensions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/through2": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "3"
+            }
+        },
+        "node_modules/tiny-typed-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+            "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/tmp-promise": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+            "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tmp": "^0.2.0"
+            }
+        },
+        "node_modules/tmp-promise/node_modules/tmp": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/to-regex-range": {
@@ -809,6 +8425,102 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/trim-newlines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+            "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/truncate-utf8-bytes": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+            "dev": true,
+            "license": "WTFPL",
+            "dependencies": {
+                "utf8-byte-length": "^1.0.1"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/type-fest": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "optional": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/typescript": {
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/union": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
@@ -821,12 +8533,83 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
         "node_modules/url-join": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
             "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/utf8-byte-length": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+            "dev": true,
+            "license": "(WTFPL OR MIT)"
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/verror": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+            "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defaults": "^1.0.3"
+            }
         },
         "node_modules/whatwg-encoding": {
             "version": "2.0.0",
@@ -839,6 +8622,212 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/xmlbuilder": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zip-stream": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+            "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "archiver-utils": "^3.0.4",
+                "compress-commons": "^4.1.2",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/zip-stream/node_modules/archiver-utils": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+            "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "glob": "^7.2.3",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">= 10"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -5,17 +5,77 @@
     "author": "Manic.agency",
     "license": "MIT",
     "private": true,
+    "main": "electron.js",
     "scripts": {
-      "dev": "node scripts/dev.js --mode=dev",
-      "preview": "node scripts/dev.js --mode=prod-preview --port=3001",
-      "build": "npm run build:deploy",
-      "build:deploy": "node scripts/build.js --target=deploy",
-      "build:portable": "node scripts/generate-fonts-json.js --base64 && node scripts/build.js --target=portable",
-      "generate-fonts": "node scripts/generate-fonts-json.js",
-      "generate-fonts:base64": "node scripts/generate-fonts-json.js --base64"
+        "start": "electron .",
+        "dev": "node scripts/dev.js --mode=dev",
+        "preview": "node scripts/dev.js --mode=prod-preview --port=3001",
+        "build": "npm run build:deploy",
+        "build:deploy": "node scripts/build.js --target=deploy",
+        "build:portable": "node scripts/generate-fonts-json.js --base64 && node scripts/build.js --target=portable",
+        "generate-fonts": "node scripts/generate-fonts-json.js",
+        "generate-fonts:base64": "node scripts/generate-fonts-json.js --base64",
+        "pack": "electron-builder --dir",
+        "dist": "npm run build:portable && electron-builder",
+        "release:electron": "npm run build:portable && electron-builder --publish always",
+        "comment": "--- Versioning & Release ---",
+        "commit": "cz",
+        "release": "standard-version",
+        "release:first": "standard-version --first-release",
+        "release:dryrun": "standard-version --dry-run"
     },
     "devDependencies": {
-      "chokidar": "^3.5.3",
-      "http-server": "^14.1.1" 
+        "chokidar": "^3.5.3",
+        "commitizen": "^4.3.1",
+        "conventional-changelog-cli": "^5.0.0",
+        "cz-conventional-changelog": "^3.3.0",
+        "electron": "^29.1.5",
+        "electron-builder": "^24.13.3",
+        "electron-log": "^5.3.3",
+        "electron-updater": "^6.1.8",
+        "http-server": "^14.1.1",
+        "standard-version": "^9.5.0"
+    },
+    "config": {
+        "commitizen": {
+            "path": "./node_modules/cz-conventional-changelog"
+        }
+    },
+    "standard-version": {
+        "skip": {}
+    },
+    "build": {
+        "appId": "agency.manic.logomaker",
+        "productName": "Logomaker",
+        "directories": {
+            "output": "release/",
+            "buildResources": "assets"
+        },
+        "files": [
+            "dist/portable/**/*",
+            "electron.js",
+            "preload.js",
+            "node_modules/electron-updater/**/*",
+            "node_modules/electron-log/**/*"
+        ],
+        "win": {
+            "target": "nsis",
+            "icon": "assets/icon.ico"
+        },
+        "mac": {
+            "target": "dmg",
+            "category": "public.app-category.graphics-design",
+            "icon": "assets/icon.icns"
+        },
+        "linux": {
+            "target": "AppImage",
+            "category": "Graphics",
+            "icon": "assets/icons"
+        },
+        "publish": {
+            "provider": "github",
+            "owner": "manicinc",
+            "repo": "logomaker"
+        }
     }
-  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "private": true,
     "main": "electron.js",
     "scripts": {
-        "start": "electron .",
         "dev": "node scripts/dev.js --mode=dev",
         "preview": "node scripts/dev.js --mode=prod-preview --port=3001",
         "build": "npm run build:deploy",
@@ -22,7 +21,8 @@
         "commit": "cz",
         "release": "standard-version",
         "release:first": "standard-version --first-release",
-        "release:dryrun": "standard-version --dry-run"
+        "release:dryrun": "standard-version --dry-run",
+        "start": "npx electron electron.js"
     },
     "devDependencies": {
         "chokidar": "^3.5.3",

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,27 @@
+// preload.js
+const { contextBridge, ipcRenderer } = require('electron');
+
+// Expose protected methods that allow the renderer process to use
+// specified Electron features without exposing the entire object.
+contextBridge.exposeInMainWorld('electronAPI', {
+    // Example: If you need to send messages from renderer to main
+    // send: (channel, data) => {
+    //     // Whitelist channels
+    //     let validChannels = ['toMain'];
+    //     if (validChannels.includes(channel)) {
+    //         ipcRenderer.send(channel, data);
+    //     }
+    // },
+    // Example: If you need to receive messages from main in renderer
+    // receive: (channel, func) => {
+    //     let validChannels = ['fromMain', 'update-status', 'update-progress', 'update-downloaded'];
+    //     if (validChannels.includes(channel)) {
+    //         // Deliberately strip event as it includes `sender`
+    //         ipcRenderer.on(channel, (event, ...args) => func(...args));
+    //     }
+    // }
+    // Add other APIs you NEED to expose here, otherwise keep it minimal.
+    // For simply loading the portable build, you might not need any initially.
+});
+
+console.log('Preload script executed.');


### PR DESCRIPTION
## Summary by Sourcery

Implement comprehensive improvements to Logomaker, including PNG export fixes, SVG style enhancements, Electron app release process, and various code refinements

New Features:
- Add Electron app with auto-update capabilities
- Implement manual update check functionality

Bug Fixes:
- Fix PNG export issues with html2canvas
- Resolve SVG style rendering problems
- Improve fallback mechanisms for ZIP creation

Enhancements:
- Refactor ZIP utility for more robust file handling
- Improve HTML2Canvas capture logic
- Enhance SVG rendering with better style preservation

CI:
- Add GitHub Actions workflow for automated Electron app releases
- Implement versioning and release process using standard-version

Deployment:
- Create Electron app packaging configuration
- Add cross-platform build and release scripts

Documentation:
- Add release documentation explaining versioning and release process