### PR TITLE
fix: fix workflow actions perms; launch first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch: # ONLY allow manual trigger from Actions tab
 
 permissions:
-  contents: write # Still needed for electron-builder to create release/tag
+  contents: write
+  actions: write
 
 jobs:
   build_and_publish: # Combined job is fine for manual trigger


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add 'actions: write' permission to the release workflow to ensure full access for release-related actions