### PR TITLE
fix: fix perms in actions 2 release!

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write # NEEDED for standard-version to commit/tag & electron-builder to release
+  actions: write
   # pages: write    # Add back if deploying pages in same workflow
   # id-token: write # Add back if deploying pages in same workflow
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add 'actions: write' permission to the GitHub Actions workflow to ensure proper execution of release-related tasks