### PR TITLE
fix: fix perms rewriting in build workflow; release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,9 +88,6 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest] # Build on all platforms
     runs-on: ${{ matrix.os }}
 
-    permissions: # Permissions might be needed again for checkout/setup? Usually inherited or default is ok.
-        contents: read # Read is usually enough for build job
-
     steps:
       # Checkout the specific commit/tag created by standard-version (or just the latest)
       - name: Check out Git repository


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove redundant permissions block in the deployment workflow, simplifying the GitHub Actions configuration